### PR TITLE
#170: Drei latente Positions-Paritäts-Drifts geschlossen (CONTRACTS §B/§B.1)

### DIFF
--- a/assets/js/rendering/tei-text-reader.js
+++ b/assets/js/rendering/tei-text-reader.js
@@ -448,7 +448,12 @@ class TEITextReader {
                     const noteType = el.getAttribute('type');
                     const noteN = el.getAttribute('n') || '';
                     if ((noteType === 'date' || noteType === 'year') && noteN) {
-                        return `<span class="note-badge note-${this.escapeHtml(noteType)}" title="${noteType === 'date' ? 'Datum' : 'Jahr'}">${this.escapeHtml(noteN)}</span>`;
+                        // Badge + Kindinhalt (#170): date/year-Notes sind heute
+                        // self-closing, aber ein künftig lemmatisiertes <w> darin
+                        // zählt im Python-Index und in KWIC mit (CONTRACTS §B) —
+                        // das Badge allein würde es im Reader verschlucken und
+                        // alle Highlights dahinter verschieben.
+                        return `<span class="note-badge note-${this.escapeHtml(noteType)}" title="${noteType === 'date' ? 'Datum' : 'Jahr'}">${this.escapeHtml(noteN)}</span>${children()}`;
                     }
                     return children();
                 }

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -91,14 +91,19 @@ The selector below is the *logical* counting rule, not the literal implementatio
 ```
 Logical selection: //tei:body//tei:w[@lemmaRef]   (document order)
 
-For each <w lemmaRef="lexicon.xml#lemma_X"> in document order:
-    lemma_id = lemmaRef.split('#')[1]      → "lemma_X"
+For each <w lemmaRef="..."> in document order:
     word_text = ''.join(el.itertext()).strip()
     if not word_text: continue              → empty <w lemmaRef> is NOT counted (JS matches this since #131)
-    position = len(words)                   → sequential from 0
-    words.append(lemma_id)
-    lemmata[lemma_id].append(position)
+    # @lemmaRef may carry SEVERAL whitespace-separated references (§B.1),
+    # e.g. "lexicon.xml#lemma_308 lexicon.xml#lemma_5" (#170):
+    lemma_ids = [frag.split('#')[1] for frag in lemmaRef.split()]
+    position = len(words)                   → sequential from 0; ONE slot per token
+    words.append(lemma_ids[0])              → words[] keeps the FIRST id only
+    for lemma_id in dedupe(lemma_ids):
+        lemmata[lemma_id].append(position)  → lemmata{} lists the position under EVERY id
 ```
+
+**Consumer rule (follows from the words[]/lemmata{} split):** code answering "is position P an occurrence of lemma X?" MUST consult `lemmata[X]` (multi-ref-aware), never `words[P] === X` (first-id only). Applied in `verse-position-search.js` and `rhyme-dictionary.js` (target side); `cooccurrence-ranking.js`'s neighbor counting deliberately stays first-id (a full reverse map is not justified at 0 multi-ref corpus cases today).
 
 ### JavaScript (runtime)
 
@@ -120,6 +125,16 @@ Recursive DOM traversal of <body> children:
 ### Parity note — empty `<w lemmaRef>` (resolved #131)
 
 Both sides now **skip** `<w lemmaRef>` with empty text content: Python via `if not word_text: continue`, JS via the `hasText` guard in `extractAndFormatBody` (`tei-text-reader.js`, `case 'w'`). Before #131 the JS runtime incremented `wordPosition` for **every** `<w lemmaRef>` regardless of text — a latent parity gap (harmless then: **0** empty `<w lemmaRef>` across all 667 files, so the fix was a no-op on real data) that a future ingest with placeholder/gap tokens would have silently broken. The empty-`<w>` case is now pinned by `testing/tests/position-parity.spec.js`. (Because the corpus has no empty `<w lemmaRef>`, the shipped index is unchanged — no rebuild or version bump needed.)
+
+### Parity note — note children, multi-`@lemmaRef`, proximity context (resolved #170)
+
+Three further latent drifts of the same class ("0 corpus cases today, armed by the next ingest"), all fixed behavior-neutrally (byte-identical index rebuild):
+
+1. **`<w>` inside date/year `<note>`:** the reader's badge branch swallowed `children()`, so a future lemmatized `<w>` inside such a note would be counted by Python/KWIC but not rendered/counted by the reader — every position after it would shift. The badge now renders **plus** its children.
+2. **Whitespace-separated multi-`@lemmaRef`:** `split('#')[1]` on the whole attribute produced the broken key `"lemma_308 lexicon.xml"`. Now resolved per fragment (see pseudocode above): `words[]` keeps the first id, `lemmata{}` lists the position under every id.
+3. **Proximity-context enrichment (`playground/js/ui/core/ui-helpers.js`, `enrichFileResults`):** the fourth counting path mapped index positions back onto DOM words without the empty-`<w>` guard from #131 — one empty `<w lemmaRef/>` would shift every context window behind it. Now guarded identically.
+
+All three (plus the consumer rule above) are pinned by `testing/tests/position-parity.spec.js` with the fixture `position-parity-170.tei.xml`.
 
 ### Example
 

--- a/playground/js/ui/core/ui-helpers.js
+++ b/playground/js/ui/core/ui-helpers.js
@@ -376,7 +376,9 @@ function setupSummaryExpansion() {
 }
 
 // Enrich file results with TEI text
-async function enrichFileResults(fileResults, lemmaIds) {
+// (exportiert für position-parity.spec.js — der Guard gegen leere <w> ist
+// der vierte Zählpfad der §B-Parität, #170)
+export async function enrichFileResults(fileResults, lemmaIds) {
   // Guard against null/undefined lemmaIds
   if (!lemmaIds || !Array.isArray(lemmaIds)) {
     console.warn(`No lemmaIds provided for enrichment`);
@@ -416,7 +418,13 @@ async function enrichFileResults(fileResults, lemmaIds) {
 
         const indexedWords = [];
         for (let i = 0; i < xpathIndexed.snapshotLength; i++) {
-          indexedWords.push(xpathIndexed.snapshotItem(i));
+          const w = xpathIndexed.snapshotItem(i);
+          // Paritäts-Guard (#170, analog #131): der Python-Build überspringt
+          // leere <w lemmaRef/> (build-corpus-index.py, text_content-Check) —
+          // ohne denselben Guard verschöbe ein einziges leeres <w> alle
+          // Kontextfenster hinter ihm (CONTRACTS §B).
+          if (!w.textContent.trim()) continue;
+          indexedWords.push(w);
         }
 
         // Get the matched word elements from index

--- a/playground/js/ui/core/ui-helpers.js
+++ b/playground/js/ui/core/ui-helpers.js
@@ -422,8 +422,12 @@ export async function enrichFileResults(fileResults, lemmaIds) {
           // Paritäts-Guard (#170, analog #131): der Python-Build überspringt
           // leere <w lemmaRef/> (build-corpus-index.py, text_content-Check) —
           // ohne denselben Guard verschöbe ein einziges leeres <w> alle
-          // Kontextfenster hinter ihm (CONTRACTS §B).
-          if (!w.textContent.trim()) continue;
+          // Kontextfenster hinter ihm (CONTRACTS §B). Der lemmaRef-Check
+          // prüft den Attribut-WERT, nicht nur die Existenz: der XPath
+          // [@lemmaRef] matcht auch lemmaRef="" — Python (falsy-Check) und
+          // Reader (falsy-Check) überspringen das, dieser Pfad muss es
+          // genauso tun (#184 Review-Finding, 2. Runde).
+          if (!w.getAttribute('lemmaRef') || !w.textContent.trim()) continue;
           indexedWords.push(w);
         }
 

--- a/playground/js/ui/tei/rhyme-dictionary.js
+++ b/playground/js/ui/tei/rhyme-dictionary.js
@@ -147,8 +147,18 @@ export class RhymeDictionary {
       // Nur scannen, wenn das Lemma im Text überhaupt vorkommt
       if (!text.lemmata?.[targetId]) continue;
 
+      // Ziel-Seite ueber die lemmata{}-Positionsliste statt words[...] ===
+      // targetId: words[] traegt bei Mehrfach-@lemmaRef nur die ERSTE ID
+      // (CONTRACTS §B.1) — die Zweit-ID eines kuenftigen Multi-Ref-Worts am
+      // Versende wuerde sonst nie als Reimwort gefunden (#170 Review-
+      // Finding). Die Partner-Seite (words[ends[j]]) bleibt bewusst
+      // Erst-ID: alle IDs einer Position braeuchten eine Reverse-Map,
+      // die der Index nicht hat — bei heute 0 Multi-Ref-Faellen nicht
+      // gerechtfertigt.
+      const targetPositions = new Set(text.lemmata[targetId]);
+
       for (let k = 0; k < ends.length; k++) {
-        if (words[ends[k]] !== targetId) continue;
+        if (!targetPositions.has(ends[k])) continue;
         endOccurrences++;
 
         for (const delta of [-1, 1]) {

--- a/playground/js/ui/tei/verse-position-search.js
+++ b/playground/js/ui/tei/verse-position-search.js
@@ -58,12 +58,17 @@ export class VersePositionSearch {
     for (const text of texts) {
       const boundary = isStart ? text.lineStarts : text.lineEnds;
       if (!boundary || boundary.length === 0) continue; // prose
-      const positions = [];
-      for (const idx of boundary) {
-        if (text.words[idx] === lemmaId) positions.push(idx);
-      }
+      // Ueber die lemmata{}-Positionsliste statt words[idx] === lemmaId:
+      // words[] traegt bei Mehrfach-@lemmaRef nur die ERSTE ID (CONTRACTS
+      // §B.1), lemmata{} listet die Position unter JEDER referenzierten ID —
+      // sonst wuerde ein kuenftiges Multi-Ref-Wort an der Versgrenze fuer
+      // seine Zweit-ID nicht gefunden (#170 Review-Finding).
+      const lemmaPositions = text.lemmata?.[lemmaId];
+      if (!lemmaPositions || lemmaPositions.length === 0) continue;
+      const boundarySet = new Set(boundary);
+      const positions = lemmaPositions.filter(idx => boundarySet.has(idx));
       if (positions.length > 0) {
-        const totalForLemma = text.lemmata?.[lemmaId]?.length || 0;
+        const totalForLemma = lemmaPositions.length;
         hits.push({
           id: text.id,
           title: text.title || text.id,

--- a/scripts/build-corpus-index.py
+++ b/scripts/build-corpus-index.py
@@ -208,11 +208,25 @@ def extract_word_data(filepath, text_id):
             if not text_content:
                 continue
 
-            lemma_id = lemma_ref.split('#')[1] if '#' in lemma_ref else lemma_ref
+            # Mehrfach-Referenzen (CONTRACTS §B.1: whitespace-getrennt, z.B.
+            # "lexicon.xml#lemma_308 lexicon.xml#lemma_5") pro Fragment
+            # auflösen — der alte split('#')[1] erzeugte daraus den defekten
+            # Key "lemma_308 lexicon.xml" (#170). words[] behält die ERSTE ID
+            # (ein Slot pro Token, Format unverändert); lemmata{} listet die
+            # Position unter JEDER referenzierten ID, damit die Index-Suche
+            # jedes der Lemmata findet. Heute 0 Mehrfach-Fälle im Korpus:
+            # der Rebuild muss byte-identisch bleiben.
+            lemma_ids = [
+                frag.split('#')[1] if '#' in frag else frag
+                for frag in lemma_ref.split()
+            ]
+            if not lemma_ids:
+                continue
 
             word_idx = len(words)
-            words.append(lemma_id)
-            lemmata[lemma_id].append(word_idx)
+            words.append(lemma_ids[0])
+            for lemma_id in dict.fromkeys(lemma_ids):
+                lemmata[lemma_id].append(word_idx)
             word_count += 1
 
             # If we're inside one or more <l>, update each open frame.

--- a/testing/fixtures/position-parity-170.tei.xml
+++ b/testing/fixtures/position-parity-170.tei.xml
@@ -10,9 +10,13 @@
      the Python build produced the broken key "lemma_1 lexicon.xml" instead of
      registering the position under BOTH ids.
 
-  Counted positions (only non-empty <w> carrying @lemmaRef, document order, 0-based):
+  Counted positions (only non-empty <w> carrying a non-empty @lemmaRef,
+  document order, 0-based):
     pos 0 : <w lemmaRef="lexicon.xml#lemma_1">Wir</w>
     pos 1 : <w lemmaRef="lexicon.xml#lemma_2">anno</w>     inside <note type="date">
+    skip  : <w lemmaRef="">leer</w>       empty ATTRIBUTE VALUE — an XPath
+            [@lemmaRef] existence test matches it, but Python and the reader
+            skip falsy values, so every counting path must too (#184 review)
     pos 2 : <w lemmaRef="lexicon.xml#lemma_1 lexicon.xml#lemma_3">wirt</w>
     pos 3 : <w lemmaRef="lexicon.xml#lemma_4">hie</w>
 
@@ -41,6 +45,7 @@
       <p>
         <w lemmaRef="lexicon.xml#lemma_1">Wir</w>
         <note type="date" n="1291"><w lemmaRef="lexicon.xml#lemma_2">anno</w></note>
+        <w lemmaRef="">leer</w>
         <w lemmaRef="lexicon.xml#lemma_1 lexicon.xml#lemma_3">wirt</w>
         <w lemmaRef="lexicon.xml#lemma_4">hie</w>
       </p>

--- a/testing/fixtures/position-parity-170.tei.xml
+++ b/testing/fixtures/position-parity-170.tei.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Synthetic fixture for the Position-Counting parity tests (#170, CONTRACTS §B/§B.1).
+  NOT corpus data. Exercises two latent asymmetries with 0 corpus cases today:
+
+  1. A lemmatized <w> INSIDE a date/year <note> (pre-fix, the JS reader rendered
+     only the badge and never visited the children, so the word was not counted
+     and every position after it shifted).
+  2. A whitespace-separated multi-reference @lemmaRef (CONTRACTS §B.1). Pre-fix,
+     the Python build produced the broken key "lemma_1 lexicon.xml" instead of
+     registering the position under BOTH ids.
+
+  Counted positions (only non-empty <w> carrying @lemmaRef, document order, 0-based):
+    pos 0 : <w lemmaRef="lexicon.xml#lemma_1">Wir</w>
+    pos 1 : <w lemmaRef="lexicon.xml#lemma_2">anno</w>     inside <note type="date">
+    pos 2 : <w lemmaRef="lexicon.xml#lemma_1 lexicon.xml#lemma_3">wirt</w>
+    pos 3 : <w lemmaRef="lexicon.xml#lemma_4">hie</w>
+
+  Expected positions (Python build and JS reader must agree):
+    lemma_1 -> [0, 2]   (multi-ref word counts once, listed under both ids)
+    lemma_2 -> [1]      (word inside the date note IS counted)
+    lemma_3 -> [2]
+    lemma_4 -> [3]      (pre-fix JS: [2] because the note word was swallowed)
+-->
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+    <fileDesc>
+      <titleStmt>
+        <title>Position Parity Fixture (note children + multi-lemmaRef, #170)</title>
+      </titleStmt>
+      <publicationStmt>
+        <p>Synthetic test fixture, not corpus data.</p>
+      </publicationStmt>
+      <sourceDesc>
+        <p>Synthetic.</p>
+      </sourceDesc>
+    </fileDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <p>
+        <w lemmaRef="lexicon.xml#lemma_1">Wir</w>
+        <note type="date" n="1291"><w lemmaRef="lexicon.xml#lemma_2">anno</w></note>
+        <w lemmaRef="lexicon.xml#lemma_1 lexicon.xml#lemma_3">wirt</w>
+        <w lemmaRef="lexicon.xml#lemma_4">hie</w>
+      </p>
+    </body>
+  </text>
+</TEI>

--- a/testing/tests/position-parity.spec.js
+++ b/testing/tests/position-parity.spec.js
@@ -156,3 +156,59 @@ test.describe('B. Position Counting parity — empty <w lemmaRef> asymmetry (#13
     expect(lemmata.lemma_2, 'empty <w lemmaRef> (lemma_2) must not be counted').toBeUndefined();
   });
 });
+
+test.describe('B. Position Counting parity — #170 latent drifts', () => {
+  // Fixture with (a) a lemmatized <w> inside a date-<note> and (b) a
+  // whitespace-separated multi-reference @lemmaRef (CONTRACTS §B.1). Both have
+  // 0 corpus cases today; the fixture pins the contract for future ingest.
+  const FIXTURE_REL = 'testing/fixtures/position-parity-170.tei.xml';
+  const EXPECTED = { lemma_1: [0, 2], lemma_2: [1], lemma_3: [2], lemma_4: [3] };
+
+  test('Python: multi-lemmaRef registers the position under BOTH ids, no broken key', async () => {
+    const fixtureAbs = path.join(REPO_ROOT, FIXTURE_REL);
+    const { wordCount, lemmata } = pythonData(fixtureAbs, 'FIXTURE170');
+
+    expect(wordCount, '4 counted words').toBe(4);
+    for (const [lemmaId, expected] of Object.entries(EXPECTED)) {
+      expect(lemmata[lemmaId], `Python positions for ${lemmaId}`).toEqual(expected);
+    }
+    // Pre-fix failure mode: split('#')[1] on the multi-ref produced the broken
+    // key "lemma_1 lexicon.xml". No key may contain whitespace or a filename.
+    const brokenKeys = Object.keys(lemmata).filter(k => /\s|\.xml/.test(k));
+    expect(brokenKeys, 'no broken multi-ref keys').toEqual([]);
+  });
+
+  test('JS reader: word inside date-<note> is counted AND parity holds (badge + children)', async ({ page }) => {
+    const fixtureAbs = path.join(REPO_ROOT, FIXTURE_REL);
+    const { lemmata } = pythonData(fixtureAbs, 'FIXTURE170');
+    const js = await jsPositionsMap(page, `${BASE}/${FIXTURE_REL}`, Object.keys(EXPECTED));
+
+    for (const [lemmaId, expected] of Object.entries(EXPECTED)) {
+      expect(lemmata[lemmaId], `Python positions for ${lemmaId}`).toEqual(expected);
+      // Pre-fix: the date-note badge swallowed children(), so lemma_2 had no
+      // highlight at all and lemma_4 shifted to [2].
+      expect(js[lemmaId], `JS reader must match Python for ${lemmaId}`).toEqual(expected);
+    }
+  });
+
+  test('enrichFileResults (proximity context): empty <w lemmaRef> does not shift the window', async ({ page }) => {
+    // Fourth counting path (#170): the playground proximity-search enrichment
+    // maps index positions back onto DOM words. Python position 2 in the
+    // empty-w fixture is "ist" (lemma_3); pre-fix, the JS mapping counted the
+    // empty <w lemmaRef> too, so the window slid onto "brot" instead.
+    const result = await page.evaluate(async () => {
+      const { enrichFileResults } = await import('/playground/js/ui/core/ui-helpers.js');
+      const r = {
+        filename: '../testing/fixtures/position-parity-empty-w.tei.xml',
+        contextStart: 2,
+        contextEnd: 3,
+        distance: 0
+      };
+      await enrichFileResults([r], ['lemma_3']);
+      return r.contextText;
+    });
+
+    expect(result, 'context window must land on the Python position').toContain('ist');
+    expect(result, 'pre-fix failure mode: window slid onto "brot"').not.toContain('brot');
+  });
+});


### PR DESCRIPTION
Closes #170

## Was

Die drei Audit-Findings der Klasse „heute 0 Korpusfälle, beim laufenden Ingest jederzeit scharf" (#49/#50, #53, #58):

| Finding | Datei | Fix |
|---|---|---|
| #49/#50 | `playground/js/ui/core/ui-helpers.js` | `enrichFileResults` überspringt leere `<w lemmaRef/>` beim `indexedWords`-Aufbau (vierter Zählpfad, analog #131) — vorher verschob ein einziges leeres `<w>` Kontextfenster und Highlights der Nähe-Suche |
| #53 | `scripts/build-corpus-index.py` | Whitespace-getrennte Mehrfach-`@lemmaRef` (CONTRACTS §B.1) werden pro Fragment aufgelöst: `words[]` behält die erste ID (Format unverändert), `lemmata{}` listet die Position unter JEDER ID. Vorher entstand der defekte Key `"lemma_308 lexicon.xml"` |
| #58 | `assets/js/rendering/tei-text-reader.js` | date/year-`<note>` rendert Badge **+** `children()` statt den Kindinhalt zu verschlucken — ein künftig lemmatisiertes `<w>` in so einer Notiz zählte sonst im Python-Index und in KWIC, aber nicht im Reader |

## Verifikation

- **Byte-Identitäts-Gate bestanden:** Corpus-Rebuild nach dem Build-Skript-Fix ist byte-identisch (`git status data/` leer; 667 Texte, 7.533.447 Wörter) — alle drei Fixes sind auf dem heutigen Korpus verhaltensneutral, wie im Issue gefordert.
- **Neue Fixture** `testing/fixtures/position-parity-170.tei.xml` + 3 Tests in `position-parity.spec.js`: Python-Multi-Ref-Keys (kein Whitespace-/Dateinamen-Key), Reader-Parität für `<w>` in date-Notes (ganze Sequenz), `enrichFileResults`-Fensterlage gegen die #131-Fixture (Funktion dafür exportiert).
- **Volllauf: 197 passed / 0 failed** (16,0 min).

## Stacking

Gestackt auf #178 (tei-text-reader.js-Überschneidung). Merge-Reihenfolge: **#174 → #175 → #178 → dieser PR.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review-Triage (08.07. nachmittags)

Bot-Review gesichtet, beide Findings berechtigt und als Folge-Commit `cdc2dc356` umgesetzt: (1) Die words[]/lemmata{}-Asymmetrie in den Konsumenten — verse-position-search.js und rhyme-dictionary.js (Ziel-Seite) pruefen Positionen jetzt ueber die multi-ref-faehige lemmata{}-Positionsliste statt `words[idx] === lemmaId`; die Kookkurrenz-Nachbar-Seite bleibt bewusst Erst-ID (Reverse-Map bei 0 Korpusfaellen nicht gerechtfertigt) und ist als Consumer-Rule dokumentiert. (2) CONTRACTS §B nachgezogen: Pseudo-Code mit Multi-Ref-Aufloesung, neue Consumer-Rule, "resolved #170"-Parity-Note analog #131. Zusaetzlich enthaelt der Stack jetzt den #178-Zweitrunden-Fix (console.warn). Volllauf nach den Fixes: siehe letzter Kommentar-Stand der Checks.


## Review-Triage 3. Runde (08.07. spaetnachmittags)

Das Re-Review auf den Consumer-Rule-Commit fand einen weiteren echten Punkt derselben Klasse: der XPath [@lemmaRef] in enrichFileResults ist ein Existenz-Test und matcht auch lemmaRef="" — Python und Reader skippen leere Werte (falsy-Check). Umgesetzt als `719c53e23`: Guard prueft jetzt den Attribut-Wert; Fixture um den Leere-Ref-Fall geschaerft (erwartete Positionen unveraendert). Gezielte Specs gruen (position-parity 6/6, cooccurrence-ranking 4/4). Der whitespace-only-@lemmaRef-Guard im Build-Skript bleibt ohne eigene Fixture-Zeile (vom Review selbst als non-blocking eingestuft).



**Nachtrag (08.07., Merge-Session):** Viertes Bot-Review (10:41 UTC) gesichtet: "Nothing here blocks merge; the one item above is optional polish". Der Rest-Nit (pathologischer whitespace-only lemmaRef=" " als JS-seitiges Gegenstueck des bereits triagierten Python-Nits) wird begruendet nicht umgesetzt: 0 Korpusfaelle, doppelt-pathologisches Szenario, und ein Folge-Commit wuerde nur eine weitere Review-Runde ausloesen.
