### PR TITLE
Homographen-Auflösung + Race-Guards (#163, #164, #159, #168)

### DIFF
--- a/assets/js/rendering/tei-text-reader.js
+++ b/assets/js/rendering/tei-text-reader.js
@@ -38,6 +38,13 @@ class TEITextReader {
      * @param {object} elements - DOM element references
      */
     async openReadingView(textId, options = {}, elements) {
+        // Request-Generation-Guard (#168): Öffnet der User während eines
+        // langsamen Ladevorgangs (großes, ungecachtes TEI) einen anderen
+        // Text (z.B. Sigle-Link), darf der ältere Ladevorgang nach seinem
+        // await weder DOM noch Instanz-State überschreiben — sonst zeigen
+        // Lesebereich, aktive Sigle und Treffer-Navigation verschiedene Werke.
+        const mySeq = (this._loadSeq = (this._loadSeq || 0) + 1);
+
         this.currentTextId = textId;
 
         // Support both single lemmaId and multiple lemmaIds
@@ -74,6 +81,10 @@ class TEITextReader {
 
             // Load TEI file (cached)
             const teiDoc = await this.loadTEIFile(textMeta.filename);
+
+            // Ein neuerer openReadingView-Aufruf hat inzwischen übernommen —
+            // dieser ältere Ladevorgang darf nichts mehr rendern.
+            if (mySeq !== this._loadSeq) return;
 
             // Extract metadata (prioritizes TEI header, falls back to corpus index)
             const metadata = this.extractMetadata(teiDoc, textMeta);
@@ -121,6 +132,9 @@ class TEITextReader {
 
         } catch (error) {
             console.error('[TEITextReader] Failed to open reading view:', error);
+            // Fehler eines überholten Ladevorgangs nicht anzeigen — sie
+            // würden Loading-State/Anzeige des neueren Aufrufs zerstören.
+            if (mySeq !== this._loadSeq) return;
             this.showLoading(false);
             this.showError(`Fehler beim Laden: ${error.message}`);
         }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -369,6 +369,28 @@ async computeCooccurrences(...) {
 
 Token-Increment passiert SYNCHRON in `runSearch()`, bevor `await` läuft. Damit ist garantiert, dass der zweite Lauf den ersten ungültig macht, *bevor* der erste auch nur einen `yieldToMain()`-Cycle hatte. Loop-interner Check nach jedem Yield fängt es schnell ab.
 
+### Navigation-Epoch gegen Cross-View-Clobber (#159/#168)
+
+Der per-Modul-Token oben fängt nur **Same-View-Races** (neue Suche im selben Modul). Navigiert der User während eines laufenden Scans zu einer **anderen View**, bumpt kein Modul-Token — das fertige Ergebnis würde die inzwischen angezeigte View in `#resultsContainer` überschreiben. Dagegen exportiert der Router (`playground/js/ui/core/router.js`) einen globalen, monoton steigenden Zähler:
+
+```js
+import { getNavigationEpoch } from '../core/router.js';
+
+async runSearch() {
+  this._abortToken += 1;             // Same-View-Guard (wie oben)
+  const myToken = this._abortToken;
+  const myEpoch = getNavigationEpoch();  // Cross-View-Guard
+  const result = await this.compute(/* ... */);
+  if (this._abortToken !== myToken || getNavigationEpoch() !== myEpoch) return;
+  this.state.result = result;
+  this.render();
+}
+```
+
+`dispatch()` inkrementiert den Epoch bei JEDER Route-Änderung (`navigate()` wie `hashchange`/back/forward), aber erst nach dem Unknown-View-Check (unbekannte Route ändert die sichtbare View nicht). Beide Checks gehören zusammen in dieselbe Bedingung — auch in die Chunk-Loops nach jedem `yieldToMain()`, damit ein wegnavigierter Scan sofort abbricht statt CPU zu verbrennen. Der früher hier dokumentierte per-Modul-`isActiveView()`-Hash-Vergleich ist durch den Epoch ersetzt (eine Mechanik statt zwei, und er fängt auch Same-Route-Re-Dispatches mit neuen Params).
+
+Umgesetzt (Stand 2026-07-07): `cooccurrence-ranking.js`, `rhyme-dictionary.js`, `concept-distribution.js` (dort zusätzlich `_searchGen` als Such-Generation-Token, weil das `computing`-Flag als Identitätskriterium versagt — bei zwei überlappenden Suchen gewann die ältere), `multi-lemma-search.js`, `naming-explorer.js` (Erst-Load). Auf der Hauptseite nutzt `tei-text-reader.js openReadingView()` denselben Gedanken als `_loadSeq`-Request-Guard (kein Router dort).
+
 ### Live-Autocomplete-Dropdown (concept-distribution #113 Lesson)
 
 Klassisches DWDS/Google-Style-Dropdown unter Lemma-/Concept-Inputs. Direkter DOM-Update statt full `render()` bei jedem Keystroke — sonst verliert Input den Fokus und die Selection-Range, das Tippen wird unbedienbar.
@@ -411,7 +433,9 @@ input.addEventListener('blur', () => setTimeout(() => this.closeAutocomplete(), 
 
 ARIA: `role="combobox" + aria-controls + aria-expanded` am Input, `role="listbox"` am Dropdown, `role="option" + aria-selected` an Buttons. Scroll-into-view des aktiven Items bei Pfeil-Nav (`activeEl.scrollIntoView({block: 'nearest'})`). Reuse `resolveQuery()` als Suggestions-Quelle — kein zweiter Resolver-Pfad.
 
-Pattern ist (Stand 2026-05-16) in vier Modulen umgesetzt: `concept-distribution.js` (#113 original), `lemma-distribution.js`, `verse-position-search.js`, `cooccurrence-ranking.js` (alle drei portiert 2026-05-16). Falls weitere Module Lemma-/Concept-Input bekommen: einfach kopieren, IDs anpassen (`xxQuery`/`xxAutocomplete`/`data-xx-ac-idx`).
+Pattern ist (Stand 2026-05-16) in vier Modulen umgesetzt: `concept-distribution.js` (#113 original), `lemma-distribution.js`, `verse-position-search.js`, `cooccurrence-ranking.js` (alle drei portiert 2026-05-16; seit #106 auch `rhyme-dictionary.js`). Falls weitere Module Lemma-/Concept-Input bekommen: einfach kopieren, IDs anpassen (`xxQuery`/`xxAutocomplete`/`data-xx-ac-idx`).
+
+**Auswahl-Durchreichung (#163):** Die Dropdown-Auswahl darf nicht nur `input.value` (String) setzen — bei Homographen (drei Lemmata „rôt") löst `resolveQuery()` den String sonst wieder aufs falsche Lemma auf. Regel: Auswahl (Enter mit aktivem Item, mousedown) setzt zusätzlich `this.state.selectedLemma = c` (bzw. `selectedConcept`); der `input`-Handler setzt es bei manueller Eingabe auf `null` zurück; `runSearch()` bevorzugt `selectedLemma`, solange der Query-Text noch der gewählten Form entspricht. Default-Auflösung ohne explizite Auswahl: `searchLemmaByOrthography()` liefert Stage-1-Homographen frequenz-sortiert (Korpus-Frequenz absteigend), `matches[0]` ist also das plausibelste Lemma.
 
 ## Layout Patterns
 

--- a/playground/js/data/authority-manager.js
+++ b/playground/js/data/authority-manager.js
@@ -100,16 +100,21 @@ export class AuthorityFilesManager {
     const normalized = orthography.toLowerCase();
     const normalizedCharacters = TextNormalizer.normalizeMHG(normalized);
 
-    // Stage 1: Try exact match in lexicon (fastest, canonical forms)
-    // Try both original and normalized
-    const exactMatch = this.authorityData.lemmata.find(lemma => {
+    // Stage 1: Exact match in lexicon (canonical forms). Sammelt ALLE
+    // Homographen (z.B. rôt: NAM lemma_11330, NOM lemma_19417, ADJ
+    // lemma_4954) statt nur den ersten Array-Treffer — matches[0]-Konsumenten
+    // (Multi-Lemma-Suche, Kookkurrenz, Reim, Versposition) bekamen sonst
+    // je nach Index-Reihenfolge einen 1-Beleg-Eigennamen statt des
+    // hochfrequenten Appellativs (#163/#164). Sortierung: Korpus-Frequenz
+    // absteigend, bei Gleichstand diakritisch-exakte Eingabe zuerst.
+    const exactMatches = this.authorityData.lemmata.filter(lemma => {
       if (!lemma.lemma) return false;
       const lemmaLower = lemma.lemma.toLowerCase();
       const lemmaNormalized = TextNormalizer.normalizeMHG(lemmaLower);
       return lemmaLower === normalized || lemmaNormalized === normalizedCharacters;
     });
-    if (exactMatch) {
-      return [exactMatch];
+    if (exactMatches.length > 0) {
+      return this.rankHomographs(exactMatches, normalized);
     }
 
     // Stage 2: Search in variants index (orthographic variants from TEI corpus)
@@ -135,6 +140,48 @@ export class AuthorityFilesManager {
       return TextNormalizer.matchesNormalized(lemma.lemma, orthography);
     });
     return partialMatches;
+  }
+
+  /**
+   * Homographen nach Korpus-Frequenz absteigend sortieren; bei Gleichstand
+   * gewinnt die diakritisch-exakte Schreibform der Eingabe, danach bleibt
+   * die Index-Reihenfolge stabil. Ist der Corpus-Index noch nicht geladen,
+   * sind alle Frequenzen 0 und die bisherige Reihenfolge bleibt erhalten.
+   */
+  rankHomographs(lemmata, normalizedInput) {
+    if (lemmata.length <= 1) return lemmata;
+    const decorated = lemmata.map((lemma, idx) => ({
+      lemma,
+      idx,
+      freq: this.getCorpusFrequency(lemma.id),
+      exact: lemma.lemma && lemma.lemma.toLowerCase() === normalizedInput ? 0 : 1
+    }));
+    decorated.sort((a, b) =>
+      (b.freq - a.freq) || (a.exact - b.exact) || (a.idx - b.idx)
+    );
+    return decorated.map(d => d.lemma);
+  }
+
+  /**
+   * Gesamtzahl der Vorkommen eines Lemmas im Korpus (Summe über alle
+   * texts[].lemmata[id]-Positionslisten des Corpus-Index). Ergebnisse werden
+   * gecacht — aber erst, sobald der Corpus-Index geladen ist, damit ein
+   * früher Aufruf (Autocomplete vor Corpus-Load) keine Nullen einfriert.
+   */
+  getCorpusFrequency(lemmaId) {
+    if (this._corpusFreqCache?.has(lemmaId)) {
+      return this._corpusFreqCache.get(lemmaId);
+    }
+    const texts = window.playground?.corpusData?.texts;
+    if (!texts || texts.length === 0) return 0;
+    let total = 0;
+    for (const t of texts) {
+      const positions = t.lemmata?.[lemmaId];
+      if (positions) total += positions.length;
+    }
+    if (!this._corpusFreqCache) this._corpusFreqCache = new Map();
+    this._corpusFreqCache.set(lemmaId, total);
+    return total;
   }
 
   findLemmaById(lemmaId) {

--- a/playground/js/ui/core/router.js
+++ b/playground/js/ui/core/router.js
@@ -68,6 +68,23 @@ const SEARCH_INPUT_IDS = {
  */
 let _suppressHashUpdate = false;
 
+/**
+ * Navigation-Epoch: monoton steigender Zähler, der bei jedem Route-Dispatch
+ * (navigate() wie hashchange/back/forward) inkrementiert wird. Async-Module
+ * merken sich den Wert beim Start ihrer Berechnung und verwerfen das
+ * Ergebnis vor dem Render, wenn er sich geändert hat — sonst überschreibt
+ * ein fertig werdender Scan die inzwischen angezeigte andere View
+ * (Cross-View-Clobber, #159). Same-View-Races (zweite Suche im selben
+ * Modul) fängt der Epoch NICHT — dafür braucht jedes Modul zusätzlich
+ * einen eigenen Such-Generation-Token (#168).
+ */
+let _navigationEpoch = 0;
+
+/** Aktueller Navigation-Epoch (siehe oben). */
+export function getNavigationEpoch() {
+  return _navigationEpoch;
+}
+
 /** Parse the current hash into { view, params }, or null if empty. */
 export function parseHash() {
   const hash = window.location.hash.slice(1); // strip leading '#'
@@ -204,6 +221,10 @@ function dispatch(view, params) {
     console.warn(`[Router] Unknown view: ${view}`);
     return;
   }
+
+  // Erst NACH dem Unknown-View-Check bumpen: eine unbekannte Route ändert
+  // die sichtbare View nicht, laufende Scans der alten View bleiben gültig.
+  _navigationEpoch += 1;
 
   handler(params);
 

--- a/playground/js/ui/tei/concept-distribution.js
+++ b/playground/js/ui/tei/concept-distribution.js
@@ -11,9 +11,12 @@
  * Analog zu lemma-distribution.js (#90), aber concept-basiert (#47-R2).
  */
 
+import { getNavigationEpoch } from '../core/router.js';
+
 const DEFAULT_STATE = Object.freeze({
   query: '',
   resolvedConcept: null,     // {id, termDE, termEN, normalized} oder null
+  selectedConcept: null,     // explizite Autocomplete-Auswahl (#163) — schlägt resolveQuery
   candidates: [],            // alternative Concept-Matches
   matchingLemmata: [],       // [{id, lemma}] alle Lemmata, die diesen Concept referenzieren
   distribution: null,        // [{id, title, count, ...}] oder null wenn (noch) nicht berechnet
@@ -180,6 +183,8 @@ export class ConceptDistribution {
     const lemmaIds = matchingLemmata.map(l => l.id);
     const hits = [];
     let chunkStart = performance.now();
+    const myGen = this._searchGen;
+    const myEpoch = getNavigationEpoch();
     for (let i = 0; i < texts.length; i++) {
       const text = texts[i];
       let total = 0;
@@ -206,6 +211,9 @@ export class ConceptDistribution {
       if (performance.now() - chunkStart > CHUNK_BUDGET_MS) {
         if (onProgress) onProgress((i + 1) / texts.length);
         await yieldToMain();
+        // Abort on new search (generation token, #168) OR router navigation
+        // to another view (epoch, #159) while we were yielding.
+        if (this._searchGen !== myGen || getNavigationEpoch() !== myEpoch) return null;
         chunkStart = performance.now();
       }
     }
@@ -542,18 +550,33 @@ export class ConceptDistribution {
       this.state.query = input.value;
       this.closeAutocomplete();
       const { resolved, candidates } = this.resolveQuery(this.state.query);
-      this.state.resolvedConcept = resolved;
+      // Explizite Autocomplete-Auswahl (#163) schlägt die String-Auflösung —
+      // aber nur solange der Query-Text noch der gewählten Form entspricht.
+      const sel = this.state.selectedConcept;
+      const useSelected = sel && (sel.termDE || sel.id) === (this.state.query || '').trim();
+      const concept = useSelected ? sel : resolved;
+      this.state.resolvedConcept = concept;
       this.state.candidates = candidates;
-      this.state.matchingLemmata = resolved ? this.findMatchingLemmata(resolved.id) : [];
+      this.state.matchingLemmata = concept ? this.findMatchingLemmata(concept.id) : [];
       this.state.distribution = null;
 
-      if (!resolved || this.state.matchingLemmata.length === 0) {
+      if (!concept || this.state.matchingLemmata.length === 0) {
         this.state.computing = false;
         this.state.computeProgress = 0;
         this.render();
         this.refocusInput();
         return;
       }
+
+      // Such-Generation (#168): das computing-Flag taugt nicht als
+      // Identitätskriterium — bei zwei überlappenden Suchen gewann sonst
+      // die ÄLTERE (sie committete ihre Verteilung und setzte computing=false,
+      // die neuere verwarf sich selbst). Der Zähler macht jede Suche
+      // eindeutig; der Navigation-Epoch verhindert zusätzlich, dass ein
+      // fertiger Scan eine andere, inzwischen angezeigte View überschreibt (#159).
+      this._searchGen = (this._searchGen || 0) + 1;
+      const myGen = this._searchGen;
+      const myEpoch = getNavigationEpoch();
 
       // Asynchrone Aggregation mit Chunking. Render Spinner zuerst, dann
       // Patch-Update der Progress-Bar ohne komplettes re-render (Form bleibt
@@ -564,6 +587,7 @@ export class ConceptDistribution {
       this.refocusInput();
 
       const dist = await this.computeDistribution(this.state.matchingLemmata, (frac) => {
+        if (this._searchGen !== myGen) return;
         this.state.computeProgress = frac;
         const bar = document.getElementById('cdProgressBar');
         const label = document.getElementById('cdProgressLabel');
@@ -571,9 +595,13 @@ export class ConceptDistribution {
         if (label) label.textContent = `${Math.round(frac * 100)} %`;
       });
 
-      // Falls inzwischen eine neue Suche gestartet wurde (matchingLemmata
-      // hat sich geaendert), Ergebnis verwerfen.
-      if (!this.state.computing) return;
+      // Nur committen, wenn dies noch die aktuelle Suche ist und der User
+      // nicht wegnavigiert hat.
+      if (this._searchGen !== myGen || getNavigationEpoch() !== myEpoch) return;
+      if (!dist) {
+        this.state.computing = false;
+        return;
+      }
 
       this.state.distribution = dist;
       this.state.computing = false;
@@ -587,6 +615,8 @@ export class ConceptDistribution {
     if (input) {
       // Live-Suggestions waehrend Tippen
       input.addEventListener('input', (e) => {
+        // Manuelle Eingabe invalidiert eine frühere Dropdown-Auswahl (#163).
+        this.state.selectedConcept = null;
         this.updateAutocomplete(e.target.value);
       });
 
@@ -599,6 +629,7 @@ export class ConceptDistribution {
           if (open && this.state.autocompleteIndex >= 0) {
             const c = this.state.autocompleteItems[this.state.autocompleteIndex];
             input.value = c.termDE || c.id;
+            this.state.selectedConcept = c;
             this.closeAutocomplete();
             runSearch();
             return;
@@ -652,6 +683,7 @@ export class ConceptDistribution {
         if (!c) return;
         const inputEl = document.getElementById('cdQuery');
         if (inputEl) inputEl.value = c.termDE || c.id;
+        this.state.selectedConcept = c;
         this.closeAutocomplete();
         runSearch();
       });

--- a/playground/js/ui/tei/cooccurrence-ranking.js
+++ b/playground/js/ui/tei/cooccurrence-ranking.js
@@ -9,9 +9,12 @@
  * Issue: #107
  */
 
+import { getNavigationEpoch } from '../core/router.js';
+
 const DEFAULT_STATE = Object.freeze({
   query: '',
   resolvedLemma: null,
+  selectedLemma: null,        // explizite Autocomplete-Auswahl (#163) — schlägt resolveQuery
   candidates: [],
   window: 10,                 // ± Nachbarn pro Vorkommen
   topN: 50,
@@ -86,10 +89,12 @@ export class CooccurrenceRanking {
     let totalOccurrences = 0;
     let chunkStart = performance.now();
     const myToken = this._abortToken;
+    const myEpoch = getNavigationEpoch();
 
     for (let i = 0; i < texts.length; i++) {
-      // Abort if user triggered a new search while we were running.
-      if (this._abortToken !== myToken) return null;
+      // Abort on new search in this module (token) OR router navigation
+      // to another view (epoch, #159) while we were running.
+      if (this._abortToken !== myToken || getNavigationEpoch() !== myEpoch) return null;
 
       const text = texts[i];
       const positions = text.lemmata?.[targetLemmaId];
@@ -114,7 +119,7 @@ export class CooccurrenceRanking {
       if (performance.now() - chunkStart > CHUNK_BUDGET_MS) {
         if (onProgress) onProgress((i + 1) / texts.length);
         await yieldToMain();
-        if (this._abortToken !== myToken) return null;
+        if (this._abortToken !== myToken || getNavigationEpoch() !== myEpoch) return null;
         chunkStart = performance.now();
       }
     }
@@ -169,10 +174,15 @@ export class CooccurrenceRanking {
 
   async runSearch() {
     const { resolved, candidates } = this.resolveQuery(this.state.query);
-    this.state.resolvedLemma = resolved;
+    // Explizite Autocomplete-Auswahl (#163) schlägt die String-Auflösung —
+    // aber nur solange der Query-Text noch der gewählten Form entspricht
+    // (Tippen setzt selectedLemma im input-Handler zurück).
+    const sel = this.state.selectedLemma;
+    const useSelected = sel && (sel.lemma || sel.id) === (this.state.query || '').trim();
+    this.state.resolvedLemma = useSelected ? sel : resolved;
     this.state.candidates = candidates;
     this.state.result = null;
-    if (!resolved) {
+    if (!this.state.resolvedLemma) {
       this.render();
       return;
     }
@@ -182,12 +192,14 @@ export class CooccurrenceRanking {
     this.render();
 
     const myToken = this._abortToken;
-    const result = await this.computeCooccurrences(resolved.id, this.state.window, (p) => {
+    const myEpoch = getNavigationEpoch();
+    const target = this.state.resolvedLemma;
+    const result = await this.computeCooccurrences(target.id, this.state.window, (p) => {
       if (this._abortToken !== myToken) return;
       this.state.progress = p;
       this.updateProgressBar();
     });
-    if (this._abortToken !== myToken) return;
+    if (this._abortToken !== myToken || getNavigationEpoch() !== myEpoch) return;
     if (!result) {
       this.state.computing = false;
       return;
@@ -195,26 +207,13 @@ export class CooccurrenceRanking {
 
     const partners = this.enrichPartners(result.counts);
     this.state.result = {
-      targetLemmaId: resolved.id,
+      targetLemmaId: target.id,
       totalOccurrences: result.totalOccurrences,
       partners,
       _rawCounts: result.counts // fuer POS-Mode-Switching ohne Re-Compute
     };
     this.state.computing = false;
-    // Nicht rendern, wenn der User während des Scans zu einer anderen
-    // Playground-View navigiert ist — sonst überschreibt das fertige
-    // Ergebnis die aktuell angezeigte View in #resultsContainer (#106-Review).
-    if (!this.isActiveView()) return;
     this.render();
-  }
-
-  /**
-   * True, wenn die Router-Hash-Route noch zu diesem Modul gehört (oder kein
-   * Hash gesetzt ist, z.B. bei programmatischem show() ohne Route).
-   */
-  isActiveView() {
-    const view = (window.location.hash || '').replace(/^#/, '').split('&')[0];
-    return view === '' || view === 'cooccurrence-ranking';
   }
 
   updateProgressBar() {
@@ -499,7 +498,11 @@ export class CooccurrenceRanking {
 
     const input = document.getElementById('coRkQuery');
     if (input) {
-      input.addEventListener('input', (e) => this.updateAutocomplete(e.target.value));
+      input.addEventListener('input', (e) => {
+        // Manuelle Eingabe invalidiert eine frühere Dropdown-Auswahl (#163).
+        this.state.selectedLemma = null;
+        this.updateAutocomplete(e.target.value);
+      });
       input.addEventListener('keydown', (e) => {
         const open = this.state.autocompleteOpen && this.state.autocompleteItems.length > 0;
         if (e.key === 'Enter') {
@@ -507,6 +510,7 @@ export class CooccurrenceRanking {
           if (open && this.state.autocompleteIndex >= 0) {
             const c = this.state.autocompleteItems[this.state.autocompleteIndex];
             input.value = c.lemma || c.id;
+            this.state.selectedLemma = c;
             this.closeAutocomplete();
             runSearch();
             return;
@@ -547,6 +551,7 @@ export class CooccurrenceRanking {
         if (!c) return;
         const inputEl = document.getElementById('coRkQuery');
         if (inputEl) inputEl.value = c.lemma || c.id;
+        this.state.selectedLemma = c;
         this.closeAutocomplete();
         runSearch();
       });

--- a/playground/js/ui/tei/lemma-distribution.js
+++ b/playground/js/ui/tei/lemma-distribution.js
@@ -11,6 +11,7 @@
 const DEFAULT_STATE = Object.freeze({
   query: '',
   resolvedLemma: null,       // {id, lemma, pos} oder null
+  selectedLemma: null,       // explizite Autocomplete-Auswahl (#163) — schlägt resolveQuery
   candidates: [],            // alternative Resolutions bei Partial-Match
   sortBy: 'frequency',       // 'frequency' | 'alphabetic'
   freqMode: 'absolute',      // 'absolute' | 'relative'
@@ -339,7 +340,11 @@ export class LemmaDistribution {
       this.state.query = input.value;
       this.closeAutocomplete();
       const { resolved, candidates } = this.resolveQuery(this.state.query);
-      this.state.resolvedLemma = resolved;
+      // Explizite Autocomplete-Auswahl (#163) schlägt die String-Auflösung —
+      // aber nur solange der Query-Text noch der gewählten Form entspricht.
+      const sel = this.state.selectedLemma;
+      const useSelected = sel && (sel.lemma || sel.id) === (this.state.query || '').trim();
+      this.state.resolvedLemma = useSelected ? sel : resolved;
       this.state.candidates = candidates;
       this.render();
       // Restore focus after re-render (only if user just clicked search)
@@ -354,7 +359,11 @@ export class LemmaDistribution {
 
     const input = document.getElementById('ldQuery');
     if (input) {
-      input.addEventListener('input', (e) => this.updateAutocomplete(e.target.value));
+      input.addEventListener('input', (e) => {
+        // Manuelle Eingabe invalidiert eine frühere Dropdown-Auswahl (#163).
+        this.state.selectedLemma = null;
+        this.updateAutocomplete(e.target.value);
+      });
       input.addEventListener('keydown', (e) => {
         const open = this.state.autocompleteOpen && this.state.autocompleteItems.length > 0;
         if (e.key === 'Enter') {
@@ -362,6 +371,7 @@ export class LemmaDistribution {
           if (open && this.state.autocompleteIndex >= 0) {
             const c = this.state.autocompleteItems[this.state.autocompleteIndex];
             input.value = c.lemma || c.id;
+            this.state.selectedLemma = c;
             this.closeAutocomplete();
             runSearch();
             return;
@@ -402,6 +412,7 @@ export class LemmaDistribution {
         if (!c) return;
         const inputEl = document.getElementById('ldQuery');
         if (inputEl) inputEl.value = c.lemma || c.id;
+        this.state.selectedLemma = c;
         this.closeAutocomplete();
         runSearch();
       });

--- a/playground/js/ui/tei/multi-lemma-search.js
+++ b/playground/js/ui/tei/multi-lemma-search.js
@@ -3,6 +3,8 @@
  * Handles the modal interface for advanced multi-lemma search
  */
 
+import { getNavigationEpoch } from '../core/router.js';
+
 export class MultiLemmaSearchUI {
     constructor(teiExplorer, authorityManager) {
         this.teiExplorer = teiExplorer;
@@ -207,6 +209,11 @@ export class MultiLemmaSearchUI {
         }
 
         try {
+            // Navigiert der User während der async Korpus-Suche zu einer
+            // anderen View, darf das fertige Ergebnis die dort angezeigte
+            // View nicht überschreiben (#159).
+            const myEpoch = getNavigationEpoch();
+
             // Resolve lemma IDs
             const lemmaIds = this.teiExplorer.resolveLemmaIds(searchTerms);
 
@@ -228,10 +235,12 @@ export class MultiLemmaSearchUI {
                 const maxDistance = parseInt(this.proximityDistance.value) || 10;
                 // Try fast index-based search first (falls back to XML if needed)
                 results = await teiManager.searchMultipleLemmasUsingIndex(lemmaIds, 'proximity', maxDistance);
+                if (getNavigationEpoch() !== myEpoch) return;
                 this.teiExplorer.displayCooccurrenceResults(results, searchTerms, maxDistance, lemmaIds);
             } else {
                 // Use fast index-based search for paragraph/document mode
                 results = await teiManager.searchMultipleLemmasUsingIndex(lemmaIds, searchMode);
+                if (getNavigationEpoch() !== myEpoch) return;
                 this.teiExplorer.displayMultiLemmaResults(results, searchTerms, searchMode);
             }
 

--- a/playground/js/ui/tei/multi-lemma-search.js
+++ b/playground/js/ui/tei/multi-lemma-search.js
@@ -208,12 +208,13 @@ export class MultiLemmaSearchUI {
             return;
         }
 
-        try {
-            // Navigiert der User während der async Korpus-Suche zu einer
-            // anderen View, darf das fertige Ergebnis die dort angezeigte
-            // View nicht überschreiben (#159).
-            const myEpoch = getNavigationEpoch();
+        // Navigiert der User während der async Korpus-Suche zu einer
+        // anderen View, darf das fertige Ergebnis die dort angezeigte
+        // View nicht überschreiben (#159). Vor dem try deklariert, damit
+        // auch der catch-Pfad den Guard prüfen kann.
+        const myEpoch = getNavigationEpoch();
 
+        try {
             // Resolve lemma IDs
             const lemmaIds = this.teiExplorer.resolveLemmaIds(searchTerms);
 
@@ -246,6 +247,10 @@ export class MultiLemmaSearchUI {
 
         } catch (error) {
             console.error('Search error:', error);
+            // Gleicher Epoch-Guard wie in den Success-Pfaden: eine nach dem
+            // View-Wechsel fehlschlagende Suche darf die neue View nicht mit
+            // der Fehlermeldung überschreiben (Review-Finding PR #174).
+            if (getNavigationEpoch() !== myEpoch) return;
             if (resultsContainer) {
                 resultsContainer.innerHTML = `
                     <div class="text-sm text-red-600">

--- a/playground/js/ui/tei/naming-explorer.js
+++ b/playground/js/ui/tei/naming-explorer.js
@@ -20,6 +20,7 @@
  */
 
 import { TextNormalizer } from '../../../../assets/js/lib/text-normalizer.js';
+import { getNavigationEpoch } from '../core/router.js';
 
 const DEFAULT_STATE = Object.freeze({
   workSigle: '',
@@ -55,7 +56,11 @@ export class NamingExplorer {
 
     if (!this.index && !this.loadError) {
       container.innerHTML = '<div class="rounded-2xl border border-slate-200 bg-white p-8 text-center text-sm text-slate-500">Lade Figurenbezeichnungen ...</div>';
+      const myEpoch = getNavigationEpoch();
       await this.loadIndex();
+      // Navigiert der User während des Erst-Loads weg, nicht rendern —
+      // sonst überschreibt der fertige Index die andere View (#159).
+      if (getNavigationEpoch() !== myEpoch) return;
     }
     this.render();
   }

--- a/playground/js/ui/tei/rhyme-dictionary.js
+++ b/playground/js/ui/tei/rhyme-dictionary.js
@@ -19,9 +19,12 @@
  * Issue: #106
  */
 
+import { getNavigationEpoch } from '../core/router.js';
+
 const DEFAULT_STATE = Object.freeze({
   query: '',
   resolvedLemma: null,
+  selectedLemma: null,        // explizite Autocomplete-Auswahl (#163) — schlägt resolveQuery
   candidates: [],
   textFilter: '',             // Sigle/Titel/Autor-Substring, optional
   minCount: 1,                // Mindestanzahl Reimpaare pro Partner
@@ -125,9 +128,12 @@ export class RhymeDictionary {
     let verseTextCount = 0;
     let chunkStart = performance.now();
     const myToken = this._abortToken;
+    const myEpoch = getNavigationEpoch();
 
     for (let i = 0; i < texts.length; i++) {
-      if (this._abortToken !== myToken) return null;
+      // Abort on new search in this module (token) OR router navigation
+      // to another view (epoch, #159) while we were running.
+      if (this._abortToken !== myToken || getNavigationEpoch() !== myEpoch) return null;
 
       const text = texts[i];
       const ends = text.lineEnds;
@@ -170,7 +176,7 @@ export class RhymeDictionary {
       if (performance.now() - chunkStart > CHUNK_BUDGET_MS) {
         if (onProgress) onProgress((i + 1) / texts.length);
         await yieldToMain();
-        if (this._abortToken !== myToken) return null;
+        if (this._abortToken !== myToken || getNavigationEpoch() !== myEpoch) return null;
         chunkStart = performance.now();
       }
     }
@@ -204,10 +210,14 @@ export class RhymeDictionary {
 
   async runSearch() {
     const { resolved, candidates } = this.resolveQuery(this.state.query);
-    this.state.resolvedLemma = resolved;
+    // Explizite Autocomplete-Auswahl (#163) schlägt die String-Auflösung —
+    // aber nur solange der Query-Text noch der gewählten Form entspricht.
+    const sel = this.state.selectedLemma;
+    const useSelected = sel && (sel.lemma || sel.id) === (this.state.query || '').trim();
+    this.state.resolvedLemma = useSelected ? sel : resolved;
     this.state.candidates = candidates;
     this.state.result = null;
-    if (!resolved) {
+    if (!this.state.resolvedLemma) {
       this.render();
       return;
     }
@@ -217,12 +227,13 @@ export class RhymeDictionary {
     this.render();
 
     const myToken = this._abortToken;
-    const raw = await this.computeRhymes(resolved, (p) => {
+    const myEpoch = getNavigationEpoch();
+    const raw = await this.computeRhymes(this.state.resolvedLemma, (p) => {
       if (this._abortToken !== myToken) return;
       this.state.progress = p;
       this.updateProgressBar();
     });
-    if (this._abortToken !== myToken) return;
+    if (this._abortToken !== myToken || getNavigationEpoch() !== myEpoch) return;
     if (!raw) {
       this.state.computing = false;
       return;
@@ -233,20 +244,7 @@ export class RhymeDictionary {
       partners: this.enrichPartners(raw.partners)
     };
     this.state.computing = false;
-    // Nicht rendern, wenn der User während des Scans zu einer anderen
-    // Playground-View navigiert ist — sonst überschreibt das fertige
-    // Ergebnis die aktuell angezeigte View in #resultsContainer.
-    if (!this.isActiveView()) return;
     this.render();
-  }
-
-  /**
-   * True, wenn die Router-Hash-Route noch zu diesem Modul gehört (oder kein
-   * Hash gesetzt ist, z.B. bei programmatischem show() ohne Route).
-   */
-  isActiveView() {
-    const view = (window.location.hash || '').replace(/^#/, '').split('&')[0];
-    return view === '' || view === 'rhyme-dictionary';
   }
 
   updateProgressBar() {
@@ -530,7 +528,11 @@ export class RhymeDictionary {
 
     const input = document.getElementById('rdQuery');
     if (input) {
-      input.addEventListener('input', (e) => this.updateAutocomplete(e.target.value));
+      input.addEventListener('input', (e) => {
+        // Manuelle Eingabe invalidiert eine frühere Dropdown-Auswahl (#163).
+        this.state.selectedLemma = null;
+        this.updateAutocomplete(e.target.value);
+      });
       input.addEventListener('keydown', (e) => {
         const open = this.state.autocompleteOpen && this.state.autocompleteItems.length > 0;
         if (e.key === 'Enter') {
@@ -538,6 +540,7 @@ export class RhymeDictionary {
           if (open && this.state.autocompleteIndex >= 0) {
             const c = this.state.autocompleteItems[this.state.autocompleteIndex];
             input.value = c.lemma || c.id;
+            this.state.selectedLemma = c;
             this.closeAutocomplete();
             runSearch();
             return;
@@ -578,6 +581,7 @@ export class RhymeDictionary {
         if (!c) return;
         const inputEl = document.getElementById('rdQuery');
         if (inputEl) inputEl.value = c.lemma || c.id;
+        this.state.selectedLemma = c;
         this.closeAutocomplete();
         runSearch();
       });

--- a/playground/js/ui/tei/verse-position-search.js
+++ b/playground/js/ui/tei/verse-position-search.js
@@ -11,6 +11,7 @@
 const DEFAULT_STATE = Object.freeze({
   query: '',
   resolvedLemma: null,
+  selectedLemma: null,  // explizite Autocomplete-Auswahl (#163) — schlägt resolveQuery
   candidates: [],
   position: 'end',  // 'start' | 'end' — Versende ist der häufigere Use Case (Reim)
   // Autocomplete (Port aus #113-Pattern)
@@ -280,7 +281,11 @@ export class VersePositionSearch {
       this.state.query = input.value;
       this.closeAutocomplete();
       const { resolved, candidates } = this.resolveQuery(this.state.query);
-      this.state.resolvedLemma = resolved;
+      // Explizite Autocomplete-Auswahl (#163) schlägt die String-Auflösung —
+      // aber nur solange der Query-Text noch der gewählten Form entspricht.
+      const sel = this.state.selectedLemma;
+      const useSelected = sel && (sel.lemma || sel.id) === (this.state.query || '').trim();
+      this.state.resolvedLemma = useSelected ? sel : resolved;
       this.state.candidates = candidates;
       this.render();
       const newInput = document.getElementById('vpsQuery');
@@ -294,7 +299,11 @@ export class VersePositionSearch {
 
     const input = document.getElementById('vpsQuery');
     if (input) {
-      input.addEventListener('input', (e) => this.updateAutocomplete(e.target.value));
+      input.addEventListener('input', (e) => {
+        // Manuelle Eingabe invalidiert eine frühere Dropdown-Auswahl (#163).
+        this.state.selectedLemma = null;
+        this.updateAutocomplete(e.target.value);
+      });
       input.addEventListener('keydown', (e) => {
         const open = this.state.autocompleteOpen && this.state.autocompleteItems.length > 0;
         if (e.key === 'Enter') {
@@ -302,6 +311,7 @@ export class VersePositionSearch {
           if (open && this.state.autocompleteIndex >= 0) {
             const c = this.state.autocompleteItems[this.state.autocompleteIndex];
             input.value = c.lemma || c.id;
+            this.state.selectedLemma = c;
             this.closeAutocomplete();
             runSearch();
             return;
@@ -342,6 +352,7 @@ export class VersePositionSearch {
         if (!c) return;
         const inputEl = document.getElementById('vpsQuery');
         if (inputEl) inputEl.value = c.lemma || c.id;
+        this.state.selectedLemma = c;
         this.closeAutocomplete();
         runSearch();
       });

--- a/testing/tests/cooccurrence-ranking.spec.js
+++ b/testing/tests/cooccurrence-ranking.spec.js
@@ -1,0 +1,72 @@
+/**
+ * Kookkurrenz-Ranking + Multi-Lemma-Auflösung Tests (#163, #164)
+ *
+ * #163: Das Autocomplete-Dropdown zeigt Homographen mit verschiedenen IDs an,
+ * aber die Auswahl kam nie bei der Suche an — resolveQuery() löste den
+ * Orthographie-String erneut auf und nahm matches[0]. Die Tests verifizieren,
+ * dass (a) die Default-Auflösung frequenz-sortiert ist (ADJ rôt, 1567 Belege,
+ * schlägt den Eigennamen "Rot" mit 1 Beleg) und (b) eine explizite
+ * Dropdown-Auswahl eines selteneren Homographen durchgereicht wird.
+ *
+ * #164: Multi-Lemma-Suche "rôt + munt" lieferte 0 Treffer, weil rôt auf
+ * lemma_11330 "Rot" (NAM) statt lemma_4954 "rôt" (ADJ) auflöste. Ground
+ * Truth: alte MHDBDB liefert für rot+munt 553 Zeilen-Treffer; der
+ * Corpus-Index enthält 366 Nähe-Kookkurrenzen (dist=10) in 98 Texten.
+ */
+
+import { test, expect } from '@playwright/test';
+
+test.describe('Issue #163: Kookkurrenz-Dropdown-Homographen', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:8080/playground/#cooccurrence-ranking');
+    await page.waitForSelector('#coRkSearchBtn', { state: 'visible', timeout: 60000 });
+  });
+
+  test('Default-Auflösung wählt frequentesten Homographen (rot → ADJ rôt)', async ({ page }) => {
+    await page.fill('#coRkQuery', 'rot');
+    await page.press('#coRkQuery', 'Escape'); // Autocomplete schließen
+    await page.click('#coRkSearchBtn');
+
+    // Header muss das Adjektiv lemma_4954 zeigen, nicht den Eigennamen
+    await expect(page.locator('#resultsContainer')).toContainText('lemma_4954', { timeout: 60000 });
+    await expect(page.locator('#resultsContainer')).toContainText('ADJ');
+  });
+
+  test('Dropdown-Auswahl eines selteneren Homographen wird durchgereicht', async ({ page }) => {
+    await page.fill('#coRkQuery', 'rôt');
+    // Autocomplete zeigt alle Homographen mit ID + POS
+    await page.waitForSelector('#coRkAutocomplete button', { state: 'visible', timeout: 15000 });
+
+    // Explizit den Eigennamen lemma_11330 "Rot" (NAM) anklicken — NICHT der
+    // frequenz-sortierte Default. Vor dem Fix gewann trotzdem matches[0].
+    await page.click('#coRkAutocomplete button:has-text("lemma_11330")');
+
+    // Die Suche muss mit dem GEWÄHLTEN Lemma laufen (1 Vorkommen im Korpus)
+    await expect(page.locator('#resultsContainer')).toContainText('lemma_11330', { timeout: 60000 });
+    await expect(page.locator('#resultsContainer')).not.toContainText('lemma_4954');
+  });
+});
+
+test.describe('Issue #164: Multi-Lemma-Suche rôt + munt', () => {
+  test('resolveLemmaIds löst rôt auf das Adjektiv-Lemma auf', async ({ page }) => {
+    await page.goto('http://localhost:8080/playground/');
+    await page.waitForFunction(() => {
+      return window.playground?.corpusData?.texts?.length > 0 &&
+             window.playground?.ui?.multiLemmaSearch;
+    }, { timeout: 60000 });
+
+    const ids = await page.evaluate(() => {
+      return window.playground.ui.multiLemmaSearch.teiExplorer.resolveLemmaIds(['rôt', 'munt']);
+    });
+    expect(ids).toEqual(['4954', '4252']);
+  });
+
+  test('Nähe-Suche rôt+munt liefert Treffer (Route-E2E)', async ({ page }) => {
+    await page.goto('http://localhost:8080/playground/#multi-lemma&lemmata=r%C3%B4t,munt&mode=proximity&dist=10');
+
+    // 366 Kookkurrenzen in 98 Texten erwartet — auf jeden Fall nicht "(0 Treffer)"
+    await expect(page.locator('#resultsContainer')).toContainText('Nähe-Beziehungen', { timeout: 120000 });
+    const text = await page.locator('#resultsContainer').textContent();
+    expect(text).not.toContain('(0 Treffer)');
+  });
+});

--- a/testing/tests/search-normalization.spec.js
+++ b/testing/tests/search-normalization.spec.js
@@ -254,8 +254,9 @@ test.describe('Search Normalization Test Suite', () => {
                 // Stage 3: Partial match fallback
 
                 // expectedLemma prüft die Stufe wirklich (Audit #112):
-                // Stage 1/2 liefern genau EIN Lemma (Exact bzw. Variants-Hit
-                // auf lemma_879), Stage 3 (Partial) liefert viele Treffer.
+                // Stage 1/2 liefern bei eindeutigen Lemmata genau EIN Lemma
+                // (Exact bzw. Variants-Hit auf lemma_879), Stage 3 (Partial)
+                // liefert viele Treffer.
                 const testCases = [
                     { input: 'brôt', stage: 1, desc: 'Exact lexicon match', expectedLemma: 'lemma_879', exactCount: 1 },
                     { input: 'brott', stage: 2, desc: 'Exact variant match', expectedLemma: 'lemma_879', exactCount: 1 },
@@ -292,6 +293,40 @@ test.describe('Search Normalization Test Suite', () => {
                     expect(tc.foundIds, `${tc.input}: erwartetes Lemma`).toContain(tc.expectedLemma);
                 }
                 expect(tc.foundLemmas).toBeGreaterThanOrEqual(tc.minCount);
+            });
+        });
+
+        test('8b. searchLemmaByOrthography - Homographen frequenz-sortiert (#163/#164)', async () => {
+            // "rôt" existiert dreimal im Lexikon: lemma_11330 "Rot" (NAM,
+            // 1 Korpus-Beleg), lemma_19417 "rot" (NOM, 1 Beleg), lemma_4954
+            // "rôt" (ADJ, 1567 Belege). Stage 1 muss ALLE Homographen liefern,
+            // frequenz-sortiert, damit matches[0]-Konsumenten (Multi-Lemma-
+            // Suche, Kookkurrenz, Reim, Versposition) das plausibelste Lemma
+            // bekommen — nicht das zufällig erste im Index (#164: rôt+munt
+            // lieferte 0 Treffer, weil der Eigenname "Rot" gewann).
+            await page.waitForFunction(() => {
+                return window.playground?.corpusData?.texts?.length > 0;
+            }, { timeout: 60000 });
+
+            const result = await page.evaluate(() => {
+                const manager = window.playground.authorityManager;
+                return ['rôt', 'rot'].map(input => {
+                    const lemmas = manager.searchLemmaByOrthography(input);
+                    return {
+                        input,
+                        count: lemmas.length,
+                        firstId: lemmas[0]?.id,
+                        ids: lemmas.map(l => l.id)
+                    };
+                });
+            });
+
+            result.forEach(r => {
+                console.log(`  "${r.input}" → ${r.count} Homographen, erster: ${r.firstId} [${r.ids.join(', ')}]`);
+                expect(r.count, `${r.input}: alle Homographen müssen zurückkommen`).toBe(3);
+                expect(r.firstId, `${r.input}: frequentestes Lemma (ADJ rôt) muss zuerst stehen`).toBe('lemma_4954');
+                expect(r.ids).toContain('lemma_11330');
+                expect(r.ids).toContain('lemma_19417');
             });
         });
 


### PR DESCRIPTION
## Zusammenfassung

Vier Issues mit gemeinsamer bzw. verwandter Wurzel, gemäß Masterplan Welle 1:

**#163 (KZW-Bugreport): Kookkurrenz-Dropdown wählt immer erstes Lemma.** Das Autocomplete zeigte Homographen korrekt mit IDs an, aber der Klick setzte nur den Orthographie-String ins Eingabefeld — `resolveQuery()` löste ihn neu auf und nahm blind `matches[0]`. Fix: Auswahl (Klick/Enter) setzt jetzt `selectedLemma`, das `runSearch()` bevorzugt; manuelles Tippen setzt zurück. Umgesetzt in allen 5 Autocomplete-Modulen (Kookkurrenz, Lemma-Verteilung, Versposition, Reim-Wörterbuch, Begriffs-Verteilung).

**#164 (KZW-Bugreport): Multi-Lemma `rôt + munt` liefert nichts.** Gleiche Wurzel: `searchLemmaByOrthography()` Stage 1 nahm per `find()` das zufällig erste Lemma im Index — bei „rôt" den Eigennamen `lemma_11330` „Rot" (1 Korpus-Beleg) statt des Adjektivs `lemma_4954` (1.567 Belege in 214 Texten). Fix: Stage 1 sammelt alle Homographen und sortiert nach Korpus-Frequenz (Tiebreak: diakritisch-exakte Eingabe, dann stabil). Damit spiegelt der Playground die Hauptseiten-Semantik (die sammelt seit jeher alle exakten Matches).

**Verifikation gegen Ground Truth:** Alte MHDBDB liefert für rot+munt 553 Zeilen-Treffer. Nach dem Fix liefert die Nähe-Suche (±10 Wörter) **357 Treffer in 98 Kontexten** (Chrome-verifiziert, deckt sich mit der Corpus-Index-Rechnung: 366 Kookkurrenzen/98 Texte). Vorher: 0.

**#159: View-Clobber pattern-weit.** Der Router exportiert jetzt einen globalen Navigation-Epoch-Zähler (`getNavigationEpoch()`, Bump in `dispatch()` bei jeder Route-Änderung). Async-Module prüfen ihn zusammen mit ihrem Abort-Token nach jedem await/yield. Ersetzt die per-Modul-`isActiveView()`-Guards (entfernt in cooccurrence-ranking + rhyme-dictionary) und schützt jetzt auch die bisher ungeschützten `multi-lemma-search.js` und `naming-explorer.js` (Erst-Load).

**#168: Same-View-Races.** (a) `concept-distribution.js`: Such-Generation-Token statt `computing`-Flag — vorher gewann bei zwei überlappenden Suchen die ÄLTERE (Header zeigt Begriff B, Balkendiagramm Verteilung von A). (b) `tei-text-reader.js openReadingView()`: `_loadSeq`-Request-Guard — ein überholter Ladevorgang rendert weder DOM noch überschreibt State/Fehleranzeige.

**DESIGN.md** dokumentiert beide Mechanismen (Navigation-Epoch §, Auswahl-Durchreichung im Autocomplete-Pattern §).

## Tests

- Baseline auf main (07.07.): 185 passed / 1 failed — einziger Fail ist der bekannte #158/#162-Prosazeilen-Test (Welle-2-Gegenstand).
- Neu: `search-normalization.spec.js` Test 8b (Homographen frequenz-sortiert), `cooccurrence-ranking.spec.js` (Dropdown-Durchreichung, Default-Auflösung, resolveLemmaIds, rôt+munt-Route-E2E).
- Chrome-verifiziert: Dropdown-Klick auf `lemma_11330` (NAM) sucht wirklich `lemma_11330`; vorher gewann immer das erste Lemma.

## Hinweise fürs Review

- Die 4 Suchsemantik-Entscheidungen aus #169 (Nähesuche-Paardistanz, Stage-3-Drift, commonLemmas-Dict, Dedup) sind bewusst NICHT angefasst — Diagnose-Erkenntnisse stehen als Kommentar in #169.
- Kein Datei-Konflikt mit anderen geplanten Wellen-PRs; kann unabhängig gemergt werden.

Closes #163
Closes #164
Closes #159
Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review-Triage (08.07.)

Bot-Review gesichtet. Umgesetzt als Folge-Commit `1c41e9923`: Epoch-Guard auch im catch-Pfad von `executeSearch` (die Fehlermeldung konnte nach View-Wechsel die neue View ueberschreiben). Bewusst NICHT umgesetzt: der "unreachable guard"-Nit in concept-distribution.js — der `if (!dist)`-Zweig bleibt als billiger Belt-and-Suspenders-Check stehen.



**Nachtrag (08.07., Merge-Session):** Zweites Bot-Review (07:19 UTC, nach Folge-Commit) gesichtet: "No blocking issues found". Die 4 Beobachtungen sind non-blocking (Nit 1 bestätigt die Belt-and-Suspenders-Entscheidung; Nits 2-4 Stilfragen ohne Funktionswirkung), begründet nicht umgesetzt.
