### PR TITLE
Hilfeseiten an aktuellen Feature-Stand nachgezogen

### DIFF
--- a/assets/css/hilfe.css
+++ b/assets/css/hilfe.css
@@ -21,6 +21,7 @@
 .mb-10 { margin-bottom: 2.5rem; }
 .mb-16 { margin-bottom: 4rem; }
 .mt-6 { margin-top: 1.5rem; }
+.my-4 { margin-top: 1rem; margin-bottom: 1rem; }
 .my-6 { margin-top: 1.5rem; margin-bottom: 1.5rem; }
 .ml-4 { margin-left: 1rem; }
 .pt-6 { padding-top: 1.5rem; }

--- a/hilfe-daten-beitragen.html
+++ b/hilfe-daten-beitragen.html
@@ -739,7 +739,7 @@ L105: Element body has extra content: div    ← Cascade-Spitze</code></pre>
             <p class="text-sm text-slate-700 leading-relaxed mb-2">
                 <strong>Auto-Match:</strong> Jede <code class="px-2 py-0.5 bg-slate-100 rounded text-sm">&lt;w&gt;</code>-Wortform
                 wird gegen <code class="px-2 py-0.5 bg-slate-100 rounded text-sm">variants.xml</code>
-                (~192.000 Formen) gematcht, nach MHG-Normalisierung
+                (~257.000 Formen) gematcht, nach MHG-Normalisierung
                 (<em>â→a, ê→e, î→i, ô→o, û→u, ä→ae, ö→oe, ü→ue</em>).
                 Eindeutige Treffer setzen <code class="px-2 py-0.5 bg-slate-100 rounded text-sm">@lemmaRef</code>;
                 mehrdeutige Formen wandern in eine Disambiguierungs-TSV.
@@ -808,7 +808,7 @@ print('Stage 2 (MHDBDB):  ', 'PASS' if mhdbdb.validate(doc) else mhdbdb.error_lo
             <h3 class="text-lg font-semibold text-slate-800 mb-2">CI-Validierung</h3>
             <p class="text-sm text-slate-700 leading-relaxed">
                 Der GitHub-Action-Workflow
-                <a href="https://github.com/DigitalHumanitiesCraft/mhdbdb-tei-only/blob/main/.github/workflows/schema-validation.yml" class="text-brand-600 hover:text-brand-700 font-medium" target="_blank" rel="noopener"><code>schema-validation.yml</code></a>
+                <a href="https://github.com/DigitalHumanitiesCraft/mhdbdb-tei-only/blob/main/.github/workflows/data-integrity.yml" class="text-brand-600 hover:text-brand-700 font-medium" target="_blank" rel="noopener"><code>data-integrity.yml</code></a>
                 läuft auf jedem PR und auf direkten Pushes auf <code class="px-2 py-0.5 bg-slate-100 rounded text-sm">main</code>.
                 Er regeneriert die <code class="px-2 py-0.5 bg-slate-100 rounded text-sm">.rng</code>-Files
                 aus den <code class="px-2 py-0.5 bg-slate-100 rounded text-sm">.rnc</code>-Quellen

--- a/hilfe-daten.html
+++ b/hilfe-daten.html
@@ -146,7 +146,7 @@
                 Die MHDBDB umfasst <strong>667 mittelhochdeutsche TEI-Texte</strong> mit
                 wortgenauer semantischer Annotation. Das Wörterbuch hält
                 <strong>43.754 Lemmata</strong> vor, dazu ein Variantenwörterbuch mit
-                <strong>192.472 orthographischen Varianten</strong>, das die Suche gegen die
+                <strong>256.759 orthographischen Varianten</strong>, das die Suche gegen die
                 tatsächlich attestierten Schreibformen im Korpus abgleicht.
             </p>
 
@@ -160,7 +160,7 @@
                     <p class="text-sm text-slate-600">Lemmata im Wörterbuch</p>
                 </div>
                 <div class="bg-white rounded-xl border border-slate-200 p-5">
-                    <p class="text-3xl font-bold text-brand-600 mb-1">192.472</p>
+                    <p class="text-3xl font-bold text-brand-600 mb-1">256.759</p>
                     <p class="text-sm text-slate-600">orthographische Varianten</p>
                 </div>
             </div>
@@ -217,7 +217,7 @@
                     Eigennamen mit semantischen Relationen.
                 </li>
                 <li>
-                    <strong>variants.xml</strong> <span class="text-slate-500">(12,18 MB)</span> –
+                    <strong>variants.xml</strong> <span class="text-slate-500">(15,62 MB)</span> –
                     orthographische Varianten, aus dem Korpus abgeleitet. Grundlage der
                     Variantenauflösung in der Suche.
                 </li>
@@ -321,7 +321,7 @@
 
         <!-- Stand-Zeile -->
         <p class="hilfe-stand">
-            Stand: Mai 2026 ·
+            Stand: Juni 2026 ·
             <a href="https://github.com/DigitalHumanitiesCraft/mhdbdb-tei-only/commits/main/hilfe-daten.html" target="_blank" rel="noopener">Änderungen auf GitHub</a>
         </p>
 

--- a/hilfe-daten.html
+++ b/hilfe-daten.html
@@ -147,7 +147,10 @@
                 wortgenauer semantischer Annotation. Das Wörterbuch hält
                 <strong>43.754 Lemmata</strong> vor, dazu ein Variantenwörterbuch mit
                 <strong>256.759 orthographischen Varianten</strong>, das die Suche gegen die
-                tatsächlich attestierten Schreibformen im Korpus abgleicht.
+                tatsächlich attestierten Schreibformen im Korpus abgleicht. Für den Abgleich
+                werden diese Formen normalisiert und auf 234.244 eindeutige Zuordnungen
+                verdichtet; in der Korpussuche und im Playground erscheint daher diese
+                kleinere Zahl.
             </p>
 
             <div class="grid grid-cols-1 md:grid-cols-3 gap-4 my-6">

--- a/hilfe-korpussuche.html
+++ b/hilfe-korpussuche.html
@@ -269,7 +269,8 @@
             <p class="text-slate-700 leading-relaxed mb-3">
                 Jeder Treffer-Text trägt einen Schalter <strong>Belege anzeigen / Belege verbergen</strong>.
                 Er klappt direkt in der Trefferliste eine Keyword-in-Context-Konkordanz (KWIC) auf: pro
-                Belegstelle das gesuchte Wort, eingebettet in seinen Satzkontext. Jede Belegzeile beginnt
+                Belegstelle das gesuchte Wort, eingebettet in seinen Wortkontext (ein festes Fenster
+                benachbarter Wörter). Jede Belegzeile beginnt
                 mit der Stellenangabe – <strong>V.</strong> für Vers, <strong>Z.</strong> für Zeile und
                 <strong>S.</strong> für Seite.
             </p>

--- a/hilfe-korpussuche.html
+++ b/hilfe-korpussuche.html
@@ -134,9 +134,11 @@
                 <li><a href="#worum-es-geht" class="text-brand-600 hover:text-brand-700 font-medium">1. Worum es geht</a></li>
                 <li><a href="#lemma-suche" class="text-brand-600 hover:text-brand-700 font-medium">2. Lemma-Suche</a></li>
                 <li><a href="#texte-filtern" class="text-brand-600 hover:text-brand-700 font-medium">3. Texte filtern und auswählen</a></li>
-                <li><a href="#reading-view" class="text-brand-600 hover:text-brand-700 font-medium">4. Reading View und Highlighting</a></li>
-                <li><a href="#lemma-seite" class="text-brand-600 hover:text-brand-700 font-medium">5. Lemma-Seite</a></li>
-                <li><a href="#weiter" class="text-brand-600 hover:text-brand-700 font-medium">6. Was Sie als Nächstes tun können</a></li>
+                <li><a href="#suchergebnisse" class="text-brand-600 hover:text-brand-700 font-medium">4. Suchergebnisse: Liste, Tabelle, Belege</a></li>
+                <li><a href="#reading-view" class="text-brand-600 hover:text-brand-700 font-medium">5. Reading View und Highlighting</a></li>
+                <li><a href="#lemma-seite" class="text-brand-600 hover:text-brand-700 font-medium">6. Lemma-Seite</a></li>
+                <li><a href="#woerterbuch" class="text-brand-600 hover:text-brand-700 font-medium">7. Wörterbuch von A bis Z</a></li>
+                <li><a href="#weiter" class="text-brand-600 hover:text-brand-700 font-medium">8. Was Sie als Nächstes tun können</a></li>
             </ol>
         </nav>
 
@@ -189,7 +191,7 @@
             </p>
             <ol class="space-y-2 text-sm text-slate-700 mb-4 ml-4 list-decimal list-inside">
                 <li><strong>Exakter Treffer im Wörterbuch</strong> – Ihr Suchwort entspricht einem Lemma direkt.</li>
-                <li><strong>Variantenwörterbuch</strong> – 192.472 normalisierte Schreibvarianten werden gegen Ihre Eingabe geprüft.</li>
+                <li><strong>Variantenwörterbuch</strong> – 234.244 normalisierte Schreibvarianten werden gegen Ihre Eingabe geprüft.</li>
                 <li><strong>Teiltreffer</strong> als Fallback, wenn weder exakter noch Varianten-Treffer existiert.</li>
             </ol>
             <p class="text-slate-700 leading-relaxed">
@@ -234,9 +236,63 @@
             </div>
         </section>
 
-        <!-- 4. Reading View und Highlighting -->
+        <!-- 4. Suchergebnisse: Liste, Tabelle und Belege -->
+        <section id="suchergebnisse" class="mb-12 scroll-mt-24">
+            <h2 class="text-2xl font-bold text-slate-900 mb-4">4. Suchergebnisse: Liste, Tabelle und Belege</h2>
+
+            <p class="text-slate-700 leading-relaxed mb-4">
+                Nach der Suche erscheinen die Treffer als eigene Karte. Über dem Ergebnis können Sie
+                rechts oben zwischen zwei Ansichten umschalten: <strong>Liste</strong> (eine Karte je
+                Text) und <strong>Tabelle</strong> (eine Zeile je Text). Beide zeigen dieselben Treffer,
+                nur unterschiedlich aufbereitet.
+            </p>
+
+            <h3 class="text-lg font-semibold text-slate-900 mt-6 mb-2">Tabellen-Ansicht: sortieren und exportieren</h3>
+            <p class="text-slate-700 leading-relaxed mb-3">
+                In der Tabelle lässt sich jede Spalte über ihren Spalten-Header sortieren:
+            </p>
+            <ul class="space-y-1 text-sm text-slate-700 mb-4 ml-4 list-disc list-inside">
+                <li><strong>Titel</strong> – Werktitel, alphabetisch</li>
+                <li><strong>Autor*in</strong> – Verfasser*in, alphabetisch</li>
+                <li><strong>Treffer</strong> – absolute Zahl der Belegstellen im Text</li>
+                <li><strong>Freq./10k Wörter</strong> – Trefferzahl normiert auf 10.000 Wörter, macht unterschiedlich lange Texte vergleichbar</li>
+                <li><strong>Wörter</strong> – Gesamtlänge des Textes in Wörtern</li>
+            </ul>
+            <p class="text-slate-700 leading-relaxed mb-3">
+                Zwei Buttons über der Tabelle exportieren das Ergebnis: <strong>Kopieren</strong> legt es
+                in die Zwischenablage, <strong>CSV</strong> lädt es als Datei herunter – etwa zur
+                Weiterverarbeitung in einer Tabellenkalkulation. Ein Klick auf eine Zeile öffnet den
+                zugehörigen Text im Reading View.
+            </p>
+
+            <h3 class="text-lg font-semibold text-slate-900 mt-6 mb-2">KWIC-Belege ausklappen</h3>
+            <p class="text-slate-700 leading-relaxed mb-3">
+                Jeder Treffer-Text trägt einen Schalter <strong>Belege anzeigen / Belege verbergen</strong>.
+                Er klappt direkt in der Trefferliste eine Keyword-in-Context-Konkordanz (KWIC) auf: pro
+                Belegstelle das gesuchte Wort, eingebettet in seinen Satzkontext. Jede Belegzeile beginnt
+                mit der Stellenangabe – <strong>V.</strong> für Vers, <strong>Z.</strong> für Zeile und
+                <strong>S.</strong> für Seite.
+            </p>
+            <ul class="space-y-1 text-sm text-slate-700 mb-4 ml-4 list-disc list-inside">
+                <li><strong>Kontextfenster</strong> – ein Dropdown stellt 5, 10, 15 oder 20 Wörter je Seite ein (Voreinstellung: 10).</li>
+                <li><strong>Anzeige-Grenze</strong> – bei vielen Belegen erscheint ein Hinweis wie „Erste 100 von 1.240 Belegen"; die Gesamtzahl bleibt sichtbar.</li>
+                <li><strong>Sprung zur Fundstelle</strong> – ein Klick auf eine Belegzeile öffnet den Text im Reading View und springt an die genaue Stelle.</li>
+            </ul>
+
+            <div class="bg-blue-50 border-l-4 border-blue-400 p-4 rounded-r-lg my-6">
+                <p class="text-sm text-slate-700">
+                    <strong>Nicht verwechseln:</strong> Die KWIC-Belege hier blättern die Fundstellen
+                    schon in der Trefferliste auf, noch bevor Sie einen Text öffnen. Die Pfeile
+                    <strong>↑ Zurück</strong> und <strong>Weiter ↓</strong> aus Abschnitt 5
+                    („Zwischen Belegen springen") arbeiten dagegen <em>innerhalb</em> des bereits
+                    geöffneten Reading View.
+                </p>
+            </div>
+        </section>
+
+        <!-- 5. Reading View und Highlighting -->
         <section id="reading-view" class="mb-12 scroll-mt-24">
-            <h2 class="text-2xl font-bold text-slate-900 mb-4">4. Reading View und Highlighting</h2>
+            <h2 class="text-2xl font-bold text-slate-900 mb-4">5. Reading View und Highlighting</h2>
 
             <p class="text-slate-700 leading-relaxed mb-4">
                 Klicken Sie auf einen Treffer in der Ergebnisliste – der Volltext öffnet sich rechts im
@@ -268,6 +324,7 @@
                 <li><strong>Sigle</strong> – die kanonische Werkabkürzung in der MHDBDB</li>
                 <li><strong>Gattung</strong> – literarische Klassifikation</li>
                 <li><strong>Quelle</strong> – die Edition, auf der der digitale Text basiert</li>
+                <li><strong>TEI-XML-Download</strong> – am Ende des Panels steht ein Direkt-Download der zugrunde liegenden TEI-Datei (<code class="px-2 py-0.5 bg-slate-100 rounded text-sm">tei/&lt;SIG&gt;.tei.xml</code>); darin sind detaillierte Metadaten dokumentiert, u. a. Referenzedition, verantwortliche Editor*innen und editorische Hinweise</li>
             </ul>
             <p class="text-slate-700 leading-relaxed">
                 Liegt ein Werk in mehreren Editionen vor, listet das Metadaten-Panel die
@@ -279,9 +336,9 @@
             </p>
         </section>
 
-        <!-- 5. Lemma-Seite -->
+        <!-- 6. Lemma-Seite -->
         <section id="lemma-seite" class="mb-12 scroll-mt-24">
-            <h2 class="text-2xl font-bold text-slate-900 mb-4">5. Lemma-Seite</h2>
+            <h2 class="text-2xl font-bold text-slate-900 mb-4">6. Lemma-Seite</h2>
 
             <p class="text-slate-700 leading-relaxed mb-4">
                 Jedes Lemma in der MHDBDB hat eine eigene, persistent verlinkte Seite mit einer
@@ -310,9 +367,45 @@
             </p>
         </section>
 
-        <!-- 6. Was Sie als Nächstes tun können -->
+        <!-- 7. Wörterbuch von A bis Z -->
+        <section id="woerterbuch" class="mb-12 scroll-mt-24">
+            <h2 class="text-2xl font-bold text-slate-900 mb-4">7. Wörterbuch von A bis Z</h2>
+
+            <p class="text-slate-700 leading-relaxed mb-4">
+                Über den Menüpunkt <strong>Wörterbuch</strong> erreichen Sie die A–Z-Registerseite
+                (<a href="woerterbuch.html" class="text-brand-600 hover:text-brand-700 font-medium">woerterbuch.html</a>) –
+                den alphabetischen Einstieg zu allen rund 43.754 Lemma-Seiten. Wer nicht über eine
+                Suche kommt, sondern stöbern oder gezielt nachschlagen möchte, beginnt hier.
+            </p>
+
+            <h3 class="text-lg font-semibold text-slate-900 mt-6 mb-2">Register und Pagination</h3>
+            <p class="text-slate-700 leading-relaxed mb-3">
+                Eine A–Z-Indexleiste führt zu den einzelnen Buchstaben; ein zusätzliches
+                <code class="px-2 py-0.5 bg-slate-100 rounded text-sm">#</code>-Feld sammelt die Lemmata,
+                die mit einer Ziffer beginnen. Wie viele Einträge ein Buchstabe enthält, zeigt der
+                Tooltip beim Überfahren. Pro Buchstabe werden 200 Einträge je Seite angezeigt; bei mehr
+                Einträgen blättern Sie über die Pagination weiter. Jeder Eintrag besteht aus dem Lemma
+                und einem Wortart-Kürzel (POS-Badge) und verlinkt direkt auf die zugehörige Lemma-Seite
+                <code class="px-2 py-0.5 bg-slate-100 rounded text-sm">lemma/?id=&lt;Nummer&gt;</code>.
+            </p>
+
+            <h3 class="text-lg font-semibold text-slate-900 mt-6 mb-2">Tipp-Suche und Deep-Links</h3>
+            <p class="text-slate-700 leading-relaxed mb-3">
+                Das Suchfeld über dem Register filtert noch während des Tippens über alle Lemmata –
+                als Präfix-Suche und mit derselben mittelhochdeutschen Normalisierung wie die
+                Korpussuche (â → a, ä → ae und so weiter). Die Eingabe <code class="px-2 py-0.5 bg-slate-100 rounded text-sm">minn</code>
+                listet also alle Lemmata, die mit <em>minn-</em> beginnen.
+            </p>
+            <p class="text-slate-700 leading-relaxed">
+                Buchstabe und Seite stehen in der URL und ergeben zitierbare Deep-Links, z. B.
+                <code class="px-2 py-0.5 bg-slate-100 rounded text-sm">woerterbuch.html?buchstabe=s&amp;seite=3</code>.
+                So lässt sich eine bestimmte Registerseite verlinken und in Publikationen referenzieren.
+            </p>
+        </section>
+
+        <!-- 8. Was Sie als Nächstes tun können -->
         <section id="weiter" class="mb-12 scroll-mt-24">
-            <h2 class="text-2xl font-bold text-slate-900 mb-4">6. Was Sie als Nächstes tun können</h2>
+            <h2 class="text-2xl font-bold text-slate-900 mb-4">8. Was Sie als Nächstes tun können</h2>
 
             <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
 
@@ -343,7 +436,7 @@
 
         <!-- Stand-Zeile -->
         <p class="hilfe-stand">
-            Stand: Mai 2026 ·
+            Stand: Juni 2026 ·
             <a href="https://github.com/DigitalHumanitiesCraft/mhdbdb-tei-only/commits/main/hilfe-korpussuche.html" target="_blank" rel="noopener">Änderungen auf GitHub</a>
         </p>
 
@@ -357,9 +450,11 @@
                     <li><a href="#worum-es-geht" class="text-brand-600 hover:text-brand-700 font-medium">1. Worum es geht</a></li>
                     <li><a href="#lemma-suche" class="text-brand-600 hover:text-brand-700 font-medium">2. Lemma-Suche</a></li>
                     <li><a href="#texte-filtern" class="text-brand-600 hover:text-brand-700 font-medium">3. Texte filtern</a></li>
-                    <li><a href="#reading-view" class="text-brand-600 hover:text-brand-700 font-medium">4. Reading View</a></li>
-                    <li><a href="#lemma-seite" class="text-brand-600 hover:text-brand-700 font-medium">5. Lemma-Seite</a></li>
-                    <li><a href="#weiter" class="text-brand-600 hover:text-brand-700 font-medium">6. Was als Nächstes</a></li>
+                    <li><a href="#suchergebnisse" class="text-brand-600 hover:text-brand-700 font-medium">4. Suchergebnisse</a></li>
+                    <li><a href="#reading-view" class="text-brand-600 hover:text-brand-700 font-medium">5. Reading View</a></li>
+                    <li><a href="#lemma-seite" class="text-brand-600 hover:text-brand-700 font-medium">6. Lemma-Seite</a></li>
+                    <li><a href="#woerterbuch" class="text-brand-600 hover:text-brand-700 font-medium">7. Wörterbuch</a></li>
+                    <li><a href="#weiter" class="text-brand-600 hover:text-brand-700 font-medium">8. Was als Nächstes</a></li>
                 </ol>
             </nav>
         </aside>

--- a/hilfe-playground.html
+++ b/hilfe-playground.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Hilfe zum Playground der Mittelhochdeutschen Begriffsdatenbank: Multi-Lemma-Suche, Kookkurrenz-Analyse, Authority Files, typische Forschungsfragen.">
-    <meta name="keywords" content="MHDBDB, Playground, Hilfe, Multi-Lemma-Suche, Kookkurrenz, Authority Files, Forschung">
+    <meta name="description" content="Hilfe zum Playground der Mittelhochdeutschen Begriffsdatenbank: Multi-Lemma- und Kookkurrenz-Suche, sechs Authority Files, neun TEI-Analysewerkzeuge, typische Forschungsfragen.">
+    <meta name="keywords" content="MHDBDB, Playground, Hilfe, Multi-Lemma-Suche, Kookkurrenz, Authority Files, TEI-Analyse, Forschung">
     <meta name="author" content="Universität Salzburg">
 
     <title>Playground-Hilfe – MHDBDB</title>
@@ -137,10 +137,11 @@
                 <li><a href="#drei-spalten" class="text-brand-600 hover:text-brand-700 font-medium">2. Der Drei-Spalten-Aufbau</a></li>
                 <li><a href="#multi-lemma" class="text-brand-600 hover:text-brand-700 font-medium">3. Multi-Lemma-Suche</a></li>
                 <li><a href="#verse-position" class="text-brand-600 hover:text-brand-700 font-medium">4. Lemmasuche nach Versposition</a></li>
-                <li><a href="#forschungsfragen" class="text-brand-600 hover:text-brand-700 font-medium">5. Typische Forschungsfragen</a></li>
-                <li><a href="#authority-files" class="text-brand-600 hover:text-brand-700 font-medium">6. Authority Files im Einsatz</a></li>
-                <li><a href="#workflow" class="text-brand-600 hover:text-brand-700 font-medium">7. Vom Playground in die Leseansicht</a></li>
-                <li><a href="#weiter" class="text-brand-600 hover:text-brand-700 font-medium">8. Was Sie als Nächstes tun können</a></li>
+                <li><a href="#weitere-werkzeuge" class="text-brand-600 hover:text-brand-700 font-medium">5. Weitere TEI-Analyse-Werkzeuge</a></li>
+                <li><a href="#forschungsfragen" class="text-brand-600 hover:text-brand-700 font-medium">6. Typische Forschungsfragen</a></li>
+                <li><a href="#authority-files" class="text-brand-600 hover:text-brand-700 font-medium">7. Authority Files im Einsatz</a></li>
+                <li><a href="#workflow" class="text-brand-600 hover:text-brand-700 font-medium">8. Vom Playground in die Leseansicht</a></li>
+                <li><a href="#weiter" class="text-brand-600 hover:text-brand-700 font-medium">9. Was Sie als Nächstes tun können</a></li>
             </ol>
         </nav>
 
@@ -149,11 +150,13 @@
             <h2 class="text-2xl font-bold text-slate-900 mb-4">1. Worum es geht</h2>
             <p class="text-slate-700 leading-relaxed mb-4">
                 Der <a href="playground/index.html" class="text-brand-600 hover:text-brand-700 font-medium">Playground</a>
-                erweitert die Korpussuche um zwei Dinge: Sie können <strong>mehrere Lemmata
-                gleichzeitig</strong> suchen und prüfen, wie nahe sie im Text zusammen stehen
-                (Kookkurrenz-Analyse), und Sie können die sechs <strong>Authority Files</strong>
-                direkt durchsuchen – Autor*innen, Werke, das Wörterbuch, die Begriffstaxonomie,
-                Gattungen und Eigennamen.
+                erweitert die Korpussuche um drei Säulen: Erstens die <strong>Mehr-Lemma- und
+                Kookkurrenz-Suche</strong> – mehrere Lemmata gleichzeitig suchen und prüfen, wie
+                nahe sie im Text zusammenstehen. Zweitens die sechs durchsuchbaren
+                <strong>Authority Files</strong> – Autor*innen, Werke, das Wörterbuch, die
+                Begriffstaxonomie, Gattungen und Eigennamen. Drittens <strong>neun
+                TEI-Analysewerkzeuge</strong> über dem vorgeladenen Korpus, von der
+                Wortfrequenz bis zum Kookkurrenz-Ranking.
             </p>
             <p class="text-slate-700 leading-relaxed">
                 Die Oberfläche ist forschungsorientiert: etwas dichter, mit mehr Bedienelementen
@@ -171,11 +174,11 @@
             </p>
             <ol class="space-y-2 text-sm text-slate-700 mb-4 ml-4 list-decimal list-inside">
                 <li><strong>Korpus-Browser</strong> (links) – alle 667 Texte sind standardmäßig aktiv. Hier schränken Sie die Analyse auf bestimmte Werke, Autor*innen oder Gattungen ein.</li>
-                <li><strong>Abfragen</strong> (Mitte) – sechs Authority-File-Einstiegspunkte plus die TEI-Analyse mit Multi-Lemma-Suche.</li>
+                <li><strong>Abfragen</strong> (Mitte) – sechs Authority-File-Einstiegspunkte plus neun TEI-Analysewerkzeuge: Multi-Lemma-Suche, Lemmasuche nach Versposition, Wortfrequenz-Analyse, Text-Statistiken, Lemma-Verteilung, Begriffs-Verteilung, Textvergleich, Kookkurrenz-Ranking und Erweiterte Figurenbezeichnungen (Beta).</li>
                 <li><strong>Ergebnisse</strong> (rechts) – die Trefferliste zur aktuellen Abfrage, mit farbkodiertem Highlighting und Klick-Navigation in die Leseansicht.</li>
             </ol>
             <p class="text-slate-700 leading-relaxed">
-                Beim ersten Besuch lädt der Playground den Korpus-Index (rund 36 MB) und den
+                Beim ersten Besuch lädt der Playground den Korpus-Index (rund 40 MB) und den
                 Authority-Index (rund 3 MB) einmalig in den Browser-Cache. Das dauert je nach
                 Verbindung einige Sekunden bis eine Minute. Bei späteren Besuchen liest der
                 Playground direkt aus dem lokalen Cache, solange Sie ihn nicht über
@@ -202,7 +205,7 @@
             </p>
             <p class="text-slate-700 leading-relaxed">
                 Die dreistufige Variantenauflösung aus der Korpussuche gilt auch hier: exakter
-                Treffer im Wörterbuch, dann Prüfung gegen 192.472 orthographische Varianten, dann
+                Treffer im Wörterbuch, dann Prüfung gegen 234.244 orthographische Varianten, dann
                 Teiltreffer als Fallback. Sonderzeichen (â, ê, î, ô, û, ä, ö, ü) werden automatisch
                 normalisiert.
             </p>
@@ -297,9 +300,122 @@
             </p>
         </section>
 
-        <!-- 5. Typische Forschungsfragen -->
+        <!-- 5. Weitere TEI-Analyse-Werkzeuge -->
+        <section id="weitere-werkzeuge" class="mb-12 scroll-mt-24">
+            <h2 class="text-2xl font-bold text-slate-900 mb-4">5. Weitere TEI-Analyse-Werkzeuge</h2>
+
+            <p class="text-slate-700 leading-relaxed mb-4">
+                Neben der Multi-Lemma-Suche und der Lemmasuche nach Versposition bietet der
+                Bereich <strong>TEI-Textanalyse</strong> sieben weitere Werkzeuge über dem
+                vorgeladenen Korpus. Alle rechnen vollständig im Browser auf den vorgebauten
+                Indexen; wo es sinnvoll ist, führt ein Klick auf ein Ergebnis direkt in die
+                Leseansicht.
+            </p>
+
+            <div class="bg-white rounded-xl border border-slate-200 p-5 my-4">
+                <h4 class="text-base font-semibold text-slate-900 mb-2">Wortfrequenz-Analyse</h4>
+                <p class="text-sm text-slate-700 leading-relaxed">
+                    Listet die häufigsten Lemmata über das gesamte Korpus oder einen einzelnen
+                    Text (Top-N). Ein POS-basierter Stoppwort-Filter entfernt häufige
+                    Funktionswörter (Artikel, Pronomen, Präpositionen, Konjunktionen) und hebt
+                    inhaltstragende Lemmata hervor. Wahlweise absolute oder relative Frequenz,
+                    sortiert nach Häufigkeit oder alphabetisch.
+                </p>
+            </div>
+
+            <div class="bg-white rounded-xl border border-slate-200 p-5 my-4">
+                <h4 class="text-base font-semibold text-slate-900 mb-2">Text-Statistiken</h4>
+                <p class="text-sm text-slate-700 leading-relaxed">
+                    Pro Text: Token-Zahl, Lemma-Diversität (verschiedene Lemmata zur Gesamtzahl),
+                    Hapax-Rate und durchschnittliche Lemma-Frequenz, als sortierbare
+                    Korpus-Tabelle. Hohe Lemma-Diversität bei knappem Text ist ein Indikator für
+                    lexikalischen Reichtum. Über Checkboxen lässt sich ein Subset bilden („Nur
+                    Auswahl anzeigen"); die Auswahl übersteht das Sortieren.
+                </p>
+            </div>
+
+            <div class="bg-white rounded-xl border border-slate-200 p-5 my-4">
+                <h4 class="text-base font-semibold text-slate-900 mb-2">Lemma-Verteilung</h4>
+                <p class="text-sm text-slate-700 leading-relaxed">
+                    Zeigt ein einzelnes Lemma als Balkendiagramm über alle Texte: die Top-N als
+                    Balken, der Rest als aufklappbare Tabelle. Wahlweise absolut oder relativ
+                    (pro 1000 Tokens). Ein Klick auf einen Balken oder eine Sigle öffnet die
+                    Leseansicht mit Highlighting.
+                </p>
+            </div>
+
+            <div class="bg-white rounded-xl border border-slate-200 p-5 my-4">
+                <h4 class="text-base font-semibold text-slate-900 mb-2">Begriffs-Verteilung</h4>
+                <p class="text-sm text-slate-700 leading-relaxed">
+                    Wie die Lemma-Verteilung, aber begriffsbasiert: Sie geben einen Begriff ein
+                    (deutsch, englisch oder als <code class="px-2 py-0.5 bg-slate-100 rounded text-xs">concept_</code>-ID)
+                    und sehen das Balkendiagramm über alle Texte. Aggregiert werden alle Lemmata,
+                    deren Bedeutungen dem Begriff zugeordnet sind (Datenpfad Begriff → Bedeutungen
+                    → Lemmata → Texte). Ein Autocomplete schlägt passende Begriffe vor, alternative
+                    Kandidaten werden angezeigt (etwa bei „love" → Intimität und Liebe/Zuneigung);
+                    eine aufklappbare Liste der zugeordneten Lemmata erlaubt die Validierung der
+                    Auswahl.
+                </p>
+            </div>
+
+            <div class="bg-white rounded-xl border border-slate-200 p-5 my-4">
+                <h4 class="text-base font-semibold text-slate-900 mb-2">Textvergleich</h4>
+                <p class="text-sm text-slate-700 leading-relaxed">
+                    Vergleicht zwei über Dropdown gewählte Texte und berechnet drei Lemma-Mengen:
+                    nur in A, in beiden, nur in B – je mit Frequenz in A, Frequenz in B und der
+                    absoluten Differenz. Sortier- und filterbar, mit A↔B-Swap für die gespiegelte
+                    Perspektive. Nützlich für Fragen wie „Welche Lemmata teilt der Parzival mit
+                    dem Jüngeren Titurel?" oder zur Suche nach geteilten seltenen Lemmata als
+                    Lehnvers-Indiz. Ein Klick auf eine Frequenz-Zahl öffnet den jeweiligen Text in
+                    der Leseansicht.
+                </p>
+            </div>
+
+            <div class="bg-white rounded-xl border border-slate-200 p-5 my-4">
+                <h4 class="text-base font-semibold text-slate-900 mb-2">Kookkurrenz-Ranking</h4>
+                <p class="text-sm text-slate-700 leading-relaxed">
+                    Beantwortet die Frage „Welche Lemmata stehen am häufigsten bei <em>X</em>?".
+                    Sie geben ein <strong>einzelnes</strong> Lemma ein und erhalten eine rangierte
+                    Tabelle der häufigsten Nachbar-Lemmata innerhalb eines Kontextfensters
+                    (±3 bis ±25 Wörter, Standard ±10). Der POS-Filter steht standardmäßig auf
+                    Inhaltswörtern (Nomen, Verben, Adjektive, Adverbien), damit Funktionswörter
+                    die Liste nicht dominieren; alternativ nur Nomen, nur Verben, nur Adjektive
+                    oder alle. Ein Klick auf ein Partner-Lemma öffnet dessen Lemma-Seite; über
+                    den separaten Link „→ Belege" je Zeile landen beide Lemmata im Nähe-Modus
+                    der Multi-Lemma-Suche.
+                </p>
+            </div>
+
+            <div class="bg-blue-50 border-l-4 border-blue-400 p-4 rounded-r-lg my-6">
+                <p class="text-sm text-slate-700">
+                    <strong>Kookkurrenz-Ranking vs. Nähe-Analyse:</strong> Beide drehen sich um
+                    Wortumgebungen, beantworten aber verschiedene Fragen. Das Kookkurrenz-Ranking
+                    geht von einem <em>einzigen</em> Lemma aus und rankt ungerichtet, welche anderen
+                    Lemmata in seiner Umgebung am häufigsten auftauchen – es entdeckt die Partner
+                    für Sie. Die Nähe-Analyse der Multi-Lemma-Suche (Abschnitt 3) setzt dagegen
+                    voraus, dass Sie die Lemmata bereits kennen, und prüft nur, an welchen Stellen
+                    sie nah zusammenstehen.
+                </p>
+            </div>
+
+            <div class="bg-white rounded-xl border border-slate-200 p-5 my-4">
+                <h4 class="text-base font-semibold text-slate-900 mb-2">Erweiterte Figurenbezeichnungen <span class="text-xs font-normal text-brand-600 ml-1">Beta</span></h4>
+                <p class="text-sm text-slate-700 leading-relaxed">
+                    Kuratierte Bezeichnungspraktiken jenseits des Eigennamens für vier Werke
+                    (Eneasroman, Iwein, Rolandslied, Trojanerkrieg) aus Linda Beutel-Thurows
+                    Dissertationsprojekt <em>Naming-analysis</em>. Pro Figur sind die Terme in drei
+                    Kategorien gegliedert: Eigennamen, Antonomasien („der rîter" für Iwein) und
+                    Epitheta („der küene"), je mit Häufigkeit und aufklappbaren Belegstellen samt
+                    Versangabe und Sprecher (Erzähler, Figurenrede oder Selbstnennung). Für
+                    Rolandslied und Trojanerkrieg verlinken die Versangaben direkt in die
+                    Leseansicht. Die Daten sind mit sichtbarer Attribution und DOI eingebunden.
+                </p>
+            </div>
+        </section>
+
+        <!-- 6. Typische Forschungsfragen -->
         <section id="forschungsfragen" class="mb-12 scroll-mt-24">
-            <h2 class="text-2xl font-bold text-slate-900 mb-4">5. Typische Forschungsfragen</h2>
+            <h2 class="text-2xl font-bold text-slate-900 mb-4">6. Typische Forschungsfragen</h2>
 
             <p class="text-slate-700 leading-relaxed mb-4">
                 Damit die abstrakten Modi greifbarer werden: vier Fragen, die häufig an die
@@ -352,9 +468,9 @@
             </div>
         </section>
 
-        <!-- 5. Authority Files im Einsatz -->
+        <!-- 7. Authority Files im Einsatz -->
         <section id="authority-files" class="mb-12 scroll-mt-24">
-            <h2 class="text-2xl font-bold text-slate-900 mb-4">6. Authority Files im Einsatz</h2>
+            <h2 class="text-2xl font-bold text-slate-900 mb-4">7. Authority Files im Einsatz</h2>
 
             <p class="text-slate-700 leading-relaxed mb-4">
                 Sechs Authority-Ansichten öffnen je einen Einstiegspunkt in die kontrollierten
@@ -381,9 +497,9 @@
             </div>
         </section>
 
-        <!-- 6. Workflow -->
+        <!-- 8. Workflow -->
         <section id="workflow" class="mb-12 scroll-mt-24">
-            <h2 class="text-2xl font-bold text-slate-900 mb-4">7. Vom Playground in die Leseansicht</h2>
+            <h2 class="text-2xl font-bold text-slate-900 mb-4">8. Vom Playground in die Leseansicht</h2>
 
             <p class="text-slate-700 leading-relaxed mb-4">
                 Der typische Forschungsworkflow verbindet Playground und Korpussuche:
@@ -401,9 +517,9 @@
             </p>
         </section>
 
-        <!-- 7. Weiter -->
+        <!-- 9. Weiter -->
         <section id="weiter" class="mb-12 scroll-mt-24">
-            <h2 class="text-2xl font-bold text-slate-900 mb-4">8. Was Sie als Nächstes tun können</h2>
+            <h2 class="text-2xl font-bold text-slate-900 mb-4">9. Was Sie als Nächstes tun können</h2>
 
             <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
 
@@ -433,7 +549,7 @@
 
         <!-- Stand-Zeile -->
         <p class="hilfe-stand">
-            Stand: Mai 2026 ·
+            Stand: Juni 2026 ·
             <a href="https://github.com/DigitalHumanitiesCraft/mhdbdb-tei-only/commits/main/hilfe-playground.html" target="_blank" rel="noopener">Änderungen auf GitHub</a>
         </p>
 
@@ -448,10 +564,11 @@
                     <li><a href="#drei-spalten" class="text-brand-600 hover:text-brand-700 font-medium">2. Drei-Spalten-Aufbau</a></li>
                     <li><a href="#multi-lemma" class="text-brand-600 hover:text-brand-700 font-medium">3. Multi-Lemma-Suche</a></li>
                     <li><a href="#verse-position" class="text-brand-600 hover:text-brand-700 font-medium">4. Versposition</a></li>
-                    <li><a href="#forschungsfragen" class="text-brand-600 hover:text-brand-700 font-medium">5. Forschungsfragen</a></li>
-                    <li><a href="#authority-files" class="text-brand-600 hover:text-brand-700 font-medium">6. Authority Files</a></li>
-                    <li><a href="#workflow" class="text-brand-600 hover:text-brand-700 font-medium">7. Zur Leseansicht</a></li>
-                    <li><a href="#weiter" class="text-brand-600 hover:text-brand-700 font-medium">8. Was als Nächstes</a></li>
+                    <li><a href="#weitere-werkzeuge" class="text-brand-600 hover:text-brand-700 font-medium">5. Weitere Werkzeuge</a></li>
+                    <li><a href="#forschungsfragen" class="text-brand-600 hover:text-brand-700 font-medium">6. Forschungsfragen</a></li>
+                    <li><a href="#authority-files" class="text-brand-600 hover:text-brand-700 font-medium">7. Authority Files</a></li>
+                    <li><a href="#workflow" class="text-brand-600 hover:text-brand-700 font-medium">8. Zur Leseansicht</a></li>
+                    <li><a href="#weiter" class="text-brand-600 hover:text-brand-700 font-medium">9. Was als Nächstes</a></li>
                 </ol>
             </nav>
         </aside>

--- a/hilfe-playground.html
+++ b/hilfe-playground.html
@@ -313,18 +313,19 @@
             </p>
 
             <div class="bg-white rounded-xl border border-slate-200 p-5 my-4">
-                <h4 class="text-base font-semibold text-slate-900 mb-2">Wortfrequenz-Analyse</h4>
+                <h3 class="text-base font-semibold text-slate-900 mb-2">Wortfrequenz-Analyse</h3>
                 <p class="text-sm text-slate-700 leading-relaxed">
                     Listet die häufigsten Lemmata über das gesamte Korpus oder einen einzelnen
                     Text (Top-N). Ein POS-basierter Stoppwort-Filter entfernt häufige
                     Funktionswörter (Artikel, Pronomen, Präpositionen, Konjunktionen) und hebt
-                    inhaltstragende Lemmata hervor. Wahlweise absolute oder relative Frequenz,
-                    sortiert nach Häufigkeit oder alphabetisch.
+                    inhaltstragende Lemmata hervor. Die Tabelle zeigt je Lemma die absolute und
+                    die relative Frequenz (pro 1.000 Tokens); sortiert wird wahlweise nach der
+                    absoluten oder der relativen Frequenz.
                 </p>
             </div>
 
             <div class="bg-white rounded-xl border border-slate-200 p-5 my-4">
-                <h4 class="text-base font-semibold text-slate-900 mb-2">Text-Statistiken</h4>
+                <h3 class="text-base font-semibold text-slate-900 mb-2">Text-Statistiken</h3>
                 <p class="text-sm text-slate-700 leading-relaxed">
                     Pro Text: Token-Zahl, Lemma-Diversität (verschiedene Lemmata zur Gesamtzahl),
                     Hapax-Rate und durchschnittliche Lemma-Frequenz, als sortierbare
@@ -335,7 +336,7 @@
             </div>
 
             <div class="bg-white rounded-xl border border-slate-200 p-5 my-4">
-                <h4 class="text-base font-semibold text-slate-900 mb-2">Lemma-Verteilung</h4>
+                <h3 class="text-base font-semibold text-slate-900 mb-2">Lemma-Verteilung</h3>
                 <p class="text-sm text-slate-700 leading-relaxed">
                     Zeigt ein einzelnes Lemma als Balkendiagramm über alle Texte: die Top-N als
                     Balken, der Rest als aufklappbare Tabelle. Wahlweise absolut oder relativ
@@ -345,7 +346,7 @@
             </div>
 
             <div class="bg-white rounded-xl border border-slate-200 p-5 my-4">
-                <h4 class="text-base font-semibold text-slate-900 mb-2">Begriffs-Verteilung</h4>
+                <h3 class="text-base font-semibold text-slate-900 mb-2">Begriffs-Verteilung</h3>
                 <p class="text-sm text-slate-700 leading-relaxed">
                     Wie die Lemma-Verteilung, aber begriffsbasiert: Sie geben einen Begriff ein
                     (deutsch, englisch oder als <code class="px-2 py-0.5 bg-slate-100 rounded text-xs">concept_</code>-ID)
@@ -359,7 +360,7 @@
             </div>
 
             <div class="bg-white rounded-xl border border-slate-200 p-5 my-4">
-                <h4 class="text-base font-semibold text-slate-900 mb-2">Textvergleich</h4>
+                <h3 class="text-base font-semibold text-slate-900 mb-2">Textvergleich</h3>
                 <p class="text-sm text-slate-700 leading-relaxed">
                     Vergleicht zwei über Dropdown gewählte Texte und berechnet drei Lemma-Mengen:
                     nur in A, in beiden, nur in B – je mit Frequenz in A, Frequenz in B und der
@@ -372,7 +373,7 @@
             </div>
 
             <div class="bg-white rounded-xl border border-slate-200 p-5 my-4">
-                <h4 class="text-base font-semibold text-slate-900 mb-2">Kookkurrenz-Ranking</h4>
+                <h3 class="text-base font-semibold text-slate-900 mb-2">Kookkurrenz-Ranking</h3>
                 <p class="text-sm text-slate-700 leading-relaxed">
                     Beantwortet die Frage „Welche Lemmata stehen am häufigsten bei <em>X</em>?".
                     Sie geben ein <strong>einzelnes</strong> Lemma ein und erhalten eine rangierte
@@ -399,7 +400,7 @@
             </div>
 
             <div class="bg-white rounded-xl border border-slate-200 p-5 my-4">
-                <h4 class="text-base font-semibold text-slate-900 mb-2">Erweiterte Figurenbezeichnungen <span class="text-xs font-normal text-brand-600 ml-1">Beta</span></h4>
+                <h3 class="text-base font-semibold text-slate-900 mb-2">Erweiterte Figurenbezeichnungen <span class="text-xs font-normal text-brand-600 ml-1">Beta</span></h3>
                 <p class="text-sm text-slate-700 leading-relaxed">
                     Kuratierte Bezeichnungspraktiken jenseits des Eigennamens für vier Werke
                     (Eneasroman, Iwein, Rolandslied, Trojanerkrieg) aus Linda Beutel-Thurows

--- a/hilfe-schema.html
+++ b/hilfe-schema.html
@@ -279,6 +279,45 @@
                 werden vom Korpus-Index übersprungen. Vollständige normative Spezifikation:
                 <a href="https://github.com/DigitalHumanitiesCraft/mhdbdb-tei-only/blob/main/docs/TEI-MODEL.md" class="text-brand-600 hover:text-brand-700 font-medium" target="_blank" rel="noopener">docs/TEI-MODEL.md</a>.
             </p>
+
+            <h3 class="text-lg font-semibold text-slate-800 mb-2 mt-4">Optionale Inline-Elemente (PD-001)</h3>
+            <p class="text-slate-700 leading-relaxed mb-4">
+                Über den Kern aus
+                <code class="px-2 py-0.5 bg-slate-100 rounded text-sm">&lt;w&gt;</code>,
+                <code class="px-2 py-0.5 bg-slate-100 rounded text-sm">&lt;pc&gt;</code> und
+                <code class="px-2 py-0.5 bg-slate-100 rounded text-sm">&lt;hi&gt;</code> hinaus
+                erlaubt das Schema seit der Erweiterung vom 8.&nbsp;Mai 2026 weitere optionale
+                TEI-P5-Inline-Elemente. Sie stehen jedem Korpus offen, sind aber für keines
+                verpflichtend; Lyrik-, Predigt- oder Rezept-Korpora müssen sie nicht nutzen:
+            </p>
+            <ul class="space-y-1 text-sm text-slate-700 mb-4 ml-4 list-disc list-inside">
+                <li><strong>Editorisches Vokabular</strong> –
+                    <code class="px-2 py-0.5 bg-slate-100 rounded">&lt;unclear&gt;</code>,
+                    <code class="px-2 py-0.5 bg-slate-100 rounded">&lt;add&gt;</code>,
+                    <code class="px-2 py-0.5 bg-slate-100 rounded">&lt;gap&gt;</code>,
+                    <code class="px-2 py-0.5 bg-slate-100 rounded">&lt;abbr&gt;</code>,
+                    <code class="px-2 py-0.5 bg-slate-100 rounded">&lt;expan&gt;</code>,
+                    <code class="px-2 py-0.5 bg-slate-100 rounded">&lt;am&gt;</code>,
+                    <code class="px-2 py-0.5 bg-slate-100 rounded">&lt;g&gt;</code></li>
+                <li><strong>Onomastik</strong> –
+                    <code class="px-2 py-0.5 bg-slate-100 rounded">&lt;persName&gt;</code>,
+                    <code class="px-2 py-0.5 bg-slate-100 rounded">&lt;placeName&gt;</code>,
+                    <code class="px-2 py-0.5 bg-slate-100 rounded">&lt;roleName&gt;</code>,
+                    <code class="px-2 py-0.5 bg-slate-100 rounded">&lt;occupation&gt;</code>,
+                    <code class="px-2 py-0.5 bg-slate-100 rounded">&lt;person&gt;</code></li>
+                <li><strong>Domänen-Elemente</strong> –
+                    <code class="px-2 py-0.5 bg-slate-100 rounded">&lt;unit&gt;</code>,
+                    <code class="px-2 py-0.5 bg-slate-100 rounded">&lt;rs&gt;</code>,
+                    <code class="px-2 py-0.5 bg-slate-100 rounded">&lt;figure&gt;</code></li>
+            </ul>
+            <p class="text-sm text-slate-600 leading-relaxed">
+                Zusätzlich sind seit dem 8.&nbsp;Mai 2026 wieder verschachteltes
+                <code class="px-2 py-0.5 bg-slate-100 rounded text-sm">&lt;hi&gt;</code> sowie
+                <code class="px-2 py-0.5 bg-slate-100 rounded text-sm">&lt;w&gt;</code> mit
+                gemischtem <code class="px-2 py-0.5 bg-slate-100 rounded text-sm">&lt;hi&gt;</code>-Inhalt
+                zulässig. Vollständige Liste und Begründung:
+                <a href="https://github.com/DigitalHumanitiesCraft/mhdbdb-tei-only/blob/main/docs/TEI-MODEL.md" class="text-brand-600 hover:text-brand-700 font-medium" target="_blank" rel="noopener">TEI-MODEL §6.0 (PD-001)</a>.
+            </p>
         </section>
 
         <!-- 3. Beispieldateien -->
@@ -474,6 +513,21 @@
                             das genaue Enum dokumentiert
                             <a href="https://github.com/DigitalHumanitiesCraft/mhdbdb-tei-only/blob/main/docs/TEI-MODEL.md" class="text-brand-600 hover:text-brand-700 font-medium" target="_blank" rel="noopener">TEI-MODEL §6</a>.
                         </p>
+                        <p class="text-sm text-slate-700 leading-relaxed">
+                            Domänenspezifische Korpora dürfen das
+                            <code class="px-2 py-0.5 bg-slate-100 rounded text-sm">@type</code>-Enum
+                            erweitern: Rechenbücher (z.&nbsp;B. ARITHMETIC) nutzen zusätzlich zu den
+                            7 Standard-Werten 24 weitere arithmetische Werte
+                            (<code class="px-2 py-0.5 bg-slate-100 rounded text-sm">outline</code>,
+                            <code class="px-2 py-0.5 bg-slate-100 rounded text-sm">regula_de_tri</code>,
+                            <code class="px-2 py-0.5 bg-slate-100 rounded text-sm">addition</code>,
+                            <code class="px-2 py-0.5 bg-slate-100 rounded text-sm">multiplication</code>
+                            u.&nbsp;a.), gelistet in
+                            <a href="https://github.com/DigitalHumanitiesCraft/mhdbdb-tei-only/blob/main/docs/TEI-MODEL.md" class="text-brand-600 hover:text-brand-700 font-medium" target="_blank" rel="noopener">TEI-MODEL §6.0</a>.
+                            Das ARITHMETIC-Korpus ist noch nicht ingestiert
+                            (<a href="https://github.com/DigitalHumanitiesCraft/mhdbdb-tei-only/issues/92" class="text-brand-600 hover:text-brand-700 font-medium" target="_blank" rel="noopener">Issue #92</a>),
+                            die Schema-Erlaubnis ist aber bereits live.
+                        </p>
                     </div>
                 </li>
 
@@ -603,7 +657,7 @@ print('MHDBDB:', 'VALID' if mhdbdb.validate(tree)  else mhdbdb.error_log)
 
         <!-- Stand-Zeile -->
         <p class="hilfe-stand">
-            Stand: Mai 2026 ·
+            Stand: Juni 2026 ·
             <a href="https://github.com/DigitalHumanitiesCraft/mhdbdb-tei-only/commits/main/hilfe-schema.html" target="_blank" rel="noopener">Änderungen auf GitHub</a>
         </p>
 

--- a/hilfe.html
+++ b/hilfe.html
@@ -84,7 +84,7 @@
 </header>
 <!-- NAV:END -->
 
-    <!-- Hilfe-interne Nav-Leiste (4 Tabs) -->
+    <!-- Hilfe-interne Nav-Leiste (5 Tabs) -->
     <nav class="bg-white border-b border-slate-200" aria-label="Hilfe-Bereiche">
         <div class="container mx-auto px-6">
             <div class="flex flex-wrap gap-x-8 gap-y-2 -mb-px">
@@ -117,7 +117,8 @@
                 Willkommen in der Hilfe der Mittelhochdeutschen Begriffsdatenbank.
                 Hier finden Sie eine kurze Anleitung für die ersten Schritte sowie
                 ausführliche Walkthroughs für die Korpussuche, das Forschungswerkzeug
-                Playground und einen Überblick über die Datenbasis.
+                Playground, einen Überblick über die Datenbasis und das normative
+                TEI-Encoding-Modell des Schemas.
             </p>
         </section>
 
@@ -243,7 +244,7 @@
         <!-- Themen-Kacheln -->
         <section class="mb-16">
             <h2 class="text-2xl font-bold text-slate-900 mb-6">Themen-Seiten</h2>
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
 
                 <a href="hilfe-korpussuche.html" class="block bg-white rounded-2xl border border-slate-200 p-6 shadow-sm hover:border-brand-400 hover:shadow-md transition group">
                     <div class="flex items-center gap-3 mb-3">
@@ -284,6 +285,20 @@
                     </p>
                 </a>
 
+                <a href="hilfe-schema.html" class="block bg-white rounded-2xl border border-slate-200 p-6 shadow-sm hover:border-brand-400 hover:shadow-md transition group">
+                    <div class="flex items-center gap-3 mb-3">
+                        <svg class="w-6 h-6 text-brand-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"></path>
+                        </svg>
+                        <h3 class="text-lg font-bold text-slate-900 group-hover:text-brand-700 transition">Schema</h3>
+                    </div>
+                    <p class="text-sm text-slate-600">
+                        Das normative TEI-Encoding-Modell: Pflicht-Elemente, neun
+                        Beispieldateien, ein Step-by-Step-Tutorial und die Validierung
+                        MHDBDB-konformer TEI-XML.
+                    </p>
+                </a>
+
             </div>
         </section>
 
@@ -303,7 +318,7 @@
 
         <!-- Stand-Zeile -->
         <p class="hilfe-stand">
-            Stand: Mai 2026 ·
+            Stand: Juni 2026 ·
             <a href="https://github.com/DigitalHumanitiesCraft/mhdbdb-tei-only/commits/main/hilfe.html" target="_blank" rel="noopener">Änderungen auf GitHub</a>
         </p>
 

--- a/index.html
+++ b/index.html
@@ -344,7 +344,7 @@
               <span class="text-brand-600 font-bold">•</span>
               <div>
                 <a href="https://github.com/DigitalHumanitiesCraft/mhdbdb-tei-only/blob/main/authority-files/variants.xml" target="_blank" rel="noopener" class="text-brand-600 hover:text-brand-700 font-bold">variants.xml</a>
-                <span class="text-slate-500"> (12.18 MB)</span>
+                <span class="text-slate-500"> (15.62 MB)</span>
                 <span class="text-slate-600">
                   – Orthographische Varianten aus TEI-Korpus</span
                 >

--- a/index.html
+++ b/index.html
@@ -258,7 +258,7 @@
           <div
             class="bg-white rounded-2xl p-8 text-center border border-slate-200 shadow-sm"
           >
-            <div class="text-4xl font-bold text-brand-600 mb-2">192.472</div>
+            <div class="text-4xl font-bold text-brand-600 mb-2">256.759</div>
             <div class="text-sm font-medium text-slate-600">
               Orthographische Varianten
             </div>

--- a/playground/index.html
+++ b/playground/index.html
@@ -105,7 +105,7 @@
                         <div class="animate-spin h-5 w-5 border-2 border-brand-600 border-t-transparent rounded-full"></div>
                         <span class="text-sm font-medium text-brand-700">Lade 667 TEI-Texte...</span>
                     </div>
-                    <p class="text-xs text-slate-600">Der vollständige MHDBDB-Korpus wird automatisch geladen (rund 39 MB gzipped, einmalig). Dies dauert je nach Verbindung einige Sekunden bis eine Minute.</p>
+                    <p class="text-xs text-slate-600">Der vollständige MHDBDB-Korpus wird automatisch geladen (rund 40 MB gzipped, einmalig). Dies dauert je nach Verbindung einige Sekunden bis eine Minute.</p>
                 </div>
 
                 <!-- File Browser (shown after loading) -->
@@ -402,7 +402,7 @@
                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                             </svg>
-                            <span>Sie können Lemma-IDs (z.B. "879") oder Lemma-Formen verwenden (z.B. "brôt" oder einfach "brot"). Sonderzeichen (â, ê, î, ô, û, ä, ö, ü) werden automatisch normalisiert. Alle 175.910 Varianten aus dem Korpus werden erkannt.</span>
+                            <span>Sie können Lemma-IDs (z.B. "879") oder Lemma-Formen verwenden (z.B. "brôt" oder einfach "brot"). Sonderzeichen (â, ê, î, ô, û, ä, ö, ü) werden automatisch normalisiert. Alle 234.244 Varianten werden erkannt.</span>
                         </div>
                     </div>
 


### PR DESCRIPTION
Zieht 16 in einem Audit bestaetigte Drift-Luecken in den Hilfeseiten nach (Stand der Inhalte war Mai 2026, mehrere Features seither nicht dokumentiert) plus zwei UI-Folgefixe.

## Neu dokumentierte Features
- **KWIC-Belege (#129)** und **Tabellen-Ansicht / Sortierung / CSV-Export (#114)** in der Korpussuche
- **Woerterbuch A-Z-Einstiegsseite + Tipp-Suchfeld (#117)**
- **TEI-XML-Download** im Reader-Metadaten-Panel (#96)
- **Sieben fehlende Playground-Analysewerkzeuge** (Wortfrequenz, Text-Statistiken, Lemma-Verteilung, Begriffs-Verteilung, Textvergleich, Kookkurrenz-Ranking, Erweiterte Figurenbezeichnungen Beta) -> jetzt alle neun beschrieben
- **PD-001 Schemaerweiterung** in hilfe-schema.html (optionale Inline-Elemente + ARITHMETIC-div-Typen)
- **Schema-Hilfeseite** im Hub-Kachelraster verlinkt

## Korrigierte Fakten
- Toter CI-Link `schema-validation.yml` -> `data-integrity.yml` (Konsolidierung #125)
- Veraltete Variantenzahlen und Index-/Dateigroessen aktualisiert
- Zwei Variantenzahlen bewusst getrennt gehalten: **234.244** Resolver-Mappings (Suche: Korpussuche, Playground) vs. **256.759** Roh-`<form>`-Elemente (Datenbasis: Startseite, Daten-Hilfe)

## Verifikation
- 12-Agenten-Workflow (Editor je Seite + adversariales Diff-Review), 0 Blocker
- Zwei minor-Reviewbefunde nachkorrigiert (Kookkurrenz-Klicklogik gegen `cooccurrence-ranking.js`, `<rs>`-Kategorie gegen `TEI-MODEL.md` §6.0)
- `build-pages.py --check` gruen (Nav/Footer build-injiziert, unberuehrt), keine neuen Tailwind-Klassen, Chrome-Sichtung der beiden grossen Seiten

## Hinweis
index.html und playground/index.html sind nutzersichtbare UI-Dateien: vor Merge idealerweise von @wachauer final gesichtet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)