### PR TITLE
#192: Varianten-Kennzahlen vereinheitlicht + HTML-Seiten im Zähl-Audit

### DIFF
--- a/hilfe-playground.html
+++ b/hilfe-playground.html
@@ -223,7 +223,7 @@
             </p>
             <p class="text-slate-700 leading-relaxed">
                 Die dreistufige Variantenauflösung aus der Korpussuche gilt auch hier: exakter
-                Treffer im Wörterbuch, dann Prüfung gegen 234.244 orthographische Varianten, dann
+                Treffer im Wörterbuch, dann Prüfung gegen 234.244 normalisierte Schreibvarianten, dann
                 Teiltreffer als Fallback. Sonderzeichen (â, ê, î, ô, û, ä, ö, ü) werden automatisch
                 normalisiert.
             </p>

--- a/playground/index.html
+++ b/playground/index.html
@@ -429,7 +429,7 @@
                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                             </svg>
-                            <span>Sie können Lemma-IDs (z.B. "879") oder Lemma-Formen verwenden (z.B. "brôt" oder einfach "brot"). Sonderzeichen (â, ê, î, ô, û, ä, ö, ü) werden automatisch normalisiert. Alle 234.244 Varianten werden erkannt.</span>
+                            <span>Sie können Lemma-IDs (z.B. "879") oder Lemma-Formen verwenden (z.B. "brôt" oder einfach "brot"). Sonderzeichen (â, ê, î, ô, û, ä, ö, ü) werden automatisch normalisiert. Alle 234.244 normalisierten Schreibvarianten werden erkannt.</span>
                         </div>
                     </div>
 

--- a/scripts/audit/doc-count-audit.py
+++ b/scripts/audit/doc-count-audit.py
@@ -24,6 +24,10 @@ import sys
 from pathlib import Path
 from lxml import etree
 
+# scripts/ auf den Pfad, damit der Parity-Normalizer importierbar ist
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from mhg_normalizer import normalize_mhg
+
 if sys.stdout.encoding and sys.stdout.encoding.lower() not in ('utf-8', 'utf8'):
     sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8', line_buffering=True)
 
@@ -34,6 +38,23 @@ def count_xml_elements(path: str, xpath: str) -> int:
     return len(tree.xpath(xpath, namespaces={'tei': 'http://www.tei-c.org/ns/1.0'}))
 
 
+def count_variants_normalized(path: str) -> int:
+    """Distinct normalized forms in variants.xml — die Zahl, gegen die die
+    Suche tatsächlich prüft (Variants-Dictionary dedupliziert nach
+    MHG-Normalisierung, siehe CONTRACTS.md). Muss mit dem JS-Build der
+    Runtime-Map übereinstimmen; Parity haengt an normalize_mhg()."""
+    tree = etree.parse(path)
+    orth_tag = '{http://www.tei-c.org/ns/1.0}orth'
+    normed = set()
+    for form in tree.xpath('//tei:form[@xml:id]',
+                           namespaces={'tei': 'http://www.tei-c.org/ns/1.0'}):
+        orth = form.find(orth_tag)
+        text = orth.text if orth is not None else form.text
+        if text and text.strip():
+            normed.add(normalize_mhg(text.strip()))
+    return len(normed)
+
+
 def collect_counts() -> dict:
     counts = {}
     counts['corpus_files'] = len(glob.glob('tei/*.tei.xml'))
@@ -41,6 +62,7 @@ def collect_counts() -> dict:
     counts['lexicon_entries'] = count_xml_elements('authority-files/lexicon.xml', '//tei:entry[@xml:id]')
     counts['variants_entries'] = count_xml_elements('authority-files/variants.xml', '//tei:entry[@corresp]')
     counts['variants_forms'] = count_xml_elements('authority-files/variants.xml', '//tei:form[@xml:id]')
+    counts['variants_normalized'] = count_variants_normalized('authority-files/variants.xml')
     counts['persons'] = count_xml_elements('authority-files/persons.xml', '//tei:person[@xml:id]')
     counts['works'] = count_xml_elements('authority-files/works.xml', '//tei:bibl[@xml:id]')
     counts['concepts'] = count_xml_elements('authority-files/concepts.xml', '//tei:category[@xml:id]')
@@ -58,6 +80,7 @@ LABELS = [
     ('lexicon.xml — Lemmata', 'lexicon_entries'),
     ('variants.xml — Eintraege', 'variants_entries'),
     ('variants.xml — Formen', 'variants_forms'),
+    ('variants.xml — normalisiert dedupliziert', 'variants_normalized'),
     ('persons.xml — Personen', 'persons'),
     ('works.xml — Werke', 'works'),
     ('concepts.xml — Kategorien', 'concepts'),
@@ -76,6 +99,17 @@ DOC_TARGETS = [
     ('docs/INDEX.md', ['corpus_files']),
     ('docs/ROADMAP.md', ['corpus_files']),
     # CLAUDE.md is intentionally vague ("~670 TEI texts"), no exact check.
+    # User-facing HTML-Seiten (#192): hartkodierte Kennzahlen driften mit
+    # jedem Ingest. Konvention (erklaert auf hilfe-daten.html):
+    # variants_forms = rohe orthographische Varianten,
+    # variants_normalized = dedupliziert — die Zahl, die Suche/Playground zeigen.
+    ('README.md', ['corpus_files', 'lexicon_entries']),
+    ('hilfe-daten.html', ['corpus_files', 'lexicon_entries',
+                          'variants_forms', 'variants_normalized']),
+    ('hilfe-korpussuche.html', ['variants_normalized']),
+    ('hilfe-playground.html', ['variants_normalized']),
+    ('hilfe-daten-beitragen.html', ['variants_forms']),
+    ('playground/index.html', ['variants_normalized']),
 ]
 
 
@@ -93,28 +127,39 @@ def find_stale_numbers(doc_path: str, current: int, key: str) -> list:
     if not Path(doc_path).exists() or current < 100:
         return []
 
-    # Strong keyword anchors (must appear immediately after the number).
+    # Strong keyword anchors (must appear right after the number; in HTML
+    # duerfen begrenzt Tags dazwischenliegen, z. B. Stat-Karten
+    # "<p>256.759</p><p>orthographische Varianten</p>").
     near_keywords = {
-        'corpus_files': r'\s*(?:TEI(?:-XML)?\s+(?:files?|Dateien)|Korpus(?:-?[Dd]ateien)?)',
-        'lexicon_entries': r'\s*Lemmata',
-        'works': r'\s*Werke',
-        'variants_entries': r'\s*(?:Variant|Eintr[äa]ge)',
-        'variants_forms': r'\s*Formen',
-        'persons': r'\s*Personen',
-        'concepts': r'\s*(?:Konzepte|Begriffe|Kategorien)',
-        'genres': r'\s*(?:Gattungen|Kategorien)',
-        'names': r'\s*(?:Namen|Kategorien)',
+        'corpus_files': r'(?:TEI(?:-XML)?\s+(?:files?|Dateien)|Korpus(?:-?[Dd]ateien)?|(?:mittelhochdeutsche\s+)?TEI-Texte)',
+        'lexicon_entries': r'Lemmata',
+        'works': r'Werke',
+        'variants_entries': r'(?:Variant|Eintr[äa]ge)',
+        'variants_forms': r'(?:Formen|orthographische\w*\s+Varianten)',
+        'variants_normalized': r'(?:normalisierte\w*\s+(?:Schreibvarianten|Varianten)|eindeutige\s+Zuordnungen)',
+        'persons': r'Personen',
+        'concepts': r'(?:Konzepte|Begriffe|Kategorien)',
+        'genres': r'(?:Gattungen|Kategorien)',
+        'names': r'(?:Namen|Kategorien)',
     }
     keywords = near_keywords.get(key)
     if not keywords:
         return []
+    # Begrenzt HTML-Tags plus Whitespace-Läufe zwischen Zahl und Anker
+    # erlauben (Stat-Karten: Zahl und Label in getrennten, eingerückten <p>).
+    anchor = re.compile(r'(?:\s+|</?[a-zA-Z][^>]{0,80}>){0,8}' + keywords)
 
     # Drift window: 2 absolute or 2% relative (whichever is larger). Die
     # fruehere 50er-Kappung machte das Audit blind fuer jeden Backfill/Ingest
     # >50 Eintraege (der +125-Lemma-Backfill #115 passierte unbemerkt, Review
     # PR #156). Gegen Fehlalarme wie "100 Lemmata" schuetzt nicht die Kappung,
     # sondern der strikte Keyword-Anchor plus die relative Distanz.
-    window_size = max(2, int(current * 0.02))
+    # Die Varianten-Zahlen haben hochpraezise Anker („orthographische
+    # Varianten", „normalisierte Schreibvarianten") — dort darf das Fenster
+    # weit sein, sonst bleibt Drift wie 175.910 → 256.759 (#192, -31 %)
+    # unsichtbar. Fuer generische Anker bleibt das enge 2 %-Fenster.
+    rel = 0.5 if key in ('variants_forms', 'variants_normalized') else 0.02
+    window_size = max(2, int(current * rel))
     content = Path(doc_path).read_text(encoding='utf-8')
 
     findings = []
@@ -126,10 +171,14 @@ def find_stale_numbers(doc_path: str, current: int, key: str) -> list:
             continue
         if num == current or abs(num - current) > window_size:
             continue
-        # Keyword must appear immediately after (within ~3 chars: space, slash,
-        # comma, closing bracket are all ok).
-        suffix = content[m.end():m.end() + 25]
-        if re.match(keywords, suffix):
+        # Bewusst gerundete Angaben („~257.000 Formen", „rund 257.000") sind
+        # kein Drift — ueberspringen.
+        prefix = content[max(0, m.start() - 8):m.start()]
+        if re.search(r'(?:~|rund\s|ca\.\s|etwa\s|über\s)$', prefix):
+            continue
+        # Keyword must appear right after the number (bounded markup allowed).
+        suffix = content[m.end():m.end() + 300]
+        if anchor.match(suffix):
             line_no = content[:m.start()].count('\n') + 1
             # Show a bit of context centered on the match
             ctx_start = max(0, m.start() - 25)
@@ -171,7 +220,8 @@ def main():
                 total_drift += len(findings)
 
     if total_drift == 0:
-        print('  No drift detected against scanned docs (data counts only).')
+        print('  No drift detected against scanned docs + user-facing HTML pages')
+        print('  (data counts only).')
         print('  NB: covers corpus/authority data counts; does NOT check code-derived')
         print('      counts (playground tools, ui/ module counts, router entry points).')
     else:


### PR DESCRIPTION
Die im Issue gelisteten Zahlen-Fundstellen waren durch den Zähler-Sweep `f999462ec` (02.07.) bereits weitgehend aktuell — dieser PR schließt die Reste ab:

## Changes
- **hilfe-playground.html + playground/index.html**: 234.244 heißt jetzt einheitlich „normalisierte Schreibvarianten" (war fälschlich als „orthographische Varianten" bzw. „Varianten" beschriftet). Konvention bleibt wie auf `hilfe-daten.html` erklärt: **256.759** = rohe orthographische Varianten, **234.244** = normalisiert dedupliziert (die Zahl, die Suche/Playground anzeigen; heute gegen `variants.xml` + `mhg_normalizer` verifiziert).
- **doc-count-audit.py (Drift-Prävention, Issue-Task 3)**: neuer Zähler `variants_normalized`; der Drift-Scan deckt jetzt auch README.md und die fünf User-facing HTML-Seiten ab. Dafür: begrenzte HTML-Tags zwischen Zahl und Anker erlaubt (Stat-Karten), Guard für bewusst gerundete Angaben („~257.000"), weites Fenster (50 %) für die präzise verankerten Varianten-Zahlen — ein Drift wie 175.910 → 256.759 wäre damit sichtbar geworden.
- **Negativ-Test verifiziert**: geplantete Alt-Zahlen (175.910 / 43.754 / 192.472) → Audit meldet sie, `--check` Exit 1; sauberer Lauf Exit 0.
- **Obsidian-Vault** (extern, unversioniert): die zwei zitierten Alt-Zahlen (175.910 in „MHDBDB Next und Playground", ~192.000 in „TEI-XML") direkt korrigiert, mit Standdatum.

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)