### PR TITLE
Playground: Feature-Position Reim-Wörterbuch ↔ Lemmasuche nach Versposition tauschen (#197)

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -249,13 +249,13 @@
                                 <span class="text-xs font-normal text-brand-600/80 mt-0.5">Sucht mehrere Lemmata gemeinsam</span>
                             </span>
                         </button>
-                        <button id="findVersePositionBtn" class="w-full rounded-xl border border-slate-200 bg-white px-4 py-2 text-left text-sm font-medium text-slate-700 transition hover:border-brand-400 hover:text-brand-700 flex items-center gap-2.5">
+                        <button id="showRhymeDictionaryBtn" class="w-full rounded-xl border border-slate-200 bg-white px-4 py-2 text-left text-sm font-medium text-slate-700 transition hover:border-brand-400 hover:text-brand-700 flex items-center gap-2.5">
                             <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h10M4 18h7"></path>
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 9l10.5-3m0 6.553v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 11-.99-3.467l2.31-.66a2.25 2.25 0 001.632-2.163zm0 0V2.25L9 5.25v10.303m0 0v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 11-.99-3.467l2.31-.66A2.25 2.25 0 009 15.553z"></path>
                             </svg>
                             <span class="flex flex-col items-start leading-tight">
-                                <span>Lemmasuche nach Versposition</span>
-                                <span class="text-xs font-normal text-slate-500 mt-0.5">Sucht Lemmata am Versanfang oder Versende</span>
+                                <span>Reim-Wörterbuch</span>
+                                <span class="text-xs font-normal text-slate-500 mt-0.5">Reimpartner-Lemmata an benachbarten Versenden</span>
                             </span>
                         </button>
                         <button id="showWordFrequencyBtn" class="w-full rounded-xl border border-slate-200 bg-white px-4 py-2 text-left text-sm font-medium text-slate-700 transition hover:border-brand-400 hover:text-brand-700 flex items-center gap-2.5">
@@ -312,13 +312,13 @@
                                 <span class="text-xs font-normal text-slate-500 mt-0.5">Häufigste Nachbar-Lemmata eines Lemmas</span>
                             </span>
                         </button>
-                        <button id="showRhymeDictionaryBtn" class="w-full rounded-xl border border-slate-200 bg-white px-4 py-2 text-left text-sm font-medium text-slate-700 transition hover:border-brand-400 hover:text-brand-700 flex items-center gap-2.5">
+                        <button id="findVersePositionBtn" class="w-full rounded-xl border border-slate-200 bg-white px-4 py-2 text-left text-sm font-medium text-slate-700 transition hover:border-brand-400 hover:text-brand-700 flex items-center gap-2.5">
                             <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 9l10.5-3m0 6.553v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 11-.99-3.467l2.31-.66a2.25 2.25 0 001.632-2.163zm0 0V2.25L9 5.25v10.303m0 0v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 11-.99-3.467l2.31-.66A2.25 2.25 0 009 15.553z"></path>
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h10M4 18h7"></path>
                             </svg>
                             <span class="flex flex-col items-start leading-tight">
-                                <span>Reim-Wörterbuch</span>
-                                <span class="text-xs font-normal text-slate-500 mt-0.5">Reimpartner-Lemmata an benachbarten Versenden</span>
+                                <span>Lemmasuche nach Versposition</span>
+                                <span class="text-xs font-normal text-slate-500 mt-0.5">Sucht Lemmata am Versanfang oder Versende</span>
                             </span>
                         </button>
                         <button id="showNamingExplorerBtn" class="w-full rounded-xl border border-slate-200 bg-white px-4 py-2 text-left text-sm font-medium text-slate-700 transition hover:border-brand-400 hover:text-brand-700 flex items-center gap-2.5">


### PR DESCRIPTION
Kleiner UI-Tausch laut Issue: In der TEI-Textanalyse-Card des Playgrounds rückt das **Reim-Wörterbuch** an Position 2 (direkt nach der Multi-Lemma-Suche); die **Lemmasuche nach Versposition** übernimmt dessen bisherige Position (nach Kookkurrenz-Ranking, vor den Erweiterten Figurenbezeichnungen).

## Changes
- `playground/index.html`: die beiden `<button>`-Blöcke (`findVersePositionBtn` / `showRhymeDictionaryBtn`) getauscht – reiner Markup-Tausch, 8 Zeilen +/-

## Verifikation
- JS bindet per Button-ID (`playground/js/playground-main.js`), Router per URL-Hash – beides reihenfolgenunabhängig
- HTML-Parse nach dem Tausch: alle Button-IDs weiterhin einmalig, Tag-Balance fehlerfrei
- Kein Playwright-Test prüft die Sidebar-Reihenfolge (Tests navigieren per `#rhyme-dictionary`/`#verse-position`-Hash); keine Daten-/Index-Änderung

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)