### PR TITLE
#134: AK-Ausschnitts-Kontext in Metadaten und Leseansicht

### DIFF
--- a/assets/css/korpus.css
+++ b/assets/css/korpus.css
@@ -119,6 +119,19 @@
   border-bottom: 1px solid var(--border-primary);
 }
 
+/* Excerpt banner (#134): Ausschnittsbeziehung sichtbar über dem Text,
+   blue-50-Info-Box analog zum Hinweis-Pattern der Startseite (#20) */
+.excerpt-banner {
+  margin: var(--space-4) var(--space-6) 0;
+  padding: var(--space-3) var(--space-4);
+  background: #eff6ff;
+  border: 1px solid #bfdbfe;
+  border-radius: 0.75rem;
+  font-size: var(--text-sm);
+  line-height: 1.6;
+  color: #1e3a8a;
+}
+
 .metadata-toggle-container {
   padding: var(--space-4) var(--space-6);
 }

--- a/assets/js/rendering/tei-text-reader.js
+++ b/assets/js/rendering/tei-text-reader.js
@@ -227,6 +227,12 @@ class TEITextReader {
                         verseRange: verseScope.textContent.trim(),
                         context: contextNote ? contextNote.textContent.trim() : null
                     };
+                } else {
+                    // Authoring-Signal statt stillem No-op: der Banner lebt rein
+                    // von kuratierten Header-Daten — fehlt der analytic-Titel
+                    // zum Versbereich, soll das beim Kuratieren auffallen,
+                    // nicht erst in der manuellen QA (Review-Finding PR #178).
+                    console.warn('[TEITextReader] biblScope unit="verse" gefunden, aber kein <analytic><title> — Excerpt-Banner wird nicht angezeigt.');
                 }
             }
 

--- a/assets/js/rendering/tei-text-reader.js
+++ b/assets/js/rendering/tei-text-reader.js
@@ -208,8 +208,13 @@ class TEITextReader {
             // work iff its header biblStruct carries a verse range
             // (biblScope unit="verse"). An <analytic> title alone is NOT
             // sufficient — 534 corpus headers have one for ordinary
-            // journal/book-section editions.
-            const excerptBibl = teiDoc.querySelector('sourceDesc biblStruct');
+            // journal/book-section editions. Headers may carry SEVERAL
+            // biblStruct entries (book + bookSection, e.g. FB/HZ/WZB), so the
+            // verse-scoped one is searched for across all of them, not just
+            // the first in document order.
+            const excerptBibl = Array.from(teiDoc.querySelectorAll('sourceDesc biblStruct'))
+                .find(bs => Array.from(bs.querySelectorAll('imprint biblScope'))
+                    .some(scope => scope.getAttribute('unit') === 'verse'));
             if (excerptBibl) {
                 const verseScope = Array.from(excerptBibl.querySelectorAll('imprint biblScope'))
                     .find(bs => bs.getAttribute('unit') === 'verse');

--- a/assets/js/rendering/tei-text-reader.js
+++ b/assets/js/rendering/tei-text-reader.js
@@ -187,7 +187,10 @@ class TEITextReader {
 
             // External links
             handschriftencensus: null,
-            zoteroLinks: []
+            zoteroLinks: [],
+
+            // Excerpt relationship (from TEI header biblStruct, #134)
+            excerpt: null
         };
 
         try {
@@ -198,6 +201,27 @@ class TEITextReader {
                 // Extract work ID: "works.xml#work_131" → "work_131"
                 if (corresp && corresp.includes('#')) {
                     metadata.workId = corresp.split('#')[1];
+                }
+            }
+
+            // 1b. Excerpt relationship (#134): a text is an excerpt of a larger
+            // work iff its header biblStruct carries a verse range
+            // (biblScope unit="verse"). An <analytic> title alone is NOT
+            // sufficient — 534 corpus headers have one for ordinary
+            // journal/book-section editions.
+            const excerptBibl = teiDoc.querySelector('sourceDesc biblStruct');
+            if (excerptBibl) {
+                const verseScope = Array.from(excerptBibl.querySelectorAll('imprint biblScope'))
+                    .find(bs => bs.getAttribute('unit') === 'verse');
+                const analyticTitle = excerptBibl.querySelector('analytic > title');
+                if (verseScope && analyticTitle && analyticTitle.textContent.trim()) {
+                    const contextNote = Array.from(excerptBibl.querySelectorAll('note'))
+                        .find(n => n.getAttribute('type') === 'context');
+                    metadata.excerpt = {
+                        title: analyticTitle.textContent.trim(),
+                        verseRange: verseScope.textContent.trim(),
+                        context: contextNote ? contextNote.textContent.trim() : null
+                    };
                 }
             }
 
@@ -576,8 +600,21 @@ class TEITextReader {
         this.elements.readingTitle.textContent = metadata.title;
         this.elements.readingAuthor.textContent = metadata.author;
 
+        // Excerpt banner (#134): sichtbar über dem Text, bewusst NICHT im
+        // eingeklappten Metadaten-Bereich — die Ausschnittsbeziehung muss
+        // ohne Öffnen des Panels erkennbar sein (Akzeptanzkriterium #134).
+        let metadataHTML = '';
+        if (metadata.excerpt) {
+            metadataHTML += '<div class="excerpt-banner">';
+            metadataHTML += `<strong>${this.escapeHtml(metadata.excerpt.title)}</strong> – Ausschnitt aus: ${this.escapeHtml(metadata.title)} (Verse ${this.escapeHtml(metadata.excerpt.verseRange)}).`;
+            if (metadata.excerpt.context) {
+                metadataHTML += ` ${this.escapeHtml(metadata.excerpt.context)}`;
+            }
+            metadataHTML += '</div>';
+        }
+
         // Build comprehensive metadata HTML with collapsible section
-        let metadataHTML = '<div class="metadata-toggle-container">';
+        metadataHTML += '<div class="metadata-toggle-container">';
         metadataHTML += '<button class="metadata-toggle-btn" aria-expanded="false">';
         // Heroicon: chevron-right (collapsed state)
         metadataHTML += '<svg class="toggle-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>';
@@ -587,6 +624,20 @@ class TEITextReader {
 
         // Wikidata Image Section (will be populated asynchronously)
         metadataHTML += '<div id="wikidataImageContainer" class="wikidata-image-container" style="display: none;"></div>';
+
+        // Section 0: Excerpt relationship (#134) — strukturierte Felder
+        // analog zur Tabelle im Issue (Ausschnitt/Gesamtwerk/Versbereich/Kontext)
+        if (metadata.excerpt) {
+            metadataHTML += '<div class="metadata-section">';
+            metadataHTML += '<h4 class="metadata-section-title">Ausschnitt</h4>';
+            metadataHTML += `<div class="metadata-row"><strong>Ausschnitt:</strong> ${this.escapeHtml(metadata.excerpt.title)}</div>`;
+            metadataHTML += `<div class="metadata-row"><strong>Gesamtwerk:</strong> ${this.escapeHtml(metadata.title)}</div>`;
+            metadataHTML += `<div class="metadata-row"><strong>Versbereich:</strong> ${this.escapeHtml(metadata.excerpt.verseRange)}</div>`;
+            if (metadata.excerpt.context) {
+                metadataHTML += `<div class="metadata-row"><strong>Kontext:</strong> ${this.escapeHtml(metadata.excerpt.context)}</div>`;
+            }
+            metadataHTML += '</div>';
+        }
 
         // Section 1: All Titles
         if (metadata.titles && metadata.titles.length > 0) {

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -80,6 +80,7 @@ Full-text immersive reader with multi-lemma highlighting and rich metadata.
 - **Dual identifiers:** Separate GND/Wikidata for work vs author
 - **Context navigation:** Prev/next buttons to jump between occurrences
 - **URL parameters:** `?textId=ABG&lemmaIds=879,7532&position=310`
+- **Ausschnitts-Kontext (#134):** Texte mit `biblScope unit="verse"` im Header (Ausschnitte eines Gesamtwerks, z. B. AK aus der Steirischen Reimchronik) zeigen einen sichtbaren Banner über dem Text sowie eine „Ausschnitt"-Metadaten-Sektion (Ausschnitt/Gesamtwerk/Versbereich/Kontext); siehe TEI-MODEL.md §2.1
 
 **TEI elements rendered:**
 - Text structure: `<head>`, `<p>`, `<div>`, `<lg>` (stanzas), `<l>` (verse lines)

--- a/docs/TEI-MODEL.md
+++ b/docs/TEI-MODEL.md
@@ -98,6 +98,8 @@ The header is already largely standardized across all 667 files. This section do
 - Primaeredition immer als `<biblStruct>` mit Zotero-`corresp`
 - Digitale Zwischenstufen als `<bibl type="digitalIntermediary">` (ADR-012)
 
+**Ausschnittstexte (#134):** Ist der Korpus-Text ein definierter Ausschnitt eines groesseren Werks (z. B. AK = „Buch von Akkon" innerhalb der Steirischen Reimchronik), traegt die Primaeredition zusaetzlich `<biblScope unit="verse">{von}–{bis}</biblScope>` im `<imprint>` sowie optional `<note type="context">{inhaltlicher Zusammenhang}</note>` am `<biblStruct>`. Das `unit="verse"` ist das maschinenlesbare Excerpt-Signal: Der Reader zeigt dann Banner + „Ausschnitt"-Metadaten (Ausschnittstitel aus `<analytic>/<title>`). Ein `<analytic>`-Titel allein markiert KEINEN Ausschnitt — 534 Header haben ihn fuer gewoehnliche Editions-Angaben.
+
 ### 2.1bis Editor-Attribution & Credits
 
 Attribution der an der MHDBDB mitwirkenden Personen laeuft zentral ueber `authority-files/contributors.xml` (siehe [`TEI-MODEL-AUTH-FILES.md`](TEI-MODEL-AUTH-FILES.md) §3.8). Die Korpus-Header referenzieren dieses Register via `@ref`; namentlich ausgeschrieben wird im Header nur, was pro Datei variiert oder fuer Leser:innen direkt sichtbar sein soll.

--- a/schema/mhdbdb.rnc
+++ b/schema/mhdbdb.rnc
@@ -122,7 +122,9 @@ sourceDesc = element sourceDesc {
     }
 }
 
-# GAP 8: <note> in biblStruct (626 elements)
+# GAP 8: <note> in biblStruct (626 elements).
+# @type optional seit #134 (note type="context" traegt den Ausschnitts-Kontext
+# fuer Excerpt-Texte wie AK; analog zur note in bibl weiter unten).
 biblStruct = element biblStruct {
     attribute type { text }?,
     attribute xml:id { xsd:NCName }?,
@@ -154,7 +156,7 @@ biblStruct = element biblStruct {
         element title { attribute level { text }?, text },
         element biblScope { attribute unit { text }?, text }*
      }?,
-     element note { text }*)
+     element note { attribute type { text }?, text }*)
 }
 
 bibl = element bibl {

--- a/schema/mhdbdb.rng
+++ b/schema/mhdbdb.rng
@@ -571,6 +571,12 @@
         <zeroOrMore>
           <element>
             <name ns="http://www.tei-c.org/ns/1.0">note</name>
+            <optional>
+              <attribute>
+                <name ns="">type</name>
+                <text/>
+              </attribute>
+            </optional>
             <text/>
           </element>
         </zeroOrMore>

--- a/tei/AK.tei.xml
+++ b/tei/AK.tei.xml
@@ -77,6 +77,7 @@
                   </editor>
                   <imprint>
                     <biblScope unit="page">578–720</biblScope>
+                    <biblScope unit="verse">44579–53866</biblScope>
                     <biblScope unit="volume">5.1</biblScope>
                     <publisher>Hahn</publisher>
                     <date>1890–1893</date>
@@ -86,6 +87,7 @@
                   <title level="s">Monumenta Germaniae Historica. Deutsche Chroniken und Andere Geschichtsbücher des Mittelalters</title>
                 </series>
                 <note>Seemüller, Josef: Monumenta Germaniae Historica. Deutsche Chroniken. 5,1 u. 5,2 Ottokars Österreichische Reimchronik. Nach den Abschriften Franz Lichtensteins. Unveränderter Nachdruck der 1890-1893 bei der Hahnschen Buchhandlung, Hannover, erschienenen Ausgabe. München: Monumenta Germaniae Historica, 1980, S. 578-720. Elektronischer Text vorbereitet von Bettina Hatheyer</note>
+                <note type="context">Der Abschnitt schildert die Zerstörung Akkons durch die Sarazenen im Jahr 1291 und bildet einen in sich geschlossenen Erzählkomplex innerhalb des Gesamtwerks.</note>
               </biblStruct>
             </listBibl>
           </additional>

--- a/testing/tests/reading-view.spec.js
+++ b/testing/tests/reading-view.spec.js
@@ -288,3 +288,41 @@ test.describe('Reading View', () => {
     });
 
 });
+
+test.describe('Issue #134: Ausschnitts-Kontext (Excerpt)', () => {
+
+    test.setTimeout(120000);
+
+    test('AK zeigt Excerpt-Banner und Ausschnitt-Metadaten', async ({ page }) => {
+        await page.goto('http://localhost:8080/korpus.html?textId=AK');
+        await page.waitForSelector('#loadingScreen', { state: 'hidden', timeout: 30000 });
+        await expect(page.locator('#readingTitle')).not.toBeEmpty({ timeout: 90000 });
+
+        // Banner sichtbar über dem Text, OHNE das Metadaten-Panel zu öffnen
+        // (Akzeptanzkriterium: Ausschnittsbeziehung muss erkennbar sein)
+        const banner = page.locator('.excerpt-banner');
+        await expect(banner).toBeVisible();
+        await expect(banner).toContainText('Buch von Akkon');
+        await expect(banner).toContainText('44579–53866');
+
+        // Metadaten-Panel: strukturierte Ausschnitt-Sektion (Issue-Tabelle)
+        await page.click('.metadata-toggle-btn');
+        const sections = page.locator('.metadata-sections');
+        await expect(sections).toContainText('Ausschnitt');
+        await expect(sections).toContainText('Gesamtwerk:');
+        await expect(sections).toContainText('Versbereich:');
+        await expect(sections).toContainText('Zerstörung Akkons');
+    });
+
+    test('analytic-Titel ohne Versbereich löst KEINEN Banner aus (ABG)', async ({ page }) => {
+        // 534 Korpus-Header haben <analytic> für gewöhnliche
+        // Editions-Angaben (Zeitschriftenartikel, Sammelband-Kapitel).
+        // Excerpt-Signal ist ausschließlich biblScope unit="verse".
+        await page.goto('http://localhost:8080/korpus.html?textId=ABG');
+        await page.waitForSelector('#loadingScreen', { state: 'hidden', timeout: 30000 });
+        await expect(page.locator('#readingTitle')).not.toBeEmpty({ timeout: 90000 });
+
+        await expect(page.locator('.excerpt-banner')).toHaveCount(0);
+    });
+
+});

--- a/testing/tests/reading-view.spec.js
+++ b/testing/tests/reading-view.spec.js
@@ -325,4 +325,15 @@ test.describe('Issue #134: Ausschnitts-Kontext (Excerpt)', () => {
         await expect(page.locator('.excerpt-banner')).toHaveCount(0);
     });
 
+    test('mehrere biblStructs ohne Versbereich lösen KEINEN Banner aus (FB)', async ({ page }) => {
+        // FB trägt zwei biblStruct-Einträge (book + bookSection) — die
+        // Excerpt-Erkennung durchsucht alle, findet aber ohne
+        // biblScope unit="verse" keinen Ausschnitt (Review-Finding PR #178).
+        await page.goto('http://localhost:8080/korpus.html?textId=FB');
+        await page.waitForSelector('#loadingScreen', { state: 'hidden', timeout: 30000 });
+        await expect(page.locator('#readingTitle')).not.toBeEmpty({ timeout: 90000 });
+
+        await expect(page.locator('.excerpt-banner')).toHaveCount(0);
+    });
+
 });


### PR DESCRIPTION
## Zusammenfassung

AK („Buch von Akkon") wird bisher nicht als Ausschnitt der Steirischen Reimchronik erkennbar. Dieser PR modelliert die Ausschnittsbeziehung strukturiert im TEI-Header und zeigt sie in der Leseansicht — wiederverwendbar für jeden künftigen Ausschnittstext (nur Header-Daten kuratieren, kein Code nötig).

> **Stacking-Hinweis:** Dieser PR ist auf PR #175 gestackt (Basis-Branch \`claude/158-162-lb-number-h-prefix\`), weil beide \`tei-text-reader.js\` und \`reading-view.spec.js\` anfassen. **Merge-Reihenfolge: #174 → #175 → dieser PR.**

## Changes

- **\`tei/AK.tei.xml\`**: \`<biblScope unit="verse">44579–53866</biblScope>\` im \`imprint\` der Primäredition (aus den realen \`<l n>\`-Werten abgeleitet) + \`<note type="context">\` mit dem Issue-Wortlaut (Zerstörung Akkons 1291); konsistent mit dem bestehenden \`editorialDecl\`-Fließtext.
- **\`schema/mhdbdb.rnc\` + \`.rng\`**: \`biblStruct\`-note minimal-additiv um optionales \`@type\` erweitert (GAP-8-Kommentar aktualisiert; die \`bibl\`-note hatte es bereits). \`.rng\` via \`rnc2rng\` regeneriert, AK validiert (lxml RelaxNG).
- **\`tei-text-reader.js\`**: \`extractMetadata\` liest \`excerpt\` (Ausschnittstitel aus \`analytic/title\`, Versbereich, Kontextnote) aus dem Header-\`biblStruct\`. **Excerpt-Signal ist ausschließlich \`biblScope unit="verse"\`** — 534 der 667 Header haben ein \`<analytic>\` für gewöhnliche Editions-Angaben, das allein wäre also ein massiver False-Positive-Trigger. \`populateModal\`: sichtbarer Banner über dem Text (blue-50-Info-Box, Pattern #20) + strukturierte Sektion „Ausschnitt" (Ausschnitt/Gesamtwerk/Versbereich/Kontext, exakt die Tabelle aus dem Issue) als erste Metadaten-Sektion.
- **\`korpus.css\`**: \`.excerpt-banner\` im Custom-Property-Idiom des Readers.
- **Doku**: TEI-MODEL §2.1 (normatives Ausschnitts-Pattern), FEATURES (Reader-Featureliste).
- **Tests**: 2 neue Playwright-Tests (AK: Banner sichtbar ohne Panel-Öffnen + strukturierte Metadaten; ABG-Gegencheck: analytic ohne verse → kein Banner).

## Akzeptanzkriterien (Issue)

- [x] AK wird als Ausschnitt eines größeren Werkes erkennbar (Banner über dem Text)
- [x] Beziehung zum Gesamtwerk wird angezeigt
- [x] Versbereich wird angezeigt (44579–53866)
- [x] Kurzer inhaltlicher Kontext wird angezeigt
- [x] Lösung basiert auf strukturierten Metadaten (biblScope + note type="context")
- [x] Wiederverwendbar für andere Ausschnitttexte

## Verifikation

- Chrome: AK zeigt Banner + „Ausschnitt"-Sektion, Text beginnt konsistent bei Vers 44579; OVG (Gesamtwerk, 343k Wörter) zeigt keinen Banner; keine Konsolen-Fehler.
- Kein Index-Rebuild nötig: \`build-corpus-index.py\` liest nur \`titleStmt\` (Titel/Autor unverändert); das CI-Freshness-Gate bestätigt das automatisch.
- \`npm test\`: **193/193 passed** (13,9 min), inkl. der beiden neuen Tests.

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review-Triage (08.07.)

Bot-Review gesichtet. Umgesetzt als Folge-Commit `0cc07c526`: Die Excerpt-Erkennung durchsucht jetzt ALLE sourceDesc-biblStructs nach dem verse-biblScope statt nur das erste (13 Korpus-Header tragen zwei Eintraege, z.B. FB/HZ/WZB) + FB-Negativtest. Bewusst NICHT umgesetzt: der CSS-Hex-Nit — korpus.css definiert keine Blau-Custom-Properties und nutzt an anderer Stelle (Z.670) selbst hardcoded #bfdbfe; ein neues Token-System ist ausserhalb des PR-Scopes. Volllauf nach Fix: 194 passed / 0 failed.


## Review-Triage 2. Runde (08.07. nachmittags)

Beide Re-Reviews bestaetigen den multi-biblStruct-Fix. Umgesetzt als Folge-Commit `cae99079f`: console.warn, wenn ein verse-biblScope kuratiert wurde, aber der analytic-Titel fehlt (von beiden Reviews unabhaengig genannt — Authoring-Zeit-Signal statt stillem No-op). Bewusst belassen: der redundante verseScope-Check (harmlos, dokumentiert die Bedingung) und die Doppel-Traversierung (vernachlaessigbar bei 1-3 biblStructs pro Header).


## Review-Triage 3. Runde (08.07. spaetnachmittags)

Das neueste Re-Review bestaetigt alle Fixes ("Nothing here blocks merge"). Ein dokumentierter offener Punkt ohne Code-Aenderung: ein POSITIV-Test fuer den multi-biblStruct-Fall (verse-Scope im ZWEITEN biblStruct) existiert nicht, weil kein Korpus-Text diese Form hat — der Fall ist derzeit nur durch den FB-Negativtest plus Code-Reasoning gedeckt. Vormerkung: beim naechsten realen Ausschnittstext mit book+bookSection-Header (z.B. kuenftiger Ingest) den Positivfall als Test nachziehen.
