### PR TITLE
#27: Disambiguierungs- und Migrations-Policy als POS-TAGSET.md §6

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -90,7 +90,7 @@ This knowledge base follows a hub-and-spoke architecture with INDEX.md as the ce
 | **[TEI-MODEL.md](TEI-MODEL.md)** | Normative TEI encoding (Soll-Modell), IST/SOLL-Vergleiche, Validierungsbaseline | Data engineers, Developers |
 | **[TEI-MODEL-AUTH-FILES.md](TEI-MODEL-AUTH-FILES.md)** | Authority-File-Schemas und Migrationshistorie (lexicon, persons, works, concepts, genres, names, variants) | Data engineers |
 | **[LINECODE.md](LINECODE.md)** | Legacy Linecode → TEI mapping (Letter-zu-Element-Tabelle, xml:id-Pattern-Erklärung, Diagnose-Workflows für #23) | Data engineers |
-| **[POS-TAGSET.md](POS-TAGSET.md)** | Kanonische `@pos`-Referenz (19-Tag-Zielschema, Compound-Regeln, Legacy-Mapping ART/CNJ/GRA, Korpus-Verteilung) | Data engineers, Developers |
+| **[POS-TAGSET.md](POS-TAGSET.md)** | Kanonische `@pos`-Referenz (19-Tag-Zielschema, Compound-Regeln, Legacy-Mapping ART/CNJ/GRA, Korpus-Verteilung, Disambiguierungs-/Migrations-Policy §6) | Data engineers, Developers |
 
 ### Process (what's happening and why)
 

--- a/docs/POS-TAGSET.md
+++ b/docs/POS-TAGSET.md
@@ -103,6 +103,63 @@ Die Dominanz von `ART` (über 1 Mio.) und der niedrige `DET`-Wert (53k) zeigen, 
 
 Die Auflösung von Compound-Tags, die Korrektur von Falsch-Tags und die ART/CNJ/GRA-Migration erfolgen nicht mechanisch, sondern kontextabhängig über semantisch-grammatische Analyse. Der dafür vorgesehene Workflow ist als Agent-Skill `.gemini/skills/pos-disambiguator/` implementiert (Phasen: Split → Analyse → Merge → Validierung → Refinement). Pädagogische Beispiele für Mehrdeutigkeiten (*daz*, *als*, *haben*) liegen unter `.gemini/skills/pos-disambiguator/references/examples.md`.
 
+## 6. Disambiguierungs- und Migrations-Policy (#27)
+
+Verbindliche Policy für die Überführung des Altbestands (Compound-Tags, Legacy-Tags, bekannte Fehlannotationen) in das 19-Tag-Schema aus §1. Sie macht den Workflow planbar: Was wird in welcher Reihenfolge migriert, was entscheidet das LLM allein, was braucht Stichproben-Review, was bleibt liegen, bis KZW entscheidet. Kein Teil dieser Policy ändert das Tagset selbst.
+
+### 6.1 Verbindlichkeitsstufen
+
+| Stufe | Bedeutung |
+|-------|-----------|
+| **P-MUSS** | Ohne Erfüllung wird kein Batch committet |
+| **P-SOLL** | Abweichung erlaubt, im Provenienz-Log begründen |
+| **P-OFFEN** | Explizit KZW-Entscheid nötig, bis dahin Status quo |
+
+### 6.2 Migrations-Klassen und Reihenfolge
+
+Die Klassen sind nach Automatisierbarkeit absteigend sortiert und werden in dieser Reihenfolge abgearbeitet; jede Klasse ist ein eigener, unabhängig prüfbarer Batch (eigener Branch/PR, eigenes Provenienz-Log).
+
+| Klasse | Bestand (atomar, §4) | Verfahren | Stufe |
+|--------|---------------------:|-----------|-------|
+| K1: Rest-Artefakte (`-`, KOKOM, FM, PTK, X, SCJN) | < 100 | deterministische Tabelle (SCJN→SCNJ; Rest: Einzelfall-Liste im PR) | P-MUSS deterministisch |
+| K2: ART → DET | 1.064.439 | Batch-Umbenennung, KEIN Kontext nötig (Artikel sind DET per Definition §1) | P-MUSS deterministisch |
+| K3: GRA → ADJ | 60.278 | Batch gemäß §3 (Graduierung/Superlativ = ADJ) | P-MUSS deterministisch; Abweichung im Issue-Body („GRA→ADV/PART") ist ALT, siehe 6.5 |
+| K4: Compound-Auflösung (ADJ ADV, VRB VEX, ART CNJ, …) | ~35–40 % der Tokens | LLM kontextabhängig (Skill-Workflow), AUSSER echte Fusionen (§2: bleiben zweiwertig + `@reason`) | P-MUSS LLM + Gates 6.3 |
+| K5: CNJ → CCNJ/SCNJ | 943.199 | LLM kontextabhängig; CNJ bleibt als Fallback erlaubt bei echter Ambiguität | P-SOLL (Fallback erlaubt) |
+| K6: Bekannte Fehlannotations-Muster (Issue §2: enhaben, wiest, Morphologie-als-Zweittag, NEG-Vereinheitlichung, NAM-Übergriffe) | verstreut | LLM mit Watch-List (Skill „Known Error Patterns") | P-MUSS LLM + Gates 6.3 |
+
+Begründung der Reihenfolge: K1–K3 sind kontextfrei und schrumpfen den Problemraum messbar (über 1,1 Mio. atomare Alt-Tags), bevor die teuren LLM-Klassen laufen; K4 vor K5, weil viele CNJ-Fälle in Compounds stecken (ART CNJ: 271k) und sonst doppelt angefasst würden.
+
+### 6.3 Qualitätsgates (für K4–K6, P-MUSS)
+
+1. **Batch-Größe:** max. 1 Text pro LLM-Lauf-Einheit; Ausgabe als Diff-Liste (xml:id, alt, neu, Begründung, confidence).
+2. **Golden Set:** vor dem ersten Batch 200 händisch verifizierte Fälle (KZW/Studis) über alle Klassen; jeder Modell-/Prompt-Wechsel wird erst gegen das Golden Set gemessen (Ziel ≥ 95 % Übereinstimmung), dann eingesetzt.
+3. **Stichproben-Review:** pro Batch 50 Zufallsfälle + ALLE confidence='low' an menschliche Prüfung; Fehlerquote > 5 % → Batch verworfen, Prompt/Modell nachjustieren.
+4. **Invarianten (automatisch, CI-fähig):** (a) nur Tags aus §1 (+ dokumentierte Fusionen §2), (b) Token-Text/Reihenfolge/xml:id byte-identisch (nur `@pos`, `@comp`, `@needsSplit`, `@reason` ändern sich), (c) Positionszählung unverändert (Index-Rebuild diff-leer außer erwarteten pos-Feldern), (d) kein ART/GRA/Artefakt im Output.
+5. **Provenienz:** pro Batch ein Log unter `ingest/pos-disambig/<batch>/` (Modell, Prompt-Version, Datum, Diff-Statistik, Review-Ergebnis); revisionDesc-Change-Eintrag pro Datei.
+
+### 6.4 Technische Attribute (aus KZW-Fixierung 20.11.2025)
+
+- Kontraktionen/Fusionen: Token bleibt EIN `<w>`; echte morphologische Fusionen tragen zwei Tags + `@reason` (§2); zusätzlich `@comp="VRB+PRO"` und `@needsSplit="true"`, wo die Zerlegung analytisch gewünscht ist. KEINE Token-Splits in der Edition.
+- NEG: ausschließlich für Negationspartikeln (*niht, ne, en, n, nie* …); Negationsträger anderer Wortart bekommen NUR ihre Wortart (*dehein* → DET, *nieman* → PRO, *nie* → ADV). Bestands-Kombis wie `ADJ|NEG` werden in K6 aufgelöst.
+- Fremdsprachliches: NICHT über `@pos`, sondern über `@xml:lang` (+ optional `<foreign>`) — siehe #28-Phasenplan; für die POS-Migration out of scope.
+
+### 6.5 Aufgelöste Diskrepanzen und offene Punkte
+
+**Aufgelöst (Policy folgt Tagset-Fixierung vom 20.11.2025 = §1):**
+- ART ist kein Tag (Issue-§3-Tabelle war Zwischenstand) → K2.
+- PART ist NICHT im 19-Set (Issue-§5 nannte es als Kandidat; die fixierte Liste enthält es nicht). Partikeln von Partikelverben werden bis auf Weiteres ADV getaggt; siehe P-OFFEN-1.
+- GRA → ADJ (Issue-Body sagte an zwei Stellen ADV bzw. PART; §3 dieser Datei ist SSoT).
+
+**P-OFFEN (KZW-Entscheid nötig, blockiert die jeweilige Klasse NICHT als Ganzes):**
+1. **PART nachrüsten?** Wenn Partikelverben sauber unterscheidbar getaggt werden sollen (Issue §2.1 „zu/an/ab können Partikeln sein"), braucht es entweder ein 20. Tag PART oder eine Konvention (ADV + `@ana`?). Bis zur Entscheidung: ADV, Fälle mit confidence='low' sammeln.
+2. **CNJ-Restquote:** Wieviel ungelöstes CNJ ist akzeptabel (K5-Fallback)? Vorschlag: ≤ 10 % der ursprünglichen CNJ-Menge.
+3. **VEM im Fusions-Set:** *wiltu* = `VEM PRO` (§2) vs. Issue-Beispiele mit VRB — Liste der zulässigen Fusions-Tag-Paare finalisieren.
+
+### 6.6 Ausdrücklich NICHT Teil dieser Policy
+
+Kein Pilot-Lauf, keine Korpus-Änderung, keine Token-Kampagne im Rahmen von #27 (Scope-Entscheidung chsteiner 03.07.2026). Diese Policy ist die Vorlage, nach der künftige Kampagnen-Issues (pro Klasse eines) aufgesetzt werden. #18 (Datenmigration) hängt an K1–K3.
+
 ## Querverweise
 
 - [TEI-MODEL.md §5](TEI-MODEL.md) – `@pos` im normativen TEI-Soll-Modell

--- a/docs/POS-TAGSET.md
+++ b/docs/POS-TAGSET.md
@@ -133,14 +133,14 @@ Begründung der Reihenfolge: K1–K3 sind kontextfrei und schrumpfen den Problem
 ### 6.3 Qualitätsgates (für K4–K6, P-MUSS)
 
 1. **Batch-Größe:** max. 1 Text pro LLM-Lauf-Einheit; Ausgabe als Diff-Liste (xml:id, alt, neu, Begründung, confidence).
-2. **Golden Set:** vor dem ersten Batch 200 händisch verifizierte Fälle (KZW/Studis) über alle Klassen; jeder Modell-/Prompt-Wechsel wird erst gegen das Golden Set gemessen (Ziel ≥ 95 % Übereinstimmung), dann eingesetzt.
+2. **Golden Set:** vor dem ersten K4-Batch 200 händisch verifizierte Fälle (KZW/Studis) über alle Klassen; jeder Modell-/Prompt-Wechsel wird erst gegen das Golden Set gemessen (Ziel ≥ 95 % Übereinstimmung), dann eingesetzt. (Gilt nur für die LLM-Klassen K4–K6; die deterministischen K1–K3 brauchen kein Golden Set.)
 3. **Stichproben-Review:** pro Batch 50 Zufallsfälle + ALLE confidence='low' an menschliche Prüfung; Fehlerquote > 5 % → Batch verworfen, Prompt/Modell nachjustieren.
 4. **Invarianten (automatisch, CI-fähig):** (a) nur Tags aus §1 (+ dokumentierte Fusionen §2), (b) Token-Text/Reihenfolge/xml:id byte-identisch (nur `@pos`, `@comp`, `@needsSplit`, `@reason` ändern sich), (c) Positionszählung unverändert (Index-Rebuild diff-leer außer erwarteten pos-Feldern), (d) kein ART/GRA/Artefakt im Output.
-5. **Provenienz:** pro Batch ein Log unter `ingest/pos-disambig/<batch>/` (Modell, Prompt-Version, Datum, Diff-Statistik, Review-Ergebnis); revisionDesc-Change-Eintrag pro Datei.
+5. **Provenienz:** pro Batch ein Log unter `ingest/pos-disambig/<batch>/` (Modell, Prompt-Version, Datum, Diff-Statistik, Review-Ergebnis); revisionDesc-Change-Eintrag pro Datei. (Bewusst ein dritter Pfad-Typ unter `ingest/`: `scripts/ingest/<sigle>/` trägt Pipeline-Skripte, `ingest/<sigle>/` Roh-Quellen pro Text, `ingest/pos-disambig/` Kampagnen-Review-Logs.)
 
 ### 6.4 Technische Attribute (aus KZW-Fixierung 20.11.2025)
 
-- Kontraktionen/Fusionen: Token bleibt EIN `<w>`; echte morphologische Fusionen tragen zwei Tags + `@reason` (§2); zusätzlich `@comp="VRB+PRO"` und `@needsSplit="true"`, wo die Zerlegung analytisch gewünscht ist. KEINE Token-Splits in der Edition.
+- Kontraktionen/Fusionen: Token bleibt EIN `<w>`; echte morphologische Fusionen tragen zwei Tags + `@reason` (§2); zusätzlich `@comp="VRB+PRO"` und `@needsSplit="true"`, wo die Zerlegung analytisch gewünscht ist. KEINE Token-Splits in der Edition. **Caveat:** `@comp` und `@needsSplit` sind noch NICHT in `schema/mhdbdb.rnc` (die `<w>`-Produktion erlaubt sie nicht) und kommen im Korpus bisher nicht vor — vor dem ersten K4-Batch muss das Schema erweitert (oder ein GAP dokumentiert) werden, sonst bricht die CI-Schema-Validierung.
 - NEG: ausschließlich für Negationspartikeln (*niht, ne, en, n, nie* …); Negationsträger anderer Wortart bekommen NUR ihre Wortart (*dehein* → DET, *nieman* → PRO, *nie* → ADV). Bestands-Kombis wie `ADJ|NEG` werden in K6 aufgelöst.
 - Fremdsprachliches: NICHT über `@pos`, sondern über `@xml:lang` (+ optional `<foreign>`) — siehe #28-Phasenplan; für die POS-Migration out of scope.
 
@@ -152,7 +152,7 @@ Begründung der Reihenfolge: K1–K3 sind kontextfrei und schrumpfen den Problem
 - GRA → ADJ (Issue-Body sagte an zwei Stellen ADV bzw. PART; §3 dieser Datei ist SSoT).
 
 **P-OFFEN (KZW-Entscheid nötig, blockiert die jeweilige Klasse NICHT als Ganzes):**
-1. **PART nachrüsten?** Wenn Partikelverben sauber unterscheidbar getaggt werden sollen (Issue §2.1 „zu/an/ab können Partikeln sein"), braucht es entweder ein 20. Tag PART oder eine Konvention (ADV + `@ana`?). Bis zur Entscheidung: ADV, Fälle mit confidence='low' sammeln.
+1. **PART nachrüsten?** Wenn Partikelverben sauber unterscheidbar getaggt werden sollen (Issue §2.1 „zu/an/ab können Partikeln sein"), braucht es entweder ein 20. Tag PART oder eine Konvention (ADV + `@ana`?). Achtung bei der Konventions-Variante: `@ana` ist bereits als Sense-Referenz belegt (`lexicon.xml#lemma_{N}_sense_{M}`, siehe DATA-MODEL.md → Sense-Auflösung) — eine POS-Markierung über `@ana` würde das Attribut doppelt belegen und bräuchte mindestens ein eigenes Wert-Schema. Bis zur Entscheidung: ADV, Fälle mit confidence='low' sammeln.
 2. **CNJ-Restquote:** Wieviel ungelöstes CNJ ist akzeptabel (K5-Fallback)? Vorschlag: ≤ 10 % der ursprünglichen CNJ-Menge.
 3. **VEM im Fusions-Set:** *wiltu* = `VEM PRO` (§2) vs. Issue-Beispiele mit VRB — Liste der zulässigen Fusions-Tag-Paare finalisieren.
 


### PR DESCRIPTION
## Zusammenfassung

Das in #27 gewünschte Policy-Dokument für die POS-Disambiguierung des Altbestands — als neuer **§6 in \`docs/POS-TAGSET.md\`** (statt einer 16. Promptotyping-Datei: die 15-Datei-Menge bleibt stabil, das Tagset-Doc bleibt Single Source of Truth).

## Inhalt von §6

- **Verbindlichkeitsstufen**: P-MUSS / P-SOLL / P-OFFEN
- **6 Migrations-Klassen in Abarbeitungsreihenfolge**: K1 Rest-Artefakte (<100), K2 ART→DET (1.064.439), K3 GRA→ADJ (60.278) — alle drei deterministisch, kontextfrei; danach K4 Compound-Auflösung (~35–40 % der Tokens), K5 CNJ→CCNJ/SCNJ (943.199, Fallback erlaubt), K6 bekannte Fehlannotations-Muster — LLM-gestützt mit Gates
- **Qualitätsgates für K4–K6**: Golden Set (200 händisch verifizierte Fälle, ≥ 95 % vor Einsatz), Stichproben-Review (50/Batch + alle low-confidence, > 5 % Fehler → Batch verworfen), CI-fähige Invarianten (Token-Text/xml:id byte-identisch, Positionszählung unverändert), Provenienz-Logs pro Batch
- **Technische Attribute** aus der KZW-Fixierung 20.11.2025: \`@comp\`, \`@needsSplit\`, \`@reason\`; NEG nur für Negationspartikeln; Fremdsprachliches via \`xml:lang\` (→ #28), nicht via \`@pos\`
- **Aufgelöste Diskrepanzen** zwischen Issue-Body (älterer Stand) und fixiertem Tagset: ART kein Tag, PART nicht im 19-Set, GRA→ADJ
- **3 P-OFFEN-Punkte** für KZW (siehe Issue-Kommentar): PART nachrüsten?, akzeptable CNJ-Restquote, Fusions-Tag-Paar-Liste

## Scope

Gemäß Scope-Entscheidung (chsteiner, 03.07.): **nur Policy-Dokument** — kein Pilot-Lauf, keine Korpus-Änderung, keine Token-Kampagne. Künftige Kampagnen-Issues werden pro Klasse nach dieser Vorlage aufgesetzt; #18 (Datenmigration) hängt an K1–K3.

Hinweis: docs/INDEX.md wird auch von den offenen PRs #177/#180 in anderen, disjunkten Zeilen angefasst — kein Konfliktpotential.

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review-Triage (08.07.)

Bot-Review gesichtet, alle vier Findings berechtigt und als Folge-Commit umgesetzt: (1) Schema-Caveat fuer @comp/@needsSplit in 6.4 (Attribute weder in mhdbdb.rnc noch im Korpus — vor K4 Schema/GAP noetig); (2) @ana-Kollisionshinweis in P-OFFEN-1 (@ana ist Sense-Referenz laut DATA-MODEL); (3) Golden-Set-Gate praezisiert auf "vor dem ersten K4-Batch"; (4) Abgrenzungssatz fuer den dritten ingest/-Pfad-Typ.



**Nachtrag (08.07., Merge-Session):** Zweites Bot-Review (08:51 UTC, nach Folge-Commit) gesichtet: bestaetigt alle vier umgesetzten Findings, keine neuen blockierenden Punkte. Die 6.5-Beobachtung (VEM-Fusions-Set vs. Sektion-2-Tabelle) ist absichtlich als P-OFFEN deferred — Sektion 2 ist nicht Gegenstand dieses PRs.
