### PR TITLE
#167: 10 Frontend-/Playground-Kleinbugs aus dem Code-Audit

### DIFF
--- a/assets/js/lib/woerterbuchnetz.js
+++ b/assets/js/lib/woerterbuchnetz.js
@@ -49,15 +49,23 @@ export function fetchWbnetzEntries(normalizedForm) {
                 `https://api.woerterbuchnetz.de/open-api/dictionaries/${sigle}/lemmata/${lookupForm}`,
                 { signal: AbortSignal.timeout(10000) }
             );
-            if (!r.ok) return { sigle, entries: [] };
+            // 4xx (kein Eintrag) ist ein echtes, cachebares Ergebnis;
+            // 5xx ist transient und darf nicht memoisiert werden.
+            if (!r.ok) return { sigle, entries: [], failed: r.status >= 500 };
             const data = await r.json();
             const entries = (data.result_set || []).filter(e => isSafeLink(e.wbnetzlink));
             return { sigle, entries };
         } catch (e) {
             console.warn(`[Woerterbuchnetz] ${sigle} API unavailable:`, e.message);
-            return { sigle, entries: [] };
+            return { sigle, entries: [], failed: true };
         }
-    }));
+    })).then(results => {
+        // Degradierte Antworten (Timeout, Netzfehler, 5xx) aus dem Cache
+        // entfernen — sonst bleibt das Wörterbuch für diese Form die ganze
+        // Session leer und erholt sich nie (#167 Finding 13).
+        if (results.some(r => r.failed)) entryCache.delete(normalizedForm);
+        return results.map(({ sigle, entries }) => ({ sigle, entries }));
+    });
     entryCache.set(normalizedForm, promise);
     return promise;
 }

--- a/lemma/lemma-page.js
+++ b/lemma/lemma-page.js
@@ -146,6 +146,12 @@ class LemmaPage {
             navigator.clipboard.writeText(lemma.id).then(() => {
                 this.elements.copyIdBtn.textContent = 'kopiert!';
                 setTimeout(() => { this.elements.copyIdBtn.textContent = 'kopieren'; }, 1500);
+            }).catch((err) => {
+                // Verweigerte Clipboard-Permission darf keine unhandled
+                // rejection sein und braucht Nutzer-Feedback (#167 Finding 59).
+                console.warn('[LemmaPage] Clipboard nicht verfügbar:', err);
+                this.elements.copyIdBtn.textContent = 'Kopieren nicht möglich';
+                setTimeout(() => { this.elements.copyIdBtn.textContent = 'kopieren'; }, 2500);
             });
         });
 

--- a/playground/js/data/authority-manager.js
+++ b/playground/js/data/authority-manager.js
@@ -214,17 +214,19 @@ export class AuthorityFilesManager {
    * cooccurrence-ranking.js für Live-Dropdown im Lemma-Input. Siehe
    * DESIGN.md §Live-Autocomplete-Dropdown.
    *
-   * Eingabe wird inline normalisiert (â→a, ê→e, ü→ue, …) damit „ere" auch
-   * „êre" matcht. Linear scan über 43.754 Lemmata, ~5-10ms pro Aufruf —
-   * akzeptabel für keystroke-Frequenz.
+   * Eingabe wird mit TextNormalizer.normalizeMHG normalisiert (â→a, ê→e,
+   * ü→ue, æ→ae, ō→o, …) damit „ere" auch „êre" matcht — derselbe Normalizer,
+   * mit dem lemma.normalized gebaut wird (CONTRACTS §A). Linear scan über
+   * 43.754 Lemmata, ~5-10ms pro Aufruf — akzeptabel für keystroke-Frequenz.
    */
   getLemmaAutocompleteMatches(partialInput, maxSuggestions = 8) {
     const trimmed = (partialInput || '').trim();
     if (!trimmed) return [];
-    const needle = trimmed.toLowerCase()
-      .replace(/[âáà]/g, 'a').replace(/[êéè]/g, 'e').replace(/[îíì]/g, 'i')
-      .replace(/[ôóò]/g, 'o').replace(/[ûúù]/g, 'u')
-      .replace(/ä/g, 'ae').replace(/ö/g, 'oe').replace(/ü/g, 'ue').replace(/ß/g, 'ss');
+    // Kanonischer Normalizer statt Inline-Regex-Kette: lemma.normalized ist
+    // mit normalizeMHG gebaut — eine abweichende Eingabe-Normalisierung
+    // (fehlende Ligaturen æ/œ, Makrons ā/ē/ī/ō/ū) liefert für „mære" oder
+    // „brōt" sonst keine Vorschläge (#167 Finding 86, CONTRACTS §A).
+    const needle = TextNormalizer.normalizeMHG(trimmed);
     const lemmata = this.authorityData?.lemmata || [];
     const startsWith = [];
     const includes = [];

--- a/playground/js/data/storage/tei-storage.js
+++ b/playground/js/data/storage/tei-storage.js
@@ -17,7 +17,15 @@ export class TEIStorageManager {
         if (this.isInitialized) return true;
 
         try {
-            await this.indexedDBManager.initialize();
+            // IndexedDBManager.initialize() wirft nicht, sondern liefert
+            // false (kein IndexedDB-Support / open fehlgeschlagen) — das
+            // Ergebnis darf nicht als Erfolg gemeldet werden (#167 Finding 63).
+            const ok = await this.indexedDBManager.initialize();
+            if (!ok) {
+                console.error('❌ Storage initialization failed: IndexedDB not available');
+                this.isInitialized = false;
+                return false;
+            }
             this.isInitialized = true;
 
             console.log('🔧 Storage initialized: IndexedDB cache ready');

--- a/playground/js/ui/authority/authority-ui.js
+++ b/playground/js/ui/authority/authority-ui.js
@@ -105,6 +105,10 @@ export class AuthorityUI {
     this.lemmaExplorer.showComponentLemma(originalLemmaId, componentLemmaId, componentText);
   }
 
+  showOriginalLemmaSenses(lemmaId) {
+    this.lemmaExplorer.showOriginalLemmaSenses(lemmaId);
+  }
+
   generateLemmaSenseContent(lemma, lemmaId, originalLemmaId = null) {
     return this.lemmaExplorer.generateLemmaSenseContent(lemma, lemmaId, originalLemmaId);
   }

--- a/playground/js/ui/authority/genre-explorer.js
+++ b/playground/js/ui/authority/genre-explorer.js
@@ -172,7 +172,7 @@ export class GenreExplorer {
             </div>
             ${worksHTML}
         `;
-    });
+    }, undefined, 'works');
   }
 
   showAuthorsInGenre(genreId, genreName) {
@@ -208,7 +208,7 @@ export class GenreExplorer {
             </div>
             ${authorsHTML}
         `;
-    });
+    }, undefined, 'authors');
   }
 
   findWorksInGenre(genreId) {

--- a/playground/js/ui/authority/lemma-explorer.js
+++ b/playground/js/ui/authority/lemma-explorer.js
@@ -167,13 +167,25 @@ export class LemmaExplorer {
     container.innerHTML = `
         <div style="margin-bottom: 10px; padding: 8px; background: rgba(40, 167, 69, 0.1); border-radius: 4px;">
             <strong>Komponente:</strong> ${componentText} → ${lemma.lemma}
-            <button onclick="window.playground.ui.authorityExplorers.showLemmaSenses('${originalLemmaId}')"
+            <button onclick="window.playground.ui.authorityExplorers.showOriginalLemmaSenses('${originalLemmaId}')"
                     style="float: right; padding: 2px 6px; background: #6c757d; color: white; border: none; border-radius: 3px; font-size: 0.75rem; cursor: pointer;">
                 ← Zurück
             </button>
         </div>
         ${content}
     `;
+  }
+
+  // #167 Finding 17: „← Zurück" bei Etymologie-Komponenten darf das sichtbare
+  // Panel nicht togglen (= ausblenden), sondern rendert die Original-
+  // Bedeutungen direkt in den Container.
+  showOriginalLemmaSenses(lemmaId) {
+    const container = document.getElementById(`senses-${lemmaId}`);
+    if (!container) return;
+    const lemma = this.authorityData.lemmata.find((l) => l.id === lemmaId);
+    container.innerHTML = lemma
+      ? this.generateLemmaSenseContent(lemma, lemmaId)
+      : "Lemma nicht gefunden";
   }
 
   generateLemmaSenseContent(lemma, lemmaId, originalLemmaId = null) {

--- a/playground/js/ui/search/SearchHelpers.js
+++ b/playground/js/ui/search/SearchHelpers.js
@@ -145,19 +145,23 @@ export function generateResultItem(config) {
 
 // ==================== TOGGLE DETAILS FUNCTIONALITY ====================
 
-export function toggleDetails(detailsId, contentGenerator, emptyMessage = 'Details nicht verfügbar') {
+export function toggleDetails(detailsId, contentGenerator, emptyMessage = 'Details nicht verfügbar', contentKey = '') {
   const container = document.getElementById(detailsId);
   if (!container) return false;
 
   const isHidden = container.classList.contains('hidden') || container.style.display === 'none' || container.style.display === '';
 
-  if (!isHidden) {
+  // Sichtbar + gleicher Inhalt → zuklappen. Sichtbar + ANDERER contentKey
+  // (z.B. Wechsel „Werke" → „Autor*innen" im selben Genre-Panel) → Inhalt
+  // umschalten statt ausblenden (#167 Finding 16).
+  if (!isHidden && (!contentKey || container.dataset.contentKey === contentKey)) {
     container.classList.add('hidden');
     container.style.display = 'none';
     return true;
   }
 
   try {
+    container.dataset.contentKey = contentKey;
     const content = contentGenerator();
     if (content === null || content === '') {
       container.innerHTML = `

--- a/playground/js/ui/tei/cooccurrence-ranking.js
+++ b/playground/js/ui/tei/cooccurrence-ranking.js
@@ -570,8 +570,13 @@ export class CooccurrenceRanking {
     document.getElementById('coRkMinFreq')?.addEventListener('change', (e) => {
       const v = parseInt(e.target.value, 10);
       this.state.minFreq = isNaN(v) || v < 1 ? 1 : v;
-      // Wenn ein Result existiert, nur re-render (kein Re-Compute noetig).
-      if (this.state.result) this.render();
+      // minFreq wirkt in enrichPartners (Post-Compute) — die Partnerliste
+      // muss aus den Roh-Counts neu gefiltert werden, sonst widerspricht
+      // der Header der Tabelle (#167 Finding 21; analog posMode-Handler).
+      if (this.state.result) {
+        this.state.result.partners = this.enrichPartners(this.state.result._rawCounts || new Map());
+        this.render();
+      }
     });
     document.getElementById('coRkTopN')?.addEventListener('change', (e) => {
       this.state.topN = parseInt(e.target.value, 10) || DEFAULT_STATE.topN;

--- a/playground/js/ui/tei/multi-lemma-search.js
+++ b/playground/js/ui/tei/multi-lemma-search.js
@@ -208,6 +208,19 @@ export class MultiLemmaSearchUI {
             return;
         }
 
+        // Guard analog zu den 8 Schwester-Tools: vor dem Corpus-Load liefert
+        // die Suche sonst still leere Ergebnisse (#167 Finding 22).
+        if (!window.playground?.corpusData?.texts?.length) {
+            if (resultsContainer) {
+                resultsContainer.innerHTML = `
+                    <div class="text-sm text-red-600">
+                        Korpus ist noch nicht geladen. Bitte einen Moment warten und erneut suchen.
+                    </div>
+                `;
+            }
+            return;
+        }
+
         // Navigiert der User während der async Korpus-Suche zu einer
         // anderen View, darf das fertige Ergebnis die dort angezeigte
         // View nicht überschreiben (#159). Vor dem try deklariert, damit

--- a/playground/js/ui/tei/text-comparison.js
+++ b/playground/js/ui/tei/text-comparison.js
@@ -9,6 +9,7 @@
  */
 
 import { buildTextLabelDisambiguator } from '../core/ui-helpers.js';
+import { TextNormalizer } from '../../../../assets/js/lib/text-normalizer.js';
 
 const DEFAULT_STATE = Object.freeze({
   textAId: '',
@@ -127,9 +128,11 @@ export class TextComparison {
   }
 
   filterByName(rows) {
-    const f = this.state.nameFilter.trim().toLowerCase();
+    const f = this.state.nameFilter.trim();
     if (!f) return rows;
-    return rows.filter(r => (r.lemma || r.lemmaId).toLowerCase().includes(f));
+    // MHG-normalisierter Vergleich wie im naming-explorer: „tot" muss
+    // „tôtwunt" finden (#167 Finding 23).
+    return rows.filter(r => TextNormalizer.matchesNormalized(r.lemma || r.lemmaId, f));
   }
 
   render() {

--- a/playground/js/ui/tei/text-statistics.js
+++ b/playground/js/ui/tei/text-statistics.js
@@ -245,7 +245,13 @@ export class TextStatistics {
       cb.addEventListener('change', () => {
         if (cb.checked) this.selected.add(cb.dataset.selectId);
         else this.selected.delete(cb.dataset.selectId);
-        updateBar();
+        // Im Modus „Nur Auswahl anzeigen" muss die abgewählte Zeile sofort
+        // aus der Tabelle verschwinden (#167 Finding 67).
+        if (this.showSelectedOnly) {
+          this.render();
+        } else {
+          updateBar();
+        }
       });
     });
 


### PR DESCRIPTION
## Zusammenfassung

Alle 10 Punkte aus dem Audit-Sammelticket #167 (Low-Risk, klar umrissene Fixes; Finding-Nummern = AUDIT-REPORT-Reihenfolge).

> **Stacking-Hinweis:** Dieser PR ist auf PR #177 gestackt (Basis-Branch \`claude/161-posall-multi-pos\`), weil #167-F21 dieselbe Datei anfasst wie #177 (\`cooccurrence-ranking.js\`) und F22 dieselbe wie #174 (\`multi-lemma-search.js\`). **Merge-Reihenfolge: #174 → #177 → dieser PR.**

## Fixes

| Finding | Datei | Fix |
|---------|-------|-----|
| 13 | \`woerterbuchnetz.js\` | Degradierte API-Antworten (Timeout, Netzfehler, 5xx) werden nicht mehr session-lang gecacht; 4xx (kein Eintrag) bleibt cachebares Ergebnis |
| 16 | \`SearchHelpers.js\` + \`genre-explorer.js\` | \`toggleDetails\` bekommt \`contentKey\`: Wechsel Werke ↔ Autor*innen schaltet das Panel um statt es auszublenden; gleicher Typ togglet weiterhin zu |
| 17 | \`lemma-explorer.js\` + \`authority-ui.js\` | Neues \`showOriginalLemmaSenses()\`: „← Zurück" bei Etymologie-Komponenten rendert die Original-Bedeutungen direkt statt das sichtbare Panel zu togglen |
| 21 | \`cooccurrence-ranking.js\` | Mindest-Frequenz-Änderung filtert die Partnerliste aus \`_rawCounts\` neu (analog posMode-Handler) — Header und Tabelle stimmen wieder überein |
| 22 | \`multi-lemma-search.js\` | „Korpus noch nicht geladen"-Guard nachgezogen (die 8 Schwester-Tools hatten ihn bereits) |
| 23 | \`text-comparison.js\` | Lemma-Filter nutzt \`TextNormalizer.matchesNormalized\` — „tot" findet jetzt „tôtwunt" |
| 59 | \`lemma-page.js\` | \`clipboard.writeText\` mit \`.catch\` + Nutzer-Feedback („Kopieren nicht möglich") |
| 63 | \`tei-storage.js\` | \`initialize()\` reicht das false-Ergebnis der IndexedDB-Initialisierung durch statt fälschlich Erfolg zu melden |
| 67 | \`text-statistics.js\` | Checkbox-Abwahl re-rendert im Modus „Nur Auswahl anzeigen" sofort |
| 86 | \`authority-manager.js\` | Autocomplete-Eingabe via kanonischem \`TextNormalizer.normalizeMHG\` statt abweichender Inline-Regex-Kette — „mære"/„brōt" liefern jetzt Vorschläge (CONTRACTS §A) |

## Verifikation

- Chrome: F86 real reproduziert und verifiziert (mære, brōt mit Makron, ere → korrekte Vorschläge); F16/F17 per DOM-Test über die echte Explorer-API (Umschalten, echtes Toggle, Zurück-Navigation); keine Konsolen-Fehler.
- \`npm test\`: **192 passed / 1 failed (17,8 min)** — der eine Fail ist der bekannte #158-Dauer-Fail (\`reading-view.spec.js › prose line numbers\`), dessen Fix in PR #175 lebt (dieser Stack enthält #175 nicht). Keine Regression.

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review-Triage (08.07.)

Bot-Review gesichtet: keine blockierenden Findings. Der F16-Nit (leeres data-content-key an fremden Panels) ist rein kosmetisch und bleibt; die F13-Rueckfrage (4xx darf gecacht bleiben) ist wie vom Review selbst vermutet korrekt implementiert (nur 5xx/Netzfehler setzen failed und loeschen den Cache-Eintrag). Branch auf den um den Badge-Review-Fix ergaenzten #177-Stand rebased; Volllauf: 193 passed + 1 bekannter #158-Fail.


## Review-Triage 2. Runde (08.07. nachmittags)

Beide Re-Reviews finden keine Korrektheitsfehler. Zwei dokumentierte Punkte ohne Code-Aenderung: (1) Der Testcoverage-Vorschlag (minFreq-Refilter, Genre-Panel-Switch als Playwright-Assertions) ist berechtigt, aber bewusst nicht in diesem Batch — Kandidat fuer die naechste Test-Session. (2) Der F22-Guard ist enger als der corpusTextsThunk-Fallback der Schwester-Tools; laut Re-Review selbst safe, weil der einzige divergierende Pfad (loadCorpusIntoPlayground) tot ist — Hinweis fuer kuenftige Aenderungen an playground-main.js.
