### PR TITLE
#106 Punkt 2: Versendings-Profil als zwölftes TEI-Analyse-Werkzeug (mit Reim-Druck)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -226,7 +226,7 @@ playground/js/ui/
 - Easier testing and maintenance
 - Net reduction: 5,536 lines removed
 
-**Playground TEI-Modul-Konvention:** alle zwölf Module unter `playground/js/ui/tei/` (außer `multi-lemma-search.js` als dokumentierter Modal-Outlier) folgen dem gleichen Constructor/`show()`/`render()`-Pattern mit Thunks statt direkter Daten-Referenzen, state-driven `renderBody()`, pro-Modul-Escape-Helpers und MessageChannel-Yield bei großen Aggregationen. Sonderfall `naming-explorer.js` (#59): hängt nicht am Corpus-Index, sondern lädt seinen eigenen kleinen Index (`data/naming-index.json.gz`) lazy per fetch+pako ohne IndexedDB-Cache. Pattern ist als Template in [DESIGN.md §Playground TEI-Analysis Module Pattern](DESIGN.md#playground-tei-analysis-module-pattern) dokumentiert.
+**Playground TEI-Modul-Konvention:** alle dreizehn Module unter `playground/js/ui/tei/` (außer `multi-lemma-search.js` als dokumentierter Modal-Outlier) folgen dem gleichen Constructor/`show()`/`render()`-Pattern mit Thunks statt direkter Daten-Referenzen, state-driven `renderBody()`, pro-Modul-Escape-Helpers und MessageChannel-Yield bei großen Aggregationen. Sonderfall `naming-explorer.js` (#59): hängt nicht am Corpus-Index, sondern lädt seinen eigenen kleinen Index (`data/naming-index.json.gz`) lazy per fetch+pako ohne IndexedDB-Cache. Pattern ist als Template in [DESIGN.md §Playground TEI-Analysis Module Pattern](DESIGN.md#playground-tei-analysis-module-pattern) dokumentiert.
 
 **Authority Explorers:**
 Each explorer follows consistent pattern:

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -164,7 +164,7 @@ Browse and search six controlled vocabularies with consistent interface patterns
 
 ### TEI Text Analysis
 
-Corpus-wide text analysis using pre-built indexes. Elf Werkzeuge in elf Playground-Einträgen (Multi-Lemma bietet Dokument-, Proximity- und Vers-Modus in einem Eintrag), alle direkt im Results-Panel als in-place Form + Body (außer Multi-Lemma als Modal).
+Corpus-wide text analysis using pre-built indexes. Zwölf Werkzeuge in zwölf Playground-Einträgen (Multi-Lemma bietet Dokument-, Proximity- und Vers-Modus in einem Eintrag), alle direkt im Results-Panel als in-place Form + Body (außer Multi-Lemma als Modal).
 
 **Multi-Lemma Document Search:**
 - Input multiple lemmata (space-separated or one per line)
@@ -258,6 +258,13 @@ Corpus-wide text analysis using pre-built indexes. Elf Werkzeuge in elf Playgrou
 - Pro Partner: Reimpaar-Zahl, Texte als Sigle-Chips mit Paarzahl, „→ Belege" klappt die gezählten Verspaare direkt in der Tabelle auf: beide Verse als vollständiger `<l>`-Inhalt (lazy per TEI-Fetch; Highlight-Mapping über CONTRACTS-§B-Positionszählung, damit `lineEnds[]`-Positionen auf die richtigen Wörter zeigen), markierte Reimwörter, Versangabe aus `<l n>`, Reader-Deep-Link (`position=`); paginiert zu 10, Cap 1000 gespeicherte Verspaare pro Partner. (Vorher nur Link in den Nähe-Modus der Multi-Lemma-Suche mit Distanz 15 — zeigte auch Kookkurrenzen abseits der Versenden, also keine Reime; KZW-Report 2026-07-09)
 - Async-Chunking + Abort-Token (Pattern wie #107), Prosa (leere `lineEnds`) wird übersprungen
 - Bewusste Grenzen der Minimalvariante (Issue #106): lemma- statt token-basiert (reimende Flexionsform kann abweichen), strukturell statt phonetisch, Kreuzreime (ABAB) entgehen dem ±1-Scan; Original-Token-Variante bräuchte Index-Erweiterung (`lineEndWords[]`), phonetische Klassifikation ist #109-Folgearbeit
+
+**Versendings-Profil (#106 Punkt 2):**
+- Top-N häufigste Lemmata am Versende — Scope wählbar: Gesamtkorpus, Autor*in (optgroup) oder Einzeltext
+- Datenpfad: `text.words[lineEnds[i]]` je Vers (Corpus-Index v4.1.x), kein neuer Build-Schritt
+- Spalten: Versende-Belege (absolut), Anteil an allen Versenden des Scopes, **Reim-Druck** = Anteil der Vorkommen des Lemmas am Versende vs. gesamt (#106 Punkt 3: hoher Wert = reimgetrieben, niedriger = semantisch motiviert)
+- Funktionswort-Filter (gleiche POS-Menge wie Wortfrequenz/Hapax), Lemma-Links auf die Lemma-Seiten
+- Nur Versdichtung (leere `lineEnds` -> übersprungen); Use Case aus dem Issue: Reim-Stil-Vergleich Wolfram/Hartmann/Gottfried
 
 **Erweiterte Figurenbezeichnungen (#59, Beta):**
 - Kuratierte Bezeichnungspraktiken jenseits des Eigennamens für vier Werke (ENE, IW, ROL, TRO) aus dem Dissertationsprojekt Naming-analysis von Linda Beutel-Thurow

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -43,7 +43,7 @@ Simple search and reading interface optimized for students and general users:
 ### Playground (Research Interface)
 Advanced exploration tools for medievalists and digital humanities researchers:
 
-- **17 Search Entry Points** - 6 authority file explorers + 11 TEI analysis tools
+- **18 Search Entry Points** - 6 authority file explorers + 12 TEI analysis tools
 - **Multi-Lemma Search** - Find texts containing multiple lemmata with:
   - Document-level search (all lemmata anywhere in text)
   - Proximity search (co-occurrence within N words)
@@ -51,7 +51,7 @@ Advanced exploration tools for medievalists and digital humanities researchers:
   - 3-stage lemma resolution (exact match → variants → partial match)
   - Color-coded results with clickable navigation to reading view
 - **Authority Exploration** - Browse and search persons, works, lemmata, concepts, genres, names
-- **TEI Analysis** - Eleven analysis tools over the pre-loaded MHDBDB corpus: multi-lemma search (document + proximity + same-verse), verse-position lemma search, word frequency, corpus-wide hapax legomena, text statistics, lemma distribution, concept distribution, text comparison, co-occurrence ranking, rhyme dictionary, curated character-naming explorer (4 works, Beta)
+- **TEI Analysis** - Twelve analysis tools over the pre-loaded MHDBDB corpus: multi-lemma search (document + proximity + same-verse), verse-position lemma search, word frequency, corpus-wide hapax legomena, text statistics, lemma distribution, concept distribution, text comparison, co-occurrence ranking, rhyme dictionary, verse-ending profile, curated character-naming explorer (4 works, Beta)
 
 ## Technical Stack
 

--- a/hilfe-playground.html
+++ b/hilfe-playground.html
@@ -192,7 +192,7 @@
             </p>
             <ol class="space-y-2 text-sm text-slate-700 mb-4 ml-4 list-decimal list-inside">
                 <li><strong>Korpus-Browser</strong> (links) – alle 667 Texte sind standardmäßig aktiv. Hier schränken Sie die Analyse auf bestimmte Werke, Autor*innen oder Gattungen ein.</li>
-                <li><strong>Abfragen</strong> (Mitte) – sechs Authority-File-Einstiegspunkte plus elf TEI-Analysewerkzeuge: Multi-Lemma-Suche, Lemmasuche nach Versposition, Wortfrequenz-Analyse, Echte Hapaxlegomena, Text-Statistiken, Lemma-Verteilung, Begriffs-Verteilung, Textvergleich, Kookkurrenz-Ranking, Reim-Wörterbuch und Erweiterte Figurenbezeichnungen (Beta).</li>
+                <li><strong>Abfragen</strong> (Mitte) – sechs Authority-File-Einstiegspunkte plus zwölf TEI-Analysewerkzeuge: Multi-Lemma-Suche, Lemmasuche nach Versposition, Wortfrequenz-Analyse, Echte Hapaxlegomena, Text-Statistiken, Lemma-Verteilung, Begriffs-Verteilung, Textvergleich, Kookkurrenz-Ranking, Reim-Wörterbuch, Versendings-Profil und Erweiterte Figurenbezeichnungen (Beta).</li>
                 <li><strong>Ergebnisse</strong> (rechts) – die Trefferliste zur aktuellen Abfrage, mit farbkodiertem Highlighting und Klick-Navigation in die Leseansicht.</li>
             </ol>
             <p class="text-slate-700 leading-relaxed">
@@ -444,6 +444,22 @@
                     Die Heuristik ist strukturell und lemma-basiert: Kreuzreime (ABAB) und rein
                     klangliche Übereinstimmungen jenseits der Schriftform entgehen ihr; Prosatexte
                     werden ignoriert.
+                </p>
+            </div>
+
+            <div class="bg-white rounded-xl border border-slate-200 p-5 my-4">
+                <h3 class="text-base font-semibold text-slate-900 mb-2">Versendings-Profil</h3>
+                <p class="text-sm text-slate-700 leading-relaxed">
+                    Zeigt die häufigsten Lemmata am Versende – für das Gesamtkorpus, eine Autorin
+                    bzw. einen Autor oder einen einzelnen Text. Damit lassen sich Reim-Stile
+                    vergleichen: Was reimt Wolfram bevorzugt, was Hartmann? Neben der absoluten
+                    Zahl der Versende-Belege nennt die Tabelle den Anteil an allen Versenden des
+                    gewählten Bereichs sowie den <strong>Reim-Druck</strong>: den Anteil der
+                    Vorkommen eines Lemmas, die am Versende stehen. Ein Lemma mit 70 % Ende-Anteil
+                    ist stark reimgetrieben, eines mit 5 % eher semantisch motiviert. Der
+                    Funktionswort-Filter blendet Pronomen, Artikel und Hilfsverben aus. Wie alle
+                    Vers-Werkzeuge wertet das Profil nur Versdichtung aus (rund 90 % des Korpus);
+                    Prosa-Texte werden übersprungen.
                 </p>
             </div>
 

--- a/playground/index.html
+++ b/playground/index.html
@@ -258,6 +258,15 @@
                                 <span class="text-xs font-normal text-slate-500 mt-0.5">Reimpartner-Lemmata an benachbarten Versenden</span>
                             </span>
                         </button>
+                        <button id="showVerseEndingProfileBtn" class="w-full rounded-xl border border-slate-200 bg-white px-4 py-2 text-left text-sm font-medium text-slate-700 transition hover:border-brand-400 hover:text-brand-700 flex items-center gap-2.5">
+                            <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M10 10h10M4 14h16M10 18h10"></path>
+                            </svg>
+                            <span class="flex flex-col items-start leading-tight">
+                                <span>Versendings-Profil</span>
+                                <span class="text-xs font-normal text-slate-500 mt-0.5">Top-Lemmata am Versende pro Korpus, Autor*in oder Text</span>
+                            </span>
+                        </button>
                         <button id="showWordFrequencyBtn" class="w-full rounded-xl border border-slate-200 bg-white px-4 py-2 text-left text-sm font-medium text-slate-700 transition hover:border-brand-400 hover:text-brand-700 flex items-center gap-2.5">
                             <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>

--- a/playground/js/playground-main.js
+++ b/playground/js/playground-main.js
@@ -23,6 +23,7 @@ import { TextComparison } from './ui/tei/text-comparison.js';
 import { CooccurrenceRanking } from './ui/tei/cooccurrence-ranking.js';
 import { RhymeDictionary } from './ui/tei/rhyme-dictionary.js';
 import { HapaxLegomenaAnalyzer } from './ui/tei/hapax-legomena.js';
+import { VerseEndingProfileAnalyzer } from './ui/tei/verse-ending-profile.js';
 import { NamingExplorer } from './ui/tei/naming-explorer.js';
 
 // Wire up file display helpers for progress.js
@@ -87,6 +88,7 @@ class MHDBDBPlayground {
         this.ui.cooccurrenceRanking = new CooccurrenceRanking(corpusTextsThunk, this.authorityManager);
         this.ui.rhymeDictionary = new RhymeDictionary(corpusTextsThunk, this.authorityManager);
         this.ui.hapaxLegomena = new HapaxLegomenaAnalyzer(corpusTextsThunk, this.authorityData);
+        this.ui.verseEndingProfile = new VerseEndingProfileAnalyzer(corpusTextsThunk, this.authorityData);
         this.ui.namingExplorer = new NamingExplorer('../data');
 
         this.init();
@@ -488,6 +490,7 @@ class MHDBDBPlayground {
             { id: 'showCooccurrenceRankingBtn', handler: () => navigate('cooccurrence-ranking') },
             { id: 'showRhymeDictionaryBtn', handler: () => navigate('rhyme-dictionary') },
             { id: 'showHapaxLegomenaBtn', handler: () => navigate('hapax-legomena') },
+            { id: 'showVerseEndingProfileBtn', handler: () => navigate('verse-ending-profile') },
             { id: 'showNamingExplorerBtn', handler: () => navigate('naming') }
         ];
 

--- a/playground/js/ui/core/router.js
+++ b/playground/js/ui/core/router.js
@@ -11,7 +11,7 @@
  *   authors, works, lemmata, concepts, genres, names,
  *   multi-lemma, verse-position, word-frequency, text-statistics, lemma-distribution,
  *   concept-distribution, text-comparison, cooccurrence-ranking, rhyme-dictionary,
- *   hapax-legomena, naming
+ *   hapax-legomena, verse-ending-profile, naming
  *
  * Example URLs:
  *   playground/#authors                          → open Autoren-Explorer
@@ -26,6 +26,7 @@
  *   playground/#cooccurrence-ranking             → open Kookkurrenz-Ranking
  *   playground/#rhyme-dictionary                 → open Reim-Wörterbuch
  *   playground/#hapax-legomena                   → open Echte Hapaxlegomena
+ *   playground/#verse-ending-profile             → open Versendings-Profil
  *   playground/#naming                           → open Erweiterte Figurenbezeichnungen (Beta)
  */
 
@@ -46,6 +47,7 @@ const ROUTES = {
   'cooccurrence-ranking': ()     => window.playground.ui.cooccurrenceRanking.show(),
   'rhyme-dictionary':   ()       => window.playground.ui.rhymeDictionary.show(),
   'hapax-legomena':     ()       => window.playground.ui.hapaxLegomena.show(),
+  'verse-ending-profile': ()     => window.playground.ui.verseEndingProfile.show(),
   'naming':             ()       => window.playground.ui.namingExplorer.show(),
 };
 

--- a/playground/js/ui/tei/verse-ending-profile.js
+++ b/playground/js/ui/tei/verse-ending-profile.js
@@ -1,0 +1,291 @@
+/**
+ * MHDBDB Playground - Versendings-Profil
+ *
+ * Top-N häufigste Versende-Lemmata pro Gesamtkorpus, Autor oder Text
+ * (#106 Punkt 2). Datenbasis sind die lineEnds[]-Arrays des Corpus-Index
+ * v4.1.0+ (#47.3): text.words[lineEnds[i]] ist das Lemma am Ende von Vers i.
+ * Kein neuer Build-Schritt. Prosa-Texte (leere lineEnds) werden übersprungen.
+ *
+ * Die Spalte „Reim-Druck" setzt die Versende-Belege eines Lemmas ins
+ * Verhältnis zu allen seinen Vorkommen im gewählten Scope (#106 Punkt 3:
+ * ein Lemma mit hohem Ende-Anteil ist stark reimgetrieben, eines mit
+ * niedrigem eher semantisch motiviert).
+ */
+
+import { buildTextLabelDisambiguator } from '../core/ui-helpers.js';
+import { FUNCTION_WORD_POS } from './word-frequency.js';
+
+const TOP_N_OPTIONS = [20, 50, 100, 200];
+const DEFAULT_TOP_N = 50;
+
+export class VerseEndingProfileAnalyzer {
+  /**
+   * @param {() => Array} getCorpusTexts  thunk returning the current corpus
+   *   texts array (same indirection as word-frequency.js).
+   * @param {object} authorityData
+   */
+  constructor(getCorpusTexts, authorityData) {
+    this.getCorpusTexts = getCorpusTexts;
+    this.authorityData = authorityData;
+    this._lemmaById = null;
+    this._lastProfile = null;
+    this.state = {
+      scope: 'corpus',
+      topN: DEFAULT_TOP_N,
+      hideFunctionWords: false
+    };
+  }
+
+  getLemmaById(id) {
+    if (!this._lemmaById) {
+      const lemmata = this.authorityData?.lemmata || [];
+      this._lemmaById = new Map(lemmata.map(l => [l.id, l]));
+    }
+    return this._lemmaById.get(id);
+  }
+
+  // Nur Versdichtung zählt: Texte ohne <l>-Grenzen liefern keine Versenden.
+  verseTexts() {
+    return (this.getCorpusTexts() || []).filter(t => t.lineEnds && t.lineEnds.length > 0);
+  }
+
+  scopedTexts(scope) {
+    const texts = this.verseTexts();
+    if (scope === 'corpus') return texts;
+    if (scope.startsWith('author:')) {
+      const author = scope.slice('author:'.length);
+      return texts.filter(t => (t.author || 'Unbekannt') === author);
+    }
+    return texts.filter(t => t.id === scope);
+  }
+
+  computeProfile(scope) {
+    const texts = this.scopedTexts(scope);
+    if (texts.length === 0) return null;
+
+    const endCounts = new Map();   // lemmaId -> Belege am Versende
+    const totalCounts = new Map(); // lemmaId -> alle Vorkommen im Scope
+    let verseCount = 0;
+
+    for (const text of texts) {
+      verseCount += text.lineEnds.length;
+      for (const endIdx of text.lineEnds) {
+        const lemmaId = text.words[endIdx];
+        if (!lemmaId) continue;
+        endCounts.set(lemmaId, (endCounts.get(lemmaId) || 0) + 1);
+      }
+      for (const [lemmaId, positions] of Object.entries(text.lemmata || {})) {
+        totalCounts.set(lemmaId, (totalCounts.get(lemmaId) || 0) + positions.length);
+      }
+    }
+
+    let scopeLabel, scopeMeta;
+    if (scope === 'corpus') {
+      scopeLabel = 'Gesamtkorpus (Versdichtung)';
+      scopeMeta = `${texts.length.toLocaleString('de-DE')} Vers-Texte`;
+    } else if (scope.startsWith('author:')) {
+      scopeLabel = scope.slice('author:'.length);
+      scopeMeta = `${texts.length.toLocaleString('de-DE')} Vers-Text${texts.length === 1 ? '' : 'e'}`;
+    } else {
+      const t = texts[0];
+      scopeLabel = t.title || t.id;
+      scopeMeta = t.author ? `${t.id} • ${t.author}` : t.id;
+    }
+
+    return { endCounts, totalCounts, verseCount, scopeLabel, scopeMeta };
+  }
+
+  async show() {
+    const texts = this.getCorpusTexts();
+    if (!texts || texts.length === 0) {
+      this.renderError('Korpus ist noch nicht geladen. Bitte einen Moment warten und Button erneut klicken.');
+      return;
+    }
+    this._lastProfile = this.computeProfile(this.state.scope);
+    this.render();
+  }
+
+  render() {
+    const container = document.getElementById('resultsContainer');
+    if (!container) return;
+
+    container.innerHTML = `
+      <div class="space-y-4">
+        ${this.renderToolbar()}
+        ${this.renderTable()}
+      </div>
+    `;
+    this.attachToolbarHandlers();
+  }
+
+  renderToolbar() {
+    const texts = [...this.verseTexts()].sort((a, b) =>
+      (a.id || '').localeCompare(b.id || '', 'de')
+    );
+    const disambig = buildTextLabelDisambiguator(texts, this.authorityData?.works || []);
+
+    // Autoren mit mindestens einem Vers-Text, alphabetisch
+    const authors = [...new Set(texts.map(t => t.author || 'Unbekannt'))]
+      .sort((a, b) => a.localeCompare(b, 'de'));
+
+    const authorOptions = authors.map(a => {
+      const val = `author:${a}`;
+      return `<option value="${escapeHtml(val)}"${this.state.scope === val ? ' selected' : ''}>${escapeHtml(a)}</option>`;
+    }).join('');
+    const textOptions = texts.map(t => {
+      const label = `${escapeHtml(t.id)}${t.title ? '-' + escapeHtml(t.title + (disambig.get(t.id) || '')) : ''}`;
+      return `<option value="${escapeHtml(t.id)}"${this.state.scope === t.id ? ' selected' : ''}>${label}</option>`;
+    }).join('');
+
+    const scopeOptions = `
+      <option value="corpus"${this.state.scope === 'corpus' ? ' selected' : ''}>Gesamtkorpus (${texts.length} Vers-Texte)</option>
+      <optgroup label="Autor*in">${authorOptions}</optgroup>
+      <optgroup label="Text">${textOptions}</optgroup>
+    `;
+
+    const topNOptions = TOP_N_OPTIONS
+      .map(n => `<option value="${n}"${this.state.topN === n ? ' selected' : ''}>Top ${n}</option>`)
+      .join('');
+
+    return `
+      <div class="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+        <h3 class="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-500">Versendings-Profil</h3>
+        <div class="grid gap-3 sm:grid-cols-2">
+          <label class="block">
+            <span class="text-xs font-medium text-slate-600">Korpus / Autor*in / Text</span>
+            <select id="vepScope" class="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm focus:border-brand-400 focus:outline-none">${scopeOptions}</select>
+          </label>
+          <label class="block">
+            <span class="text-xs font-medium text-slate-600">Anzahl</span>
+            <select id="vepTopN" class="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm focus:border-brand-400 focus:outline-none">${topNOptions}</select>
+          </label>
+        </div>
+        <label class="mt-3 flex items-center gap-2 text-sm text-slate-700 cursor-pointer">
+          <input type="checkbox" id="vepHideFunc" ${this.state.hideFunctionWords ? 'checked' : ''} class="w-4 h-4 rounded border-slate-300 text-brand-600 focus:ring-brand-500" />
+          <span>Funktionswörter ausblenden <span class="text-xs text-slate-500">(der/die/daz, ich/er/sie, in/zuo, und/oder, niht, hân/wesen, …)</span></span>
+        </label>
+        <p class="mt-3 text-xs text-slate-500">
+          Zählt das Lemma am letzten Wort jedes Verses (<code>lineEnds[]</code>, Corpus-Index v4.1.0+).
+          „Reim-Druck" = Anteil der Vorkommen dieses Lemmas, die am Versende stehen — hohe Werte deuten
+          auf reimgetriebene Verwendung. Nur Versdichtung; Prosa-Texte werden übersprungen.
+        </p>
+      </div>
+    `;
+  }
+
+  renderTable() {
+    const data = this._lastProfile;
+    if (!data) {
+      return '<div class="rounded-2xl border border-dashed border-slate-200 bg-slate-50/70 p-6 text-center text-sm text-slate-500">Keine Daten für diese Auswahl (nur Versdichtung wird ausgewertet).</div>';
+    }
+    const { endCounts, totalCounts, verseCount, scopeLabel, scopeMeta } = data;
+
+    const allEntries = Array.from(endCounts.entries()).map(([id, endCount]) => {
+      const total = totalCounts.get(id) || endCount;
+      return {
+        id,
+        endCount,
+        shareOfVerses: verseCount > 0 ? (endCount / verseCount) * 100 : 0,
+        rhymePressure: total > 0 ? (endCount / total) * 100 : 0
+      };
+    });
+    const entries = this.state.hideFunctionWords
+      ? allEntries.filter(e => {
+          const l = this.getLemmaById(e.id);
+          const tags = l?.posAll
+            || (l?.pos ? String(l.pos).trim().split(/\s+/) : []);
+          if (tags.length === 0) return true;
+          return !tags.some(t => FUNCTION_WORD_POS.has(t));
+        })
+      : allEntries;
+    entries.sort((a, b) => b.endCount - a.endCount);
+    const top = entries.slice(0, this.state.topN);
+    const hiddenCount = allEntries.length - entries.length;
+
+    const rows = top.map((e, idx) => {
+      const lemma = this.getLemmaById(e.id);
+      const lemmaText = lemma ? lemma.lemma : e.id;
+      const cleanId = e.id.replace(/^lemma_/, '');
+      const posLabel = (lemma?.posAll || (lemma?.pos ? [lemma.pos] : [])).join(' ');
+      const pos = posLabel
+        ? `<span class="ml-2 rounded bg-slate-100 px-1.5 py-0.5 text-xs font-mono text-slate-600">${escapeHtml(posLabel)}</span>`
+        : '';
+      return `
+        <tr class="border-t border-slate-100 hover:bg-brand-50/50">
+          <td class="px-3 py-2 text-xs text-slate-500 tabular-nums">${idx + 1}</td>
+          <td class="px-3 py-2">
+            <a href="../lemma/?id=${escapeHtml(cleanId)}" target="_blank" rel="noopener" class="font-medium text-brand-700 hover:underline">${escapeHtml(lemmaText)}</a>
+            ${pos}
+          </td>
+          <td class="px-3 py-2 text-right tabular-nums text-sm text-slate-700">${e.endCount.toLocaleString('de-DE')}</td>
+          <td class="px-3 py-2 text-right tabular-nums text-sm text-slate-700">${e.shareOfVerses.toFixed(2)} %</td>
+          <td class="px-3 py-2 text-right tabular-nums text-sm text-slate-700">${e.rhymePressure.toFixed(1)} %</td>
+        </tr>
+      `;
+    }).join('');
+
+    return `
+      <div class="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+        <header class="flex items-center justify-between border-b border-slate-200 bg-slate-50/80 px-4 py-3">
+          <div>
+            <div class="text-sm font-semibold text-slate-800">${escapeHtml(scopeLabel)}</div>
+            <div class="text-xs text-slate-500">${escapeHtml(scopeMeta)}</div>
+          </div>
+          <div class="text-right text-xs text-slate-500">
+            <div>${endCounts.size.toLocaleString('de-DE')} verschiedene Versende-Lemmata${hiddenCount > 0 ? ` <span class="text-slate-400">(–${hiddenCount.toLocaleString('de-DE')} ausgeblendet)</span>` : ''}</div>
+            <div>${verseCount.toLocaleString('de-DE')} Verse</div>
+          </div>
+        </header>
+        <table class="w-full">
+          <thead class="text-xs uppercase tracking-wide text-slate-500">
+            <tr class="bg-white">
+              <th class="w-12 px-3 py-2 text-left">#</th>
+              <th class="px-3 py-2 text-left">Lemma</th>
+              <th class="px-3 py-2 text-right">Versende-Belege</th>
+              <th class="px-3 py-2 text-right">Anteil aller Versenden</th>
+              <th class="px-3 py-2 text-right">Reim-Druck</th>
+            </tr>
+          </thead>
+          <tbody>${rows}</tbody>
+        </table>
+      </div>
+    `;
+  }
+
+  renderError(msg) {
+    const container = document.getElementById('resultsContainer');
+    if (!container) return;
+    container.innerHTML = `
+      <div class="rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+        ${escapeHtml(msg)}
+      </div>
+    `;
+  }
+
+  attachToolbarHandlers() {
+    const scopeEl = document.getElementById('vepScope');
+    const topNEl = document.getElementById('vepTopN');
+    const hideFuncEl = document.getElementById('vepHideFunc');
+
+    scopeEl?.addEventListener('change', (e) => {
+      this.state.scope = e.target.value;
+      this._lastProfile = this.computeProfile(this.state.scope);
+      this.render();
+    });
+    topNEl?.addEventListener('change', (e) => {
+      this.state.topN = parseInt(e.target.value, 10) || DEFAULT_TOP_N;
+      this.render();
+    });
+    hideFuncEl?.addEventListener('change', (e) => {
+      this.state.hideFunctionWords = e.target.checked;
+      this.render();
+    });
+  }
+}
+
+function escapeHtml(s) {
+  if (s == null) return '';
+  return String(s).replace(/[&<>"']/g, c => (
+    { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+  ));
+}

--- a/testing/tests/verse-ending-profile.spec.js
+++ b/testing/tests/verse-ending-profile.spec.js
@@ -1,0 +1,44 @@
+/**
+ * Versendings-Profil Tests (#106 Punkt 2)
+ *
+ * Verifiziert das 12. TEI-Analyse-Werkzeug im Playground: Top-N Lemmata an
+ * Versenden (lineEnds[]-Scan) mit Scope-Selector (Korpus/Autor*in/Text),
+ * Reim-Druck-Spalte und Funktionswort-Filter.
+ */
+
+import { test, expect } from '@playwright/test';
+
+test.describe('Issue #106.2: Versendings-Profil', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:8080/playground/#verse-ending-profile');
+    await page.waitForSelector('#vepScope', { state: 'visible', timeout: 60000 });
+  });
+
+  test('Route öffnet das Modul, Korpus-Scope liefert Tabelle mit Reim-Druck-Spalte', async ({ page }) => {
+    await expect(page.locator('#resultsContainer')).toContainText('Reim-Druck');
+    const rowCount = await page.locator('#resultsContainer table tbody tr').count();
+    expect(rowCount).toBeGreaterThan(0);
+  });
+
+  test('Funktionswort-Filter rendert die Tabelle neu', async ({ page }) => {
+    await page.waitForSelector('#resultsContainer table tbody tr', { state: 'visible', timeout: 60000 });
+    const before = await page.locator('#resultsContainer table tbody tr').first().textContent();
+
+    await page.check('#vepHideFunc');
+    await page.waitForSelector('#resultsContainer table tbody tr', { state: 'visible', timeout: 60000 });
+    const after = await page.locator('#resultsContainer table tbody tr').first().textContent();
+
+    // Tabelle rendert weiterhin Zeilen; Top-Eintrag ändert sich, sobald ein
+    // Funktionswort vorher führte (im Gesamtkorpus praktisch sicher)
+    expect(after).toBeTruthy();
+    expect(after).not.toBe(before);
+  });
+
+  test('Text-Scope zeigt Textmeta statt Korpuslabel', async ({ page }) => {
+    // Ein konkreter Vers-Text (IW = Iwein) über das optgroup-Select
+    await page.selectOption('#vepScope', 'IW');
+    await expect(page.locator('#resultsContainer')).toContainText('IW');
+    const rowCount = await page.locator('#resultsContainer table tbody tr').count();
+    expect(rowCount).toBeGreaterThan(0);
+  });
+});

--- a/testing/tests/verse-ending-profile.spec.js
+++ b/testing/tests/verse-ending-profile.spec.js
@@ -22,16 +22,15 @@ test.describe('Issue #106.2: Versendings-Profil', () => {
 
   test('Funktionswort-Filter rendert die Tabelle neu', async ({ page }) => {
     await page.waitForSelector('#resultsContainer table tbody tr', { state: 'visible', timeout: 60000 });
-    const before = await page.locator('#resultsContainer table tbody tr').first().textContent();
 
     await page.check('#vepHideFunc');
     await page.waitForSelector('#resultsContainer table tbody tr', { state: 'visible', timeout: 60000 });
-    const after = await page.locator('#resultsContainer table tbody tr').first().textContent();
 
-    // Tabelle rendert weiterhin Zeilen; Top-Eintrag ändert sich, sobald ein
-    // Funktionswort vorher führte (im Gesamtkorpus praktisch sicher)
-    expect(after).toBeTruthy();
-    expect(after).not.toBe(before);
+    // Datenunabhängige Assertion (Review-Hinweis): sobald ≥1 Funktionswort
+    // gefiltert wird, zeigt der Header den Ausgeblendet-Zähler „(–N ausgeblendet)"
+    await expect(page.locator('#resultsContainer')).toContainText('ausgeblendet');
+    const rowCount = await page.locator('#resultsContainer table tbody tr').count();
+    expect(rowCount).toBeGreaterThan(0);
   });
 
   test('Text-Scope zeigt Textmeta statt Korpuslabel', async ({ page }) => {


### PR DESCRIPTION
Issue #106, Punkt 2 (+ Punkt-3-Metrik als Spalte) — ohne Closes-Trailer: #106 ist Rolling-Backlog.

**Versendings-Profil** als zwölftes TEI-Analyse-Werkzeug: die häufigsten Lemmata am Versende für Gesamtkorpus, Autor*in oder Einzeltext. Beantwortet die Stilfrage aus dem Issue („was reimt Wolfram bevorzugt? Hartmann? Gottfried?") ohne neuen Build-Schritt: Datenbasis ist `text.words[lineEnds[i]]` aus dem Corpus-Index v4.1.0+.

## Inhalt

- Scope-Auswahl als ein Select mit optgroups: Gesamtkorpus (600 Vers-Texte) / Autor*in / Text; Prosa (leere `lineEnds`) wird übersprungen
- Tabelle: Versende-Belege (absolut), Anteil an allen Versenden des Scopes, **Reim-Druck** = Anteil der Vorkommen des Lemmas, die am Versende stehen. Das ist die Metrik aus #106 Punkt 3 (reimgetrieben vs. semantisch motiviert) als Spalte mitgeliefert, weil die Aggregation sie ohnehin hergibt
- Funktionswort-Filter mit derselben POS-Menge wie Wortfrequenz/Hapax (`FUNCTION_WORD_POS`-Import); Lemma-Links auf die Lemma-Seiten; POS-Badges
- Muster: `word-frequency.js` (Constructor mit Thunk + authorityData, state-driven render, Toolbar-Handler); Route `#verse-ending-profile` (#48), Button in der TEI-Textanalyse-Gruppe nach dem Reim-Wörterbuch
- Hilfe-Karte in `hilfe-playground.html`; Doc-Counts 11 → 12 in INDEX/FEATURES/ARCHITECTURE nachgezogen

## Verifikation (Chrome am lokalen Server)

- Gesamtkorpus: 600 Vers-Texte, 1.356.745 Verse, 24.653 verschiedene Versende-Lemmata. (600 statt der 603 aus dem Issue-Text von Mai: HMT/HH/APO sind seit #143 korrekt als Prosa mit `<lb/>` kodiert.)
- Reim-Druck differenziert wie erhofft: reimaktive Lemmata wie *tuon* 50,7 %, *guot* 49,1 %, *sagen* 51,1 % gegenüber Artikeln (*der* 5,3 %, *daz* 4,2 %)
- Autor-Scope (Stichprobe Wachsmuot von Künzingen): 1 Vers-Text, 174 Verse; Funktionswort-Filter blendet 27 Lemmata aus; Reim-Druck 83–100 % bei *guot/güete/leit*
- `npm run build:css` ohne Diff (keine neuen Utility-Klassen)
- Playwright: 205/205 grün (15,5 min), identisch zur Baseline

## Merge-Hinweis

**Base ist `claude/196-hapax-legomena` (PR #206)**, weil die Doc-Counts (11 → 12) und `hilfe-playground.html` direkt auf dem Hapax-Stand aufsetzen — bitte #206 zuerst mergen, dieser PR rebased dann automatisch auf main. Enthält bis dahin die #196-Commits in der Ansicht.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vbmqYTNTYyD7S9gcCdJYc
