### PR TITLE
#189 Punkt 2: Korpusweite Quantifizierung unannotierter Wortformen (Diagnose-Skript)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,9 @@ scripts/sync/.zotero_cache.json
 
 # Audit script outputs (regenerated on each run)
 scripts/audit/*.json
+# CSV-Reports von quantify-unannotated-tokens.py (#189) — disposable Diagnose,
+# landen default in data/audit/ und gehoeren nie in den Index-Datenbestand
+data/audit/
 # Ausnahme: die #152-Ratschen-Baseline ist KEIN disposable Report, sie ist
 # die committete Referenzmenge des CI-Gates (check-authority-cross-refs.py)
 !scripts/audit/lexicon-baseline.json

--- a/scripts/audit/quantify-unannotated-tokens.py
+++ b/scripts/audit/quantify-unannotated-tokens.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""#189: Korpusweite Quantifizierung unannotierter Wortformen (Diagnose, read-only).
+
+Hintergrund: Wortformen ohne @lemmaRef (und meist ohne @pos) sind fuer alle
+Lemma-Features unsichtbar (GWTK-Pilotfall rott/rotten/rotte, jungen/junger).
+Dieses Skript vermisst den Bestand und baut eine Priorisierungsliste:
+
+1. Pro Text: annotierte vs. unannotierte <w> im <body> (Coverage).
+2. Korpusweit: unannotierte Oberflaechenformen aggregiert (MHG-normalisiert).
+3. Ambiguitaets-Flag: Formen, die zugleich als annotierte Schreibform im
+   Korpus vorkommen (= Homograph eines existierenden Lemmas) — genau die
+   Faelle, in denen das Alt-System mutmasslich bewusst NICHT annotiert hat.
+
+Output: CSV-Reports + Konsolen-Summary. Keine Korpus-Aenderung.
+
+Usage:
+    python scripts/audit/quantify-unannotated-tokens.py [--out-dir <dir>] [--top 50]
+"""
+import argparse
+import csv
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+from lxml import etree
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+PROJECT_ROOT = SCRIPT_DIR.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / 'scripts'))
+from mhg_normalizer import normalize_mhg  # noqa: E402
+
+TEI = '{http://www.tei-c.org/ns/1.0}'
+TEI_DIR = PROJECT_ROOT / 'tei'
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--out-dir', default=str(PROJECT_ROOT / 'data' / 'audit'))
+    ap.add_argument('--top', type=int, default=50)
+    args = ap.parse_args()
+
+    per_text = []                      # (sigle, total_w, unannot, coverage)
+    unannot_forms = Counter()          # normalized form -> count
+    unannot_form_texts = defaultdict(set)
+    unannot_examples = {}              # normalized form -> ein Original-Beispiel
+    annotated_forms = set()            # normalisierte Formen MIT lemmaRef
+
+    files = sorted(TEI_DIR.glob('*.tei.xml'))
+    for i, fp in enumerate(files):
+        if (i + 1) % 100 == 0:
+            print(f'  {i + 1}/{len(files)}...', flush=True)
+        sigle = fp.name.replace('.tei.xml', '')
+        tree = etree.parse(str(fp))
+        body = tree.find(f'.//{TEI}body')
+        if body is None:
+            continue
+        total = unannot = 0
+        for w in body.iter(f'{TEI}w'):
+            form = ''.join(w.itertext()).strip()
+            if not form:
+                continue
+            total += 1
+            norm = normalize_mhg(form.lower())
+            if w.get('lemmaRef'):
+                annotated_forms.add(norm)
+            else:
+                unannot += 1
+                unannot_forms[norm] += 1
+                unannot_form_texts[norm].add(sigle)
+                unannot_examples.setdefault(norm, form)
+        coverage = (total - unannot) / total * 100 if total else 100.0
+        per_text.append((sigle, total, unannot, coverage))
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    per_text.sort(key=lambda r: r[2], reverse=True)
+    with open(out_dir / '189-unannotated-per-text.csv', 'w', encoding='utf-8-sig', newline='') as f:
+        w = csv.writer(f, delimiter=';')
+        w.writerow(['sigle', 'tokens_w_gesamt', 'unannotiert', 'coverage_prozent'])
+        for sigle, total, unannot, cov in per_text:
+            w.writerow([sigle, total, unannot, f'{cov:.2f}'])
+
+    with open(out_dir / '189-unannotated-forms.csv', 'w', encoding='utf-8-sig', newline='') as f:
+        w = csv.writer(f, delimiter=';')
+        w.writerow(['form_normalisiert', 'beispiel_original', 'vorkommen',
+                    'texte', 'homograph_zu_annotierter_form'])
+        for norm, count in unannot_forms.most_common():
+            w.writerow([norm, unannot_examples[norm], count,
+                        len(unannot_form_texts[norm]),
+                        'ja' if norm in annotated_forms else 'nein'])
+
+    total_w = sum(r[1] for r in per_text)
+    total_un = sum(r[2] for r in per_text)
+    ambig = [(n, c) for n, c in unannot_forms.most_common() if n in annotated_forms]
+    print(f'\n<w>-Tokens gesamt: {total_w:,} | unannotiert: {total_un:,} '
+          f'({total_un / total_w * 100:.2f} %) | unannotierte Formen (Types): {len(unannot_forms):,}')
+    print(f'Davon homograph zu annotierten Formen: {len(ambig):,} Types, '
+          f'{sum(c for _, c in ambig):,} Tokens — die Priorisierungskandidaten (#189)')
+    print(f'\nTop {args.top} ambige Formen (Vorkommen):')
+    for norm, count in ambig[:args.top]:
+        print(f'  {count:>7,}  {unannot_examples[norm]}  ({len(unannot_form_texts[norm])} Texte)')
+    print(f'\nTop 15 Texte nach unannotierten Tokens:')
+    for sigle, total, unannot, cov in per_text[:15]:
+        print(f'  {unannot:>8,}  {sigle:<6} (Coverage {cov:.1f} %)')
+    print(f'\nReports: {out_dir}')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Issue #189, Punkt 2 (Quantifizierung) — ohne Closes-Trailer: Punkt 1 (GWTK-Pilot-Disambiguierung) und Punkt 3 (Lifecycle nach Nachannotation) bleiben offen.

Neues Diagnose-Skript `scripts/audit/quantify-unannotated-tokens.py` (read-only, kein Korpus-Eingriff): vermisst korpusweit die `<w>`-Tokens ohne `@lemmaRef` und baut die Priorisierungsgrundlage für die Nachannotation.

## Was es liefert

1. **Pro Text:** annotierte vs. unannotierte `<w>` im `<body>` (Coverage-Ranking).
2. **Korpusweit:** unannotierte Oberflächenformen MHG-normalisiert aggregiert (Vorkommen, Textverbreitung, ein Original-Beispiel je Form).
3. **Ambiguitäts-Flag:** Formen, die zugleich als annotierte Schreibform im Korpus vorkommen (Homograph eines existierenden Lemmas) — genau die Fälle, in denen das Alt-System mutmaßlich bewusst nicht annotiert hat (GWTK-Muster *rott/rotten*, *jungen/junger*).

Output: zwei CSV-Reports (UTF-8-BOM, Semikolon) nach `data/audit/` + Konsolen-Summary. `data/audit/` ist neu in `.gitignore` (Reports sind disposable Diagnose und gehören nie in den Index-Datenbestand).

## Ergebnisse des ersten Laufs

9.432.130 `<w>`-Tokens, davon 1.898.683 ohne `@lemmaRef` (20,13 %); 10.813 unannotierte Types, davon 6.201 homograph zu annotierten Formen — diese ambigen Types stellen 1.869.115 Tokens, also 98,4 % der unannotierten Masse. Die Top-Formen sind funktionswort-dominiert (in/ir/er/sî/man); die forschungsrelevante Inhaltswort-Schicht (500–8.000 Vorkommen) umfasst 359 Formen, angeführt von sere, stat, nôt und **minne (6.982 unsichtbare Belege in 262 Texten)**.

Die vollständige Priorisierungsliste steht als Kommentar in #189.

## Verifikation

- `py_compile` grün; Lauf über alle 667 Texte in ~4 min
- GWTK-Gegenprobe gegen die Issue-Zahlen: Coverage 64,7 % = exakt der Issue-Befund; alle sechs Pilotformen (rott/rotten/rotte/roten/jungen/junger) als homograph geflaggt
- Playwright: 205/205 grün (15,2 min) (Skript + .gitignore, Site unberührt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vbmqYTNTYyD7S9gcCdJYc
