### PR TITLE
#145: Rektoratsbericht + Dankesbrief zur Mittelverwendung 2025/26

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -107,6 +107,7 @@ Located in `/publications/` (outside `docs/`):
 - `BLOG-POST-POS-WORKFLOW.md` — DHCraft blog draft on PoS disambiguation
 - `BLOG-POST-WZB-PIPELINE.md` — DHCraft blog draft on the WZB (Wenzelsbibel) ingest pipeline (unpublished, v3)
 - `JAHRESBERICHT-2025.md` — CLARIAH-AT annual report
+- `BERICHT-REKTORAT-MITTELVERWENDUNG-2026.md` — Freiwilliger Bericht + Dankesbrief an das Rektorat über die im Oktober 2025 freigegebenen Mittel (#145, Entwurf, KZW-Review vor Versand)
 
 ## Project Status
 

--- a/publications/BERICHT-REKTORAT-MITTELVERWENDUNG-2026.md
+++ b/publications/BERICHT-REKTORAT-MITTELVERWENDUNG-2026.md
@@ -36,7 +36,7 @@ Nicht Gegenstand dieses Berichts ist die einmalige Datenmigration der MHDBDB aus
 
 ### 2. Ausgangslage
 
-Die MHDBDB dokumentiert seit 1972 den Wortschatz der mittelhochdeutschen Literatur. Nach der technischen Neuaufstellung 2025 lag das gesamte Korpus, 667 semantisch annotierte Texte mit rund 7,5 Millionen Wortbelegen und einem Lexikon von 43.879 Lemmata, erstmals vollständig in offenen Standards (TEI-XML) vor. Die freigegebenen Mittel dienten dazu, diese Datenbasis in eine dauerhaft betreibbare, öffentlich nutzbare Forschungsplattform zu überführen und die Suchwerkzeuge auf das Niveau zu heben, das die internationale Fachcommunity von der MHDBDB erwartet.
+Die MHDBDB dokumentiert seit 1972 den Wortschatz der mittelhochdeutschen Literatur; die zuletzt betriebene technische Infrastruktur stammte im Kern aus den 1990er Jahren. Nach der technischen Neuaufstellung 2025 lag das gesamte Korpus, 667 semantisch annotierte Texte mit rund 7,5 Millionen Wortbelegen und einem Lexikon von 43.879 Lemmata, erstmals vollständig in offenen Standards (TEI-XML) vor. Die freigegebenen Mittel dienten dazu, diese Datenbasis in eine dauerhaft betreibbare, öffentlich nutzbare Forschungsplattform zu überführen und die Suchwerkzeuge auf das Niveau zu heben, das die internationale Fachcommunity von der MHDBDB erwartet.
 
 ### 3. Ergebnisse aus Angebot 33/25: Such- und Analysewerkzeuge
 
@@ -81,3 +81,5 @@ Die Plattform im Überblick:
 - 20.480 vs. Angebotssummen (7.000 + 14.000 brutto = 21.000): tatsächliche Rechnungssummen von KZW/chsteiner bestätigen lassen; Bericht nennt bewusst nur die freigegebene Summe
 - Zeitraum der Leistungserbringung präzisieren (Okt 2025 bis Mitte 2026?)
 - Ob DHCraft als Mitabsender auftreten soll
+- Altersangabe bitte absegnen: Der Bericht sagt „seit 1972" bzw. „seit über fünfzig Jahren" (Projektgründung); Jahresbericht und WZB-Blog-Entwurf sprechen von einer 30-jährigen Datenbank-Geschichte (digitale Infrastruktur seit den 1990er Jahren). Beides stimmt, der Bericht unterscheidet jetzt explizit Projekt (1972) und Infrastruktur (1990er) — Formulierung bitte bestätigen
+- Korpuszahl verifiziert: „rund 7,5 Millionen Wortbelege" = 7.533.447 annotierte Tokens, nachgerechnet aus dem Corpus-Index v4.1.5 (Summe aller Positionslisten)

--- a/publications/BERICHT-REKTORAT-MITTELVERWENDUNG-2026.md
+++ b/publications/BERICHT-REKTORAT-MITTELVERWENDUNG-2026.md
@@ -1,0 +1,83 @@
+# Bericht an das Rektorat: Mittelverwendung MHDBDB 2025/26
+
+**Entwurf für #145. Annahme: Absenderin ist Dr. Katharina Zeppezauer-Wachauer (Koordinatorin MHDBDB), erstellt gemeinsam mit dem technischen Partner Digital Humanities Craft OG. Vor Versand von KZW zu prüfen: Anrede (Rektor/Rektorin namentlich?), Briefkopf, genaue Bezeichnung der Mittelfreigabe.**
+
+---
+
+## Teil 1: Dankesbrief
+
+Sehr geehrte[r] [Anrede Rektorat],
+
+im Oktober 2025 hat das Rektorat für die Mittelhochdeutsche Begriffsdatenbank (MHDBDB) Mittel in Höhe von 20.480 Euro freigegeben. Dafür möchte ich mich, auch im Namen des gesamten Teams, herzlich bedanken.
+
+Der folgende Bericht legt freiwillig und über die formale Abrechnung hinaus dar, was mit diesen Mitteln erreicht wurde. Das Ergebnis lässt sich vorab in einem Satz zusammenfassen: Die MHDBDB, seit über fünfzig Jahren ein Salzburger Forschungswerkzeug der Mediävistik, steht heute als vollständig modernisierte, öffentlich zugängliche Forschungsplattform bereit, und zwar genau in dem Umfang, den wir uns bei der Beantragung erhofft hatten.
+
+Beide Angebotspakete wurden vollständig umgesetzt: die kontinuierliche Wartung des laufenden Betriebs ebenso wie die erweiterten Such- und Analysewerkzeuge samt der technischen Evaluationsbasis für künftige Texterweiterungen. Die Plattform ist unter https://mhdbdb.plus.ac.at bzw. der Projektseite öffentlich erreichbar; ich lade Sie ein, sich selbst ein Bild zu machen.
+
+Das Vertrauen des Rektorats in dieses Projekt hat sich aus unserer Sicht ausgezahlt. Ich stehe für Rückfragen und eine Vorführung der Plattform jederzeit zur Verfügung.
+
+Mit freundlichen Grüßen
+Dr. Katharina Zeppezauer-Wachauer
+Koordinatorin der Mittelhochdeutschen Begriffsdatenbank (MHDBDB)
+Fachbereich Germanistik / Interdisziplinäres Zentrum für Mittelalter und Frühneuzeit
+
+---
+
+## Teil 2: Bericht über die Mittelverwendung
+
+### 1. Gegenstand und Abgrenzung
+
+Dieser Bericht betrifft ausschließlich die im Oktober 2025 freigegebenen Mittel in Höhe von 20.480 Euro. Sie wurden auf Grundlage zweier Angebote der Digital Humanities Craft OG (Graz) verwendet:
+
+- **Angebot 32/25** „Wartung, Bugfixes und kleinere Erweiterungen am laufenden Betrieb" (rund 60 Arbeitsstunden über sechs Monate)
+- **Angebot 33/25** „Advanced Search Tools und Evaluationsbasis für Texterweiterung"
+
+Nicht Gegenstand dieses Berichts ist die einmalige Datenmigration der MHDBDB aus der Altinfrastruktur in das heutige TEI-Format. Diese wurde separat über CLARIAH-AT gefördert und abgerechnet.
+
+### 2. Ausgangslage
+
+Die MHDBDB dokumentiert seit 1972 den Wortschatz der mittelhochdeutschen Literatur. Nach der technischen Neuaufstellung 2025 lag das gesamte Korpus, 667 semantisch annotierte Texte mit rund 7,5 Millionen Wortbelegen und einem Lexikon von 43.879 Lemmata, erstmals vollständig in offenen Standards (TEI-XML) vor. Die freigegebenen Mittel dienten dazu, diese Datenbasis in eine dauerhaft betreibbare, öffentlich nutzbare Forschungsplattform zu überführen und die Suchwerkzeuge auf das Niveau zu heben, das die internationale Fachcommunity von der MHDBDB erwartet.
+
+### 3. Ergebnisse aus Angebot 33/25: Such- und Analysewerkzeuge
+
+Der Forschungsbereich der Plattform („Playground") bietet heute sechzehn Sucheinstiege, darunter zehn korpusanalytische Werkzeuge, die es in der alten MHDBDB nicht gab:
+
+- **Multi-Lemma-Suche** mit Abstandssuche: findet Texte, in denen mehrere Begriffe gemeinsam oder in definierter Nähe zueinander vorkommen (etwa „rôt" und „munt" innerhalb von zehn Wörtern).
+- **Begriffs- und Lemma-Verteilung**: zeigt, wie sich ein Konzept (z. B. „Sterben") oder ein Einzelwort über alle 667 Texte verteilt.
+- **Kookkurrenz-Ranking, Textvergleich, Wortfrequenz- und Reimanalyse**: quantitative Werkzeuge für Fragestellungen von der Stilistik bis zur Versforschung.
+- **Kuratierte Figurenbezeichnungen**: erschließt 10.506 Belegstellen zu Eigennamen und Epitheta aus einer Salzburger Dissertationsarbeit.
+
+Dazu kommen Angebote für Lehre und breiteres Publikum: eine einfache Korpussuche mit Lesefassung aller Texte, ein alphabetisches Wörterbuch mit eigenen Seiten für alle 43.879 Lemmata samt Verknüpfung zu den Standardwörterbüchern des Mittelhochdeutschen (Lexer, MWB), sowie fünf deutschsprachige Hilfeseiten.
+
+Die im Angebot vorgesehene **Evaluationsbasis für Texterweiterungen** wurde am Pilotfall der Wenzelsbibel erprobt: Der Prager Prachtcodex (Pentateuch, Cod. 2759–2764) wurde als erster Neuzugang seit der Migration vollständig in Korpus und Suchindizes integriert. Der dabei dokumentierte Aufnahmeprozess ist inzwischen die Standardprozedur für weitere Textaufnahmen; zwei Folgeprojekte (frühneuhochdeutsche Rechenbücher, „Der Borte") sind bereits in Vorbereitung.
+
+Als Beitrag zu offener Wissenschaft stellt die Plattform seit Juni 2026 zusätzlich eine frei zugängliche Datenschnittstelle bereit (2.742 zitierfähige JSON-Ressourcen nach FAIR-Prinzipien) sowie eine dauerhafte Archivierung mit DOI über Zenodo.
+
+### 4. Ergebnisse aus Angebot 32/25: Wartung und Betriebsstabilität
+
+Der laufende Betrieb wurde über den gesamten Zeitraum ohne Ausfall gewährleistet. Im Einzelnen:
+
+- Behebung gemeldeter Fehler aus dem laufenden Nutzerbetrieb, in der Regel innerhalb weniger Tage (dokumentiert im öffentlichen Issue-Tracker des Projekts).
+- Aufbau einer automatisierten Testumgebung mit über 180 Prüfroutinen, die vor jeder Änderung die Kernfunktionen (Suche, Leseansicht, Datenintegrität) absichert.
+- Automatische Qualitätskontrollen bei jeder Datenänderung (Schema-Validierung, Indexprüfung), sodass Korrekturen am Textbestand nicht unbemerkt zu Inkonsistenzen führen können.
+- Vollständige technische und wissenschaftliche Dokumentation im öffentlichen Repositorium, einschließlich der Editionsgrundlagen und Kodierungsrichtlinien.
+
+### 5. Einordnung
+
+Mit den freigegebenen 20.480 Euro wurde die MHDBDB von einem migrierten Datenbestand zu einer betriebsstabilen Forschungsplattform mit erweitertem Werkzeugkasten ausgebaut. Sämtliche Ergebnisse sind öffentlich zugänglich, quelloffen und ohne laufende Lizenzkosten betreibbar; die Plattform kommt ohne Serverinfrastruktur mit Wartungsverträgen aus, was die Folgekosten für die Universität dauerhaft niedrig hält.
+
+Die Plattform im Überblick:
+
+- Hauptseite mit Korpussuche: https://dhcraft.org/mhdbdb-tei-only/
+- Forschungswerkzeuge (Playground): https://dhcraft.org/mhdbdb-tei-only/playground/
+- Datenschnittstelle (Dokumentation): https://dhcraft.org/mhdbdb-tei-only/api/index.html
+- Archivierung: https://doi.org/10.5281/zenodo.20627656
+
+---
+
+## Offene Punkte vor Versand (nicht Teil des Dokuments)
+
+- Anrede/Adressat im Rektorat klären
+- 20.480 vs. Angebotssummen (7.000 + 14.000 brutto = 21.000): tatsächliche Rechnungssummen von KZW/chsteiner bestätigen lassen; Bericht nennt bewusst nur die freigegebene Summe
+- Zeitraum der Leistungserbringung präzisieren (Okt 2025 bis Mitte 2026?)
+- Ob DHCraft als Mitabsender auftreten soll


### PR DESCRIPTION
## Zusammenfassung

Freiwilliger Bericht an das Rektorat über die im Oktober 2025 freigegebenen **20.480 Euro** (KV 32/25 Wartung + KV 33/25 Advanced Search Tools), mit Dankesbrief vorneweg — wie in #145 gewünscht in Für-das-Rektorat-tauglicher Sprache.

## Inhalt

- **Teil 1 Dankesbrief**: Dank für das Vertrauen, Kernbotschaft „es hat genauso funktioniert wie erhofft", Einladung zur Vorführung.
- **Teil 2 Bericht**: Gegenstand + explizite Abgrenzung von den CLARIAH-AT-Rechnungen (§1), Ausgangslage (§2), Ergebnisse aus Angebot 33/25 (Suchwerkzeuge, Wenzelsbibel-Pilot, JSON-API, Zenodo-DOI, §3), Ergebnisse aus Angebot 32/25 (Wartung, Testumgebung, CI-Qualitätskontrollen, §4), Einordnung mit Live-Adressen (§5).
- **Offene Punkte für KZW** am Dokumentende (nicht Teil des Versandtexts): Anrede/Adressat, Abgleich 20.480 vs. Angebotssummen (21.000 brutto), Leistungszeitraum, DHCraft als Mitabsender.

Quellen: KV 32/25 + 33/25 (aus dem Issue), Projekt-Doku. Die NICHT zu verwendenden CLARIAH-Rechnungen (Data-Wrangling) sind inhaltlich ausgespart und die Abgrenzung ist im Bericht selbst benannt.

KZW-Review vor Versand vorgesehen; Merge übernimmt den Entwurf nur ins Repo.

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review-Triage (08.07.)

Bot-Review gesichtet, drei Findings: (1) Altersangabe 1972/50+ vs. 30-Jahre-Angaben der Sibling-Docs — umgesetzt: der Bericht unterscheidet jetzt Projektgruendung (1972) und technische Infrastruktur (1990er); zusaetzlich als Bestaetigungspunkt in die Offene-Punkte-Liste fuer KZW aufgenommen. (2) "7,5 Mio Wortbelege" unbelegt — verifiziert: 7.533.447 annotierte Tokens, nachgerechnet aus dem Corpus-Index v4.1.5; Vermerk in der Offene-Punkte-Liste. (3) "ueber 180 Pruefroutinen" — FALSE POSITIVE: die grep-Zaehlung des Reviews (178) unterschaetzt; die Playwright-Runtime auf main zaehlt 186 Tests, "ueber 180" ist korrekt und bleibt.



**Nachtrag (08.07., Merge-Session):** Zweites Bot-Review (08:47 UTC) gesichtet: "No blocking issues". Nits begruendet nicht umgesetzt: (1) INDEX.md-Publikationsliste ist chronologisch, nicht alphabetisch gewachsen — keine Konvention verletzt. (2) Testzahl: die Playwright-Runtime (186 auf main) ist massgeblich, nicht der grep-Zaehler; "ueber 180" bleibt. Dokument geht ohnehin erst nach KZW-Freigabe raus (Offene-Punkte-Liste).
