### PR TITLE
#171 (Teil): ARI-Header-Escaping + insert-stanzas Grenzen/Nummerierung

### DIFF
--- a/scripts/ingest/ari/01-convert-original-to-mhdbdb.py
+++ b/scripts/ingest/ari/01-convert-original-to-mhdbdb.py
@@ -36,6 +36,7 @@ Verwendung:
 import argparse
 import sys
 from pathlib import Path
+from xml.sax.saxutils import escape
 from lxml import etree
 
 TEI_NS = "http://www.tei-c.org/ns/1.0"
@@ -241,11 +242,14 @@ def convert(input_path, sigle, title_de, source_url, output_path, dry_run):
     tei = etree.Element(f"{{{TEI_NS}}}TEI", nsmap=nsmap)
     tei.set(f"{{{XML_NS}}}id", sigle)
 
-    # Header aus Template
+    # Header aus Template. Vollstaendiges XML-Escaping (#171 Finding 27):
+    # das blosse "-Replace liess & und < durch — ein & im Titel oder in der
+    # GAMS-URL (Query-Parameter!) crashte etree.fromstring. source_url steht
+    # in einem target-Attribut, daher auch " mitescapen.
     header_xml = HEADER_TEMPLATE.format(
         sigle=sigle,
-        title_de=title_de.replace('"', "&quot;"),
-        source_url=source_url,
+        title_de=escape(title_de, {'"': "&quot;"}),
+        source_url=escape(source_url, {'"': "&quot;"}),
     )
     header = etree.fromstring(header_xml)
     tei.append(header)

--- a/scripts/insert-stanzas-from-linecode.py
+++ b/scripts/insert-stanzas-from-linecode.py
@@ -238,11 +238,21 @@ def insert_stanzas_for_text(sigle: str, tei_path: Path, linecode_path: Path,
             first_ls.append(l)
 
     # Build (first_l, last_l) ranges. last_l = sibling immediately before next first_l.
+    # @n zählt die tatsächlich gewrappten <lg> fortlaufend ab 1 (KZW-Decision
+    # #23: sequenziell, nicht der rohe Linecode-Wert). Der alte Anker-Index
+    # idx+1 riss bei missing_anchors/wrap_failed Lücken in die Nummerierung
+    # (#171 Finding 36).
+    next_n = 1
     for idx, ((stanza_val, candidates), first_l) in enumerate(zip(anchors, first_ls)):
         if first_l is None:
             continue
-        if idx + 1 < len(anchors) and first_ls[idx + 1] is not None:
-            next_first = first_ls[idx + 1]
+        # Boundary = the NEXT RESOLVED anchor, not just idx+1 (#171 Finding 35):
+        # if the immediately-next anchor is unresolved (None), the old code fell
+        # into the "last stanza" branch and let this stanza run to the end of
+        # its container — swallowing all following stanzas and producing nested
+        # <lg> once their own wraps were applied.
+        next_first = next((fl for fl in first_ls[idx + 1:] if fl is not None), None)
+        if next_first is not None:
             # Walk back from next_first to find the previous <l> sibling
             sib = next_first.getprevious()
             last_l = None
@@ -278,8 +288,9 @@ def insert_stanzas_for_text(sigle: str, tei_path: Path, linecode_path: Path,
                 stats["wrap_failed"].append((candidates[0], "parent mismatch"))
                 continue
 
-        if wrap_stanza(first_l, last_l, idx + 1):
+        if wrap_stanza(first_l, last_l, next_n):
             stats["wrapped"] += 1
+            next_n += 1
         else:
             stats["wrap_failed"].append((candidates[0], "wrap_stanza returned False"))
 


### PR DESCRIPTION
Part of #171 — die zwei als ingest-kritisch priorisierten Findings; das Sammelticket bleibt offen (restliche ~12 Findings sind Audit-/CI-/WZB-Skripte ohne anstehenden Lauf).

## Was

| Finding | Datei | Fix | Warum jetzt |
|---|---|---|---|
| #27 | `scripts/ingest/ari/01-convert-original-to-mhdbdb.py` | Header-Template escaped vollständig via `saxutils.escape` (`&`, `<`, `>`, `"`) — vorher nur `"`-Replace auf `title_de`, und `source_url` (steht im `target`-Attribut) gar nicht: ein `&` in Titel oder GAMS-URL crashte `etree.fromstring` | **Vor dem nächsten ARITHMETIC-Lauf (#92)** |
| #35 | `scripts/insert-stanzas-from-linecode.py` | Strophen-Grenze ist der **nächste aufgelöste** Anker statt stur `idx+1` — ein unaufgelöster Zwischen-Anker ließ die Strophe sonst per „last stanza"-Zweig bis zum Container-Ende laufen (verschachtelte `<lg>` möglich, Token-Invariante in Gefahr) | **Vor dem WVV-Bulk-Lauf (#110)** |
| #36 | ebd. | `@n` zählt die tatsächlich gewrappten `<lg>` fortlaufend ab 1 — gemäß der dokumentierten KZW-Decision (#23, 2026-05-11: „fortlaufend ab 1", nicht der Linecode-Rohwert). Der Anker-Index riss bei missing/failed Ankern Lücken (1, 2, 4, …) | ebd. |

Hinweis zu #36: Falls für WVV gewünscht ist, dass später manuell nachgetragene Sonderstrophen (Tegernsee-Spruch, 8a, 42a) ihre „Lücken-Nummern" behalten, wäre das eine bewusste Abweichung von der KZW-Regel und gehört in die #110-Entscheidung — der Fix folgt der dokumentierten Regel.

## Verifikation

Synthetische Repros gegen die **echten** Skript-Funktionen (importlib, Scratchpad):
- F27: Roundtrip mit `&`/`<`/`"` in Titel und URL parst und bleibt wertidentisch; Gegenprobe bestätigt, dass die Alt-Logik an `&` crashte.
- F35/36: Fixture mit fehlendem Zwischen-Anker (Strophe 3 von 4 nicht im TEI) → 3 `<lg>`, `@n = [1, 2, 3]`, keine Verschachtelung, Strophengrenzen exakt, alle `<l>`/`<w>` erhalten.
- Schärfe-Check: identischer Test auf dem Vor-Fix-Stand schlägt fehl (`@n = ['1', '2', '4']`).
- `python -m py_compile` auf beiden Skripten grün. Kein Playwright-Lauf: reine Ingest-Skripte, kein Frontend-/Index-/Korpus-Artefakt berührt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review-Triage (08.07. nachmittags)

Bot-Review gesichtet: keine Korrektheits-Findings ("looks correct and safe to merge"). Zwei non-blocking Gedanken dokumentiert, ohne Code-Aenderung: (1) Das "-Escaping fuer title_de (nur Textkontext) ist strikt nicht noetig — bewusst einheitlich mit source_url gehalten, wie vom Review selbst als vorzugswuerdig eingestuft. (2) Die Scratchpad-Repros als committete Regressionstests zu promoten scheitert derzeit am Fehlen jeder Python-Test-Infrastruktur unter scripts/ — sinnvoller Kandidat, falls das Projekt je pytest einfuehrt.
