### PR TITLE
#196: Werktitel und Autor im Hapax-Detail-Panel

### DIFF
--- a/playground/js/ui/tei/hapax-legomena.js
+++ b/playground/js/ui/tei/hapax-legomena.js
@@ -445,6 +445,37 @@ export class HapaxLegomenaAnalyzer {
     return this._textLabelCache;
   }
 
+  /**
+   * Fundstellen eines Eintrags mit Werktitel, Autor und Versangabe (#196).
+   *
+   * Die Tabellenspalte zeigt nur die Sigle, weil sie in eine Zeile passen
+   * muss. Im Detail-Panel ist Platz für die Frage, die bei einem Hapax
+   * zuerst kommt: in welchem Werk steht es, und von wem stammt das.
+   * 660 der 667 Texte tragen einen Autor im Korpus-Index; die übrigen
+   * bekommen gar keinen Klammerzusatz statt eines leeren.
+   */
+  renderFundstellen(entry) {
+    const textById = new Map((this.getCorpusTexts() || []).map(t => [t.id, t]));
+    const items = (entry.occ || []).map(o => {
+      const text = textById.get(o.textId);
+      const verse = this.verseForPosition(text, o.pos);
+      const stelle = verse ? `Vers ${verse}` : `Pos. ${o.pos}`;
+      const titel = text?.title || o.textId;
+      const autor = text?.author ? ` <span class="text-slate-600">(${escapeHtml(text.author)})</span>` : '';
+      const url = `../korpus.html?textId=${encodeURIComponent(o.textId)}&lemmaIds=${encodeURIComponent(entry.lemmaId)}&position=${o.pos}`;
+      return `<li><a href="${url}" target="_blank" rel="noopener" class="text-brand-700 hover:underline" title="Im Reader mit Highlight öffnen">${escapeHtml(titel)}</a>${autor} <span class="text-slate-300">·</span> <span class="text-slate-600">${escapeHtml(stelle)}</span> <span class="font-mono text-xs text-slate-400">${escapeHtml(o.textId)}</span></li>`;
+    });
+    if (items.length === 0) return '';
+    const mehr = entry.count > items.length
+      ? `<div class="text-xs text-slate-400">Angezeigt sind die ersten ${items.length} von ${entry.count} Vorkommen.</div>`
+      : '';
+    return `<div>
+      <span class="text-xs font-medium text-slate-500">Fundstellen:</span>
+      <ul class="mt-1 space-y-0.5 list-disc list-inside">${items.join('')}</ul>
+      ${mehr}
+    </div>`;
+  }
+
   /** Detail-Panel: Konzepte + Wörterbuchnetz-Abgleich (lazy, on expand). */
   async toggleDetail(idx) {
     const row = document.getElementById(`hxDetailRow-${idx}`);
@@ -460,9 +491,22 @@ export class HapaxLegomenaAnalyzer {
 
     const entry = this._lastEntries?.[idx];
     if (!entry) return;
+
+    // Fundstellen mit Werk und Autor (#196, KZW 28.07.): bei einem Hapax ist
+    // die erste Frage, WO es steht und von wem. Die Sigle allein in der
+    // Tabellenspalte beantwortet das nicht. Steht bewusst vor dem Early
+    // Return, damit auch Kuratierungs-Funde ohne Authority-Eintrag ihren
+    // Fundort zeigen.
+    const fundstellenHtml = this.renderFundstellen(entry);
+
     const lemma = this.getLemmaById(entry.lemmaId);
     if (!lemma) {
-      cell.innerHTML = '<span class="text-sm text-slate-500">Kein Eintrag in lexicon.xml, Kandidat für die Kuratierung (Lemma-ID wird im Korpus referenziert, fehlt aber im Authority-File).</span>';
+      cell.innerHTML = `
+        <div class="space-y-2 text-sm">
+          ${fundstellenHtml}
+          <div class="text-slate-500">Kein Eintrag in lexicon.xml, Kandidat für die Kuratierung (Lemma-ID wird im Korpus referenziert, fehlt aber im Authority-File).</div>
+        </div>
+      `;
       return;
     }
 
@@ -475,6 +519,7 @@ export class HapaxLegomenaAnalyzer {
 
     cell.innerHTML = `
       <div class="space-y-2 text-sm">
+        ${fundstellenHtml}
         ${conceptChips ? `<div><span class="text-xs font-medium text-slate-500">Konzepte:</span> ${conceptChips}</div>` : ''}
         <div id="hxDict-${idx}" class="text-xs text-slate-500">Wörterbuchnetz wird abgefragt …</div>
       </div>

--- a/playground/js/ui/tei/hapax-legomena.js
+++ b/playground/js/ui/tei/hapax-legomena.js
@@ -461,7 +461,9 @@ export class HapaxLegomenaAnalyzer {
       const verse = this.verseForPosition(text, o.pos);
       const stelle = verse ? `Vers ${verse}` : `Pos. ${o.pos}`;
       const titel = text?.title || o.textId;
-      const autor = text?.author ? ` <span class="text-slate-600">(${escapeHtml(text.author)})</span>` : '';
+      const autor = text?.author
+        ? ` <span class="text-slate-600" data-hx-autor>(${escapeHtml(text.author)})</span>`
+        : '';
       const url = `../korpus.html?textId=${encodeURIComponent(o.textId)}&lemmaIds=${encodeURIComponent(entry.lemmaId)}&position=${o.pos}`;
       return `<li><a href="${url}" target="_blank" rel="noopener" class="text-brand-700 hover:underline" title="Im Reader mit Highlight öffnen">${escapeHtml(titel)}</a>${autor} <span class="text-slate-300">·</span> <span class="text-slate-600">${escapeHtml(stelle)}</span> <span class="font-mono text-xs text-slate-400">${escapeHtml(o.textId)}</span></li>`;
     });

--- a/playground/js/ui/tei/hapax-legomena.js
+++ b/playground/js/ui/tei/hapax-legomena.js
@@ -506,7 +506,7 @@ export class HapaxLegomenaAnalyzer {
       cell.innerHTML = `
         <div class="space-y-2 text-sm">
           ${fundstellenHtml}
-          <div class="text-slate-500">Kein Eintrag in lexicon.xml, Kandidat für die Kuratierung (Lemma-ID wird im Korpus referenziert, fehlt aber im Authority-File).</div>
+          <div class="text-slate-500">Kein Eintrag in lexicon.xml: Kandidat für die Kuratierung (Lemma-ID wird im Korpus referenziert, fehlt aber im Authority-File).</div>
         </div>
       `;
       return;

--- a/testing/tests/hapax-legomena.spec.js
+++ b/testing/tests/hapax-legomena.spec.js
@@ -101,14 +101,20 @@ test.describe('Issue #196: Echte Hapaxlegomena', () => {
     const panel = page.locator('[id^="hxDetailCell-"]').first();
     await expect(panel).toContainText('Fundstellen:', { timeout: 15000 });
 
-    // Werktitel als Reader-Link, nicht nur die Sigle.
-    const link = panel.locator('li a').first();
-    await expect(link).toHaveAttribute('href', /korpus\.html\?textId=/);
-    const titel = (await link.innerText()).trim();
-    expect(titel.length).toBeGreaterThan(3);
+    // Werktitel als Reader-Link, und zwar der TITEL, nicht die Sigle. Ein
+    // Laengenvergleich reichte dafuer nicht: Siglen wie DJEM haben vier
+    // Zeichen und bestuenden ihn auch als Fallback.
+    const zeile = panel.locator('li').first();
+    const titel = (await zeile.locator('a').innerText()).trim();
+    const sigle = (await zeile.locator('span.font-mono').innerText()).trim();
+    await expect(zeile.locator('a')).toHaveAttribute('href', /korpus\.html\?textId=/);
+    expect(titel).not.toBe(sigle);
 
-    // Autor in Klammern dahinter. 660 der 667 Texte tragen einen.
-    await expect(panel.locator('li').first()).toContainText(/\(.+\)/);
+    // Autor per eigenem Attribut statt per Klammer-Regex: Werktitel duerfen
+    // selbst Klammern enthalten ("Wenzelsbibel (Pentateuch: ...)"), und 7 der
+    // 667 Texte haben gar keinen Autor. Deshalb ueber alle Fundstellen des
+    // Panels pruefen, nicht nur ueber die erste.
+    expect(await panel.locator('li [data-hx-autor]').count()).toBeGreaterThan(0);
   });
 
   test('Route + Sidebar-Button öffnen das Modul, Liste füllt sich', async ({ page }) => {

--- a/testing/tests/hapax-legomena.spec.js
+++ b/testing/tests/hapax-legomena.spec.js
@@ -90,6 +90,27 @@ test.describe('Issue #196: Echte Hapaxlegomena', () => {
     await expect(page.locator('#hxHideNum')).toBeEnabled();
   });
 
+  test('Detail-Panel nennt Werktitel und Autor der Fundstelle (#196)', async ({ page }) => {
+    // KZW 28.07.: "wenn bei den Details auch noch direkt stehen wuerde, wer der
+    // Autor ist. Das interessiert bei Hapax besonders auf den ersten Blick."
+    // Faellt ohne die Aenderung durch: vor #196 stand im Panel nur die Sigle
+    // in der Tabellenspalte, das Panel selbst hatte Konzepte und Woerterbuch.
+    await page.waitForSelector('[data-hx-detail]', { state: 'visible', timeout: 60000 });
+    await page.locator('[data-hx-detail]').first().click();
+
+    const panel = page.locator('[id^="hxDetailCell-"]').first();
+    await expect(panel).toContainText('Fundstellen:', { timeout: 15000 });
+
+    // Werktitel als Reader-Link, nicht nur die Sigle.
+    const link = panel.locator('li a').first();
+    await expect(link).toHaveAttribute('href', /korpus\.html\?textId=/);
+    const titel = (await link.innerText()).trim();
+    expect(titel.length).toBeGreaterThan(3);
+
+    // Autor in Klammern dahinter. 660 der 667 Texte tragen einen.
+    await expect(panel.locator('li').first()).toContainText(/\(.+\)/);
+  });
+
   test('Route + Sidebar-Button öffnen das Modul, Liste füllt sich', async ({ page }) => {
     await expect(page.locator('#resultsContainer')).toContainText('Hapax');
     await expect(page.locator('#showHapaxLegomenaBtn')).toBeVisible();


### PR DESCRIPTION
Setzt KZWs Wunsch vom 28.07. in #196 um: „Ich fände es ganz brauchbar, wenn bei den Details auch noch direkt stehen würde, wer der Autor ist. Das interessiert bei Hapax besonders auf den ersten Blick."

**Auf #233 gestackt**, weil beide PRs `hapax-legomena.js` anfassen. Nach #233 mergen; der Basis-Branch wird nach dessen Merge automatisch auf `main` umgestellt.

## Vorher / nachher

Vorher zeigte das Detail-Panel Konzept-Chips und den Wörterbuchnetz-Abgleich. Wo das Lemma steht, stand nur als Sigle in der Tabellenspalte („ZUK, Vers 2410").

Jetzt:

> **Fundstellen:**
> • [Gottes Zukunft](#) (Heinrich von Neustadt) · Vers 2410  `ZUK`

Der Werktitel ist der Reader-Deep-Link, der schon vorher an der Sigle hing. Die Sigle bleibt klein dahinter stehen, weil sie in der Fachkommunikation die Kurzform ist.

## Drei Details, die nicht offensichtlich sind

1. **Der Block steht vor dem Early Return** für Lemmata ohne Authority-Eintrag. Gerade bei diesen Kuratierungs-Funden ist der Fundort die einzige verwertbare Information, und bisher zeigte das Panel dort nur einen Hinweistext.
2. **Kein leerer Klammerzusatz.** 660 der 667 Texte tragen einen Autor im Korpus-Index; die übrigen sieben bekommen gar keine Klammer statt einer leeren.
3. **Bei Schwelle 2 oder 3** hält die Aggregation nur die ersten drei Fundorte. Eine Zeile sagt jetzt, wie viele von wie vielen zu sehen sind, statt die Differenz zu verschweigen.

## Verifikation

Neuer Playwright-Test, **gegengeprüft**: mit neutralisiertem `renderFundstellen` fällt er durch.

Bemerkenswert daran: der erste Anlauf der Gegenprobe war selbst wertlos. Ich hatte nur eine der beiden Einsetzstellen entfernt, der Test blieb grün, und ohne den zweiten Versuch hätte ich das als Beleg gebucht. Genau die Lehre aus der Vorsession, diesmal im eigenen Vorgehen.

Chrome-verifiziert am ersten Listeneintrag (`Abba`): „Fundstellen: Gottes Zukunft (Heinrich von Neustadt) · Vers 2410 ZUK". Randfälle direkt gegen die Methode geprüft: Text ohne Autor bekommt keine leere Klammer, leere `occ`-Liste liefert leeren String, der Mehr-Hinweis erscheint bei 2 von 3.

`hapax-legomena.spec.js` 6/6, Em-Dash-Gate grün.

Refs #196