### PR TITLE
#196: Werktitel und Autor im Hapax-Detail-Panel

### DIFF
--- a/playground/js/ui/tei/hapax-legomena.js
+++ b/playground/js/ui/tei/hapax-legomena.js
@@ -445,6 +445,37 @@ export class HapaxLegomenaAnalyzer {
     return this._textLabelCache;
   }
 
+  /**
+   * Fundstellen eines Eintrags mit Werktitel, Autor und Versangabe (#196).
+   *
+   * Die Tabellenspalte zeigt nur die Sigle, weil sie in eine Zeile passen
+   * muss. Im Detail-Panel ist Platz für die Frage, die bei einem Hapax
+   * zuerst kommt: in welchem Werk steht es, und von wem stammt das.
+   * 660 der 667 Texte tragen einen Autor im Korpus-Index; die übrigen
+   * bekommen gar keinen Klammerzusatz statt eines leeren.
+   */
+  renderFundstellen(entry) {
+    const textById = new Map((this.getCorpusTexts() || []).map(t => [t.id, t]));
+    const items = (entry.occ || []).map(o => {
+      const text = textById.get(o.textId);
+      const verse = this.verseForPosition(text, o.pos);
+      const stelle = verse ? `Vers ${verse}` : `Pos. ${o.pos}`;
+      const titel = text?.title || o.textId;
+      const autor = text?.author ? ` <span class="text-slate-600">(${escapeHtml(text.author)})</span>` : '';
+      const url = `../korpus.html?textId=${encodeURIComponent(o.textId)}&lemmaIds=${encodeURIComponent(entry.lemmaId)}&position=${o.pos}`;
+      return `<li><a href="${url}" target="_blank" rel="noopener" class="text-brand-700 hover:underline" title="Im Reader mit Highlight öffnen">${escapeHtml(titel)}</a>${autor} <span class="text-slate-300">·</span> <span class="text-slate-600">${escapeHtml(stelle)}</span> <span class="font-mono text-xs text-slate-400">${escapeHtml(o.textId)}</span></li>`;
+    });
+    if (items.length === 0) return '';
+    const mehr = entry.count > items.length
+      ? `<div class="text-xs text-slate-400">Angezeigt sind die ersten ${items.length} von ${entry.count} Vorkommen.</div>`
+      : '';
+    return `<div>
+      <span class="text-xs font-medium text-slate-500">Fundstellen:</span>
+      <ul class="mt-1 space-y-0.5 list-disc list-inside">${items.join('')}</ul>
+      ${mehr}
+    </div>`;
+  }
+
   /** Detail-Panel: Konzepte + Wörterbuchnetz-Abgleich (lazy, on expand). */
   async toggleDetail(idx) {
     const row = document.getElementById(`hxDetailRow-${idx}`);
@@ -460,9 +491,22 @@ export class HapaxLegomenaAnalyzer {
 
     const entry = this._lastEntries?.[idx];
     if (!entry) return;
+
+    // Fundstellen mit Werk und Autor (#196, KZW 28.07.): bei einem Hapax ist
+    // die erste Frage, WO es steht und von wem. Die Sigle allein in der
+    // Tabellenspalte beantwortet das nicht. Steht bewusst vor dem Early
+    // Return, damit auch Kuratierungs-Funde ohne Authority-Eintrag ihren
+    // Fundort zeigen.
+    const fundstellenHtml = this.renderFundstellen(entry);
+
     const lemma = this.getLemmaById(entry.lemmaId);
     if (!lemma) {
-      cell.innerHTML = '<span class="text-sm text-slate-500">Kein Eintrag in lexicon.xml, Kandidat für die Kuratierung (Lemma-ID wird im Korpus referenziert, fehlt aber im Authority-File).</span>';
+      cell.innerHTML = `
+        <div class="space-y-2 text-sm">
+          ${fundstellenHtml}
+          <div class="text-slate-500">Kein Eintrag in lexicon.xml, Kandidat für die Kuratierung (Lemma-ID wird im Korpus referenziert, fehlt aber im Authority-File).</div>
+        </div>
+      `;
       return;
     }
 
@@ -475,6 +519,7 @@ export class HapaxLegomenaAnalyzer {
 
     cell.innerHTML = `
       <div class="space-y-2 text-sm">
+        ${fundstellenHtml}
         ${conceptChips ? `<div><span class="text-xs font-medium text-slate-500">Konzepte:</span> ${conceptChips}</div>` : ''}
         <div id="hxDict-${idx}" class="text-xs text-slate-500">Wörterbuchnetz wird abgefragt …</div>
       </div>

--- a/playground/js/ui/tei/hapax-legomena.js
+++ b/playground/js/ui/tei/hapax-legomena.js
@@ -461,7 +461,9 @@ export class HapaxLegomenaAnalyzer {
       const verse = this.verseForPosition(text, o.pos);
       const stelle = verse ? `Vers ${verse}` : `Pos. ${o.pos}`;
       const titel = text?.title || o.textId;
-      const autor = text?.author ? ` <span class="text-slate-600">(${escapeHtml(text.author)})</span>` : '';
+      const autor = text?.author
+        ? ` <span class="text-slate-600" data-hx-autor>(${escapeHtml(text.author)})</span>`
+        : '';
       const url = `../korpus.html?textId=${encodeURIComponent(o.textId)}&lemmaIds=${encodeURIComponent(entry.lemmaId)}&position=${o.pos}`;
       return `<li><a href="${url}" target="_blank" rel="noopener" class="text-brand-700 hover:underline" title="Im Reader mit Highlight öffnen">${escapeHtml(titel)}</a>${autor} <span class="text-slate-300">·</span> <span class="text-slate-600">${escapeHtml(stelle)}</span> <span class="font-mono text-xs text-slate-400">${escapeHtml(o.textId)}</span></li>`;
     });

--- a/playground/js/ui/tei/hapax-legomena.js
+++ b/playground/js/ui/tei/hapax-legomena.js
@@ -506,7 +506,7 @@ export class HapaxLegomenaAnalyzer {
       cell.innerHTML = `
         <div class="space-y-2 text-sm">
           ${fundstellenHtml}
-          <div class="text-slate-500">Kein Eintrag in lexicon.xml, Kandidat für die Kuratierung (Lemma-ID wird im Korpus referenziert, fehlt aber im Authority-File).</div>
+          <div class="text-slate-500">Kein Eintrag in lexicon.xml: Kandidat für die Kuratierung (Lemma-ID wird im Korpus referenziert, fehlt aber im Authority-File).</div>
         </div>
       `;
       return;

--- a/playground/js/ui/tei/hapax-legomena.js
+++ b/playground/js/ui/tei/hapax-legomena.js
@@ -447,15 +447,6 @@ export class HapaxLegomenaAnalyzer {
   }
 
   /**
-   * Fundstellen eines Eintrags mit Werktitel, Autor und Versangabe (#196).
-   *
-   * Die Tabellenspalte zeigt nur die Sigle, weil sie in eine Zeile passen
-   * muss. Im Detail-Panel ist Platz für die Frage, die bei einem Hapax
-   * zuerst kommt: in welchem Werk steht es, und von wem stammt das.
-   * 660 der 667 Texte tragen einen Autor im Korpus-Index; die übrigen
-   * bekommen gar keinen Klammerzusatz statt eines leeren.
-   */
-  /**
    * Autorname eines Texts, mit Rückgriff auf die Personen-Referenz.
    *
    * Sieben Korpusdateien tragen ein leeres `<author ref="#person_N"/>` (ALX,
@@ -478,6 +469,15 @@ export class HapaxLegomenaAnalyzer {
     return this._personById.get(ref)?.preferredName || '';
   }
 
+  /**
+   * Fundstellen eines Eintrags mit Werktitel, Autor und Versangabe (#196).
+   *
+   * Die Tabellenspalte zeigt nur die Sigle, weil sie in eine Zeile passen
+   * muss. Im Detail-Panel ist Platz für die Frage, die bei einem Hapax
+   * zuerst kommt: in welchem Werk steht es, und von wem stammt das. Über
+   * autorFuerText() bekommt jeder der 667 Texte einen Namen, auch die
+   * sieben mit leerem `<author ref>`.
+   */
   renderFundstellen(entry) {
     const textById = new Map((this.getCorpusTexts() || []).map(t => [t.id, t]));
     const items = (entry.occ || []).map(o => {

--- a/playground/js/ui/tei/hapax-legomena.js
+++ b/playground/js/ui/tei/hapax-legomena.js
@@ -142,7 +142,9 @@ export class HapaxLegomenaAnalyzer {
     //
     // DIG (römische Zahlen) braucht keinen eigenen Filter: es gibt genau drei
     // DIG-Lemmata, und keines kann hier je erscheinen. lemma_13826 "I" hat
-    // 4.755 Korpusbelege, lemma_45842 "declinare" 4 (über der höchsten
+    // 4.049 Korpusbelege (bis #138 waren es 4.755; die 706 annotierten der
+    // 814 HUG-Strophenziffern hingen an genau diesem Lemma), lemma_45842
+    // "declinare" 4 (über der höchsten
     // Schwelle 3), lemma_21509 "xxtausent" steht nur im Lexikon und kommt im
     // Korpus nicht vor.
     if (this.state.hideNumerals && facet !== 'NUM'

--- a/playground/js/ui/tei/hapax-legomena.js
+++ b/playground/js/ui/tei/hapax-legomena.js
@@ -36,6 +36,7 @@ export class HapaxLegomenaAnalyzer {
     this.authorityData = authorityData;
     this._lemmaById = null;
     this._conceptById = null;
+    this._personById = null;
     this._corpusAgg = null;      // einmalige korpusweite Aggregation
     this._textLabelCache = null;
     this.state = {
@@ -454,6 +455,29 @@ export class HapaxLegomenaAnalyzer {
    * 660 der 667 Texte tragen einen Autor im Korpus-Index; die übrigen
    * bekommen gar keinen Klammerzusatz statt eines leeren.
    */
+  /**
+   * Autorname eines Texts, mit Rückgriff auf die Personen-Referenz.
+   *
+   * Sieben Korpusdateien tragen ein leeres `<author ref="#person_N"/>` (ALX,
+   * BVSN, PSG, PTS, BOP, MHG, MRB). Sie sind deshalb nicht autorlos: die
+   * Referenz steht im Index, und `persons` kennt den Namen (Mönch von
+   * Heilsbronn, Boppe, Herger, Burggraf von Riedenburg). Ohne diesen Rückgriff
+   * unterschlüge das Panel den Autor stillschweigend und verkaufte eine
+   * Datenlücke als Design. Die leeren `<author/>`-Elemente selbst gehören
+   * trotzdem im TEI gefüllt, das ist ein eigener Vorgang.
+   */
+  autorFuerText(text) {
+    if (!text) return '';
+    if (text.author) return text.author;
+    const ref = (text.authorRef || '').replace(/^#/, '');
+    if (!ref) return '';
+    if (!this._personById) {
+      const personen = this.authorityData?.persons || [];
+      this._personById = new Map(personen.map(p => [p.id, p]));
+    }
+    return this._personById.get(ref)?.preferredName || '';
+  }
+
   renderFundstellen(entry) {
     const textById = new Map((this.getCorpusTexts() || []).map(t => [t.id, t]));
     const items = (entry.occ || []).map(o => {
@@ -461,8 +485,9 @@ export class HapaxLegomenaAnalyzer {
       const verse = this.verseForPosition(text, o.pos);
       const stelle = verse ? `Vers ${verse}` : `Pos. ${o.pos}`;
       const titel = text?.title || o.textId;
-      const autor = text?.author
-        ? ` <span class="text-slate-600" data-hx-autor>(${escapeHtml(text.author)})</span>`
+      const autorName = this.autorFuerText(text);
+      const autor = autorName
+        ? ` <span class="text-slate-600" data-hx-autor>(${escapeHtml(autorName)})</span>`
         : '';
       const url = `../korpus.html?textId=${encodeURIComponent(o.textId)}&lemmaIds=${encodeURIComponent(entry.lemmaId)}&position=${o.pos}`;
       return `<li><a href="${url}" target="_blank" rel="noopener" class="text-brand-700 hover:underline" title="Im Reader mit Highlight öffnen">${escapeHtml(titel)}</a>${autor} <span class="text-slate-300">·</span> <span class="text-slate-600">${escapeHtml(stelle)}</span> <span class="font-mono text-xs text-slate-400">${escapeHtml(o.textId)}</span></li>`;

--- a/testing/tests/hapax-legomena.spec.js
+++ b/testing/tests/hapax-legomena.spec.js
@@ -101,14 +101,20 @@ test.describe('Issue #196: Echte Hapaxlegomena', () => {
     const panel = page.locator('[id^="hxDetailCell-"]').first();
     await expect(panel).toContainText('Fundstellen:', { timeout: 15000 });
 
-    // Werktitel als Reader-Link, nicht nur die Sigle.
-    const link = panel.locator('li a').first();
-    await expect(link).toHaveAttribute('href', /korpus\.html\?textId=/);
-    const titel = (await link.innerText()).trim();
-    expect(titel.length).toBeGreaterThan(3);
+    // Werktitel als Reader-Link, und zwar der TITEL, nicht die Sigle. Ein
+    // Laengenvergleich reichte dafuer nicht: Siglen wie DJEM haben vier
+    // Zeichen und bestuenden ihn auch als Fallback.
+    const zeile = panel.locator('li').first();
+    const titel = (await zeile.locator('a').innerText()).trim();
+    const sigle = (await zeile.locator('span.font-mono').innerText()).trim();
+    await expect(zeile.locator('a')).toHaveAttribute('href', /korpus\.html\?textId=/);
+    expect(titel).not.toBe(sigle);
 
-    // Autor in Klammern dahinter. 660 der 667 Texte tragen einen.
-    await expect(panel.locator('li').first()).toContainText(/\(.+\)/);
+    // Autor per eigenem Attribut statt per Klammer-Regex: Werktitel duerfen
+    // selbst Klammern enthalten ("Wenzelsbibel (Pentateuch: ...)"), und 7 der
+    // 667 Texte haben gar keinen Autor. Deshalb ueber alle Fundstellen des
+    // Panels pruefen, nicht nur ueber die erste.
+    expect(await panel.locator('li [data-hx-autor]').count()).toBeGreaterThan(0);
   });
 
   test('Route + Sidebar-Button öffnen das Modul, Liste füllt sich', async ({ page }) => {

--- a/testing/tests/hapax-legomena.spec.js
+++ b/testing/tests/hapax-legomena.spec.js
@@ -114,9 +114,9 @@ test.describe('Issue #196: Echte Hapaxlegomena', () => {
     // selbst Klammern enthalten ("Wenzelsbibel (Pentateuch: ...)"). Sieben
     // Texte tragen ein leeres <author ref="#person_N"/>; für die greift der
     // Rückgriff auf die Personen-Referenz (autorFuerText), sie bleiben also
-    // nicht namenlos. Ein Hapax hat genau eine Fundstelle, der Count ist
-    // deshalb 1, nicht mehr.
-    expect(await panel.locator('li [data-hx-autor]').count()).toBeGreaterThan(0);
+    // nicht namenlos. Bei Frequenz 1 hat der Eintrag genau eine Fundstelle,
+    // deshalb genau ein Autor-Element.
+    await expect(panel.locator('li [data-hx-autor]')).toHaveCount(1);
   });
 
   test('Fundstellen stehen auch bei Lemmata ohne Authority-Eintrag (#196)', async ({ page }) => {
@@ -143,9 +143,14 @@ test.describe('Issue #196: Echte Hapaxlegomena', () => {
       const { entries } = hx.computeList();
       const i = entries.findIndex(e => !hx.getLemmaById(e.lemmaId));
       if (i < 0) return -1;
-      hx.state.page = Math.floor(i / 100);
+      // Seitengröße nicht hartkodieren: PAGE_SIZE ist modul-privat, aber die
+      // aktuell gerenderte Seite ist voll (gut 16.000 Einträge), ihre
+      // Zeilenzahl ist also die Seitengröße. Sonst bricht der Test still,
+      // wenn PAGE_SIZE sich ändert.
+      const proSeite = document.querySelectorAll('[data-hx-detail]').length;
+      hx.state.page = Math.floor(i / proSeite);
       hx.render();
-      return i % 100;
+      return i % proSeite;
     });
 
     if (idx < 0) {

--- a/testing/tests/hapax-legomena.spec.js
+++ b/testing/tests/hapax-legomena.spec.js
@@ -111,9 +111,11 @@ test.describe('Issue #196: Echte Hapaxlegomena', () => {
     expect(titel).not.toBe(sigle);
 
     // Autor per eigenem Attribut statt per Klammer-Regex: Werktitel dürfen
-    // selbst Klammern enthalten ("Wenzelsbibel (Pentateuch: ...)"), und 7 der
-    // 667 Texte haben gar keinen Autor. Deshalb über alle Fundstellen des
-    // Panels prüfen, nicht nur über die erste.
+    // selbst Klammern enthalten ("Wenzelsbibel (Pentateuch: ...)"). Sieben
+    // Texte tragen ein leeres <author ref="#person_N"/>; für die greift der
+    // Rückgriff auf die Personen-Referenz (autorFuerText), sie bleiben also
+    // nicht namenlos. Ein Hapax hat genau eine Fundstelle, der Count ist
+    // deshalb 1, nicht mehr.
     expect(await panel.locator('li [data-hx-autor]').count()).toBeGreaterThan(0);
   });
 
@@ -124,25 +126,37 @@ test.describe('Issue #196: Echte Hapaxlegomena', () => {
     // lexicon.xml-Eintrag entfernen, bliebe er grün. Genau diese Lemmata sind
     // aber Kuratierungs-Funde und ohne Fundort nicht nachverfolgbar.
     //
-    // Ehrliche Einschränkung: mit dem Indexstand vom 28.07. greift dieser Test
-    // NICHT. Es gibt 24 Lemma-IDs mit Korpusfrequenz 1 ohne lexicon.xml-Eintrag
-    // (lemma_78708 ff.), sie sortieren aber nach ihrer ID, landen damit unter
-    // "l" und liegen bei 16.630 Hapaxen und 100 Zeilen pro Seite tief in der
-    // Paginierung. Eine Buchstaben- oder Wortart-Facette hilft nicht: für
-    // Lemmata ohne Eintrag liefert passesFilters nur bei "alle/alle" true.
-    // Der Test skippt deshalb sichtbar, statt still grün zu sein, und greift,
-    // sobald ein solcher Eintrag auf Seite 1 auftaucht.
+    // Die erste Fassung suchte den Eintrag auf Seite 1 und skippte sonst. Das
+    // war kein datenabhängiger Skip, sondern ein dauerhafter: Einträge ohne
+    // Authority-Eintrag sortieren über den Fallback-Schlüssel `lemma_NNNNN`
+    // (computeList), landen damit unter "l" und können bei 100 Zeilen pro
+    // Seite und gut 16.000 Hapaxen nie auf Seite 1 stehen. Der Test hätte
+    // also nie etwas geprüft.
+    //
+    // Deshalb wird die Seite jetzt gezielt angesteuert. Der Klickpfad durch
+    // toggleDetail bleibt der echte Weg durch die Oberfläche, nur die
+    // Paginierung wird vorgespult.
     await page.waitForSelector('[data-hx-detail]', { state: 'visible', timeout: 60000 });
 
-    const zeile = page.locator('tr', { hasText: 'ohne Authority-Eintrag' }).first();
-    if (await zeile.count() === 0) {
-      test.skip(true, 'Kein Lemma ohne Authority-Eintrag auf Seite 1; '
-        + 'der Early-Return-Zweig ist über die Oberfläche nicht erreichbar '
-        + '(24 solcher Lemmata existieren, sortieren aber tief in die Liste).');
+    const idx = await page.evaluate(() => {
+      const hx = window.playground.ui.hapaxLegomena;
+      const { entries } = hx.computeList();
+      const i = entries.findIndex(e => !hx.getLemmaById(e.lemmaId));
+      if (i < 0) return -1;
+      hx.state.page = Math.floor(i / 100);
+      hx.render();
+      return i % 100;
+    });
+
+    if (idx < 0) {
+      test.skip(true, 'Kein Lemma ohne lexicon.xml-Eintrag im aktuellen Index; '
+        + 'dann gibt es diesen Zweig nicht zu prüfen.');
       return;
     }
 
-    await zeile.locator('[data-hx-detail]').click();
+    const zeile = page.locator('tr', { hasText: 'ohne Authority-Eintrag' }).first();
+    await expect(zeile).toBeVisible({ timeout: 15000 });
+    await page.click(`[data-hx-detail="${idx}"]`);
     const panel = page.locator('[id^="hxDetailCell-"]', { hasText: 'Kandidat für die Kuratierung' }).first();
     await expect(panel).toContainText('Fundstellen:', { timeout: 15000 });
     await expect(panel.locator('li a').first()).toHaveAttribute('href', /korpus\.html\?textId=/);

--- a/testing/tests/hapax-legomena.spec.js
+++ b/testing/tests/hapax-legomena.spec.js
@@ -90,6 +90,27 @@ test.describe('Issue #196: Echte Hapaxlegomena', () => {
     await expect(page.locator('#hxHideNum')).toBeEnabled();
   });
 
+  test('Detail-Panel nennt Werktitel und Autor der Fundstelle (#196)', async ({ page }) => {
+    // KZW 28.07.: "wenn bei den Details auch noch direkt stehen wuerde, wer der
+    // Autor ist. Das interessiert bei Hapax besonders auf den ersten Blick."
+    // Faellt ohne die Aenderung durch: vor #196 stand im Panel nur die Sigle
+    // in der Tabellenspalte, das Panel selbst hatte Konzepte und Woerterbuch.
+    await page.waitForSelector('[data-hx-detail]', { state: 'visible', timeout: 60000 });
+    await page.locator('[data-hx-detail]').first().click();
+
+    const panel = page.locator('[id^="hxDetailCell-"]').first();
+    await expect(panel).toContainText('Fundstellen:', { timeout: 15000 });
+
+    // Werktitel als Reader-Link, nicht nur die Sigle.
+    const link = panel.locator('li a').first();
+    await expect(link).toHaveAttribute('href', /korpus\.html\?textId=/);
+    const titel = (await link.innerText()).trim();
+    expect(titel.length).toBeGreaterThan(3);
+
+    // Autor in Klammern dahinter. 660 der 667 Texte tragen einen.
+    await expect(panel.locator('li').first()).toContainText(/\(.+\)/);
+  });
+
   test('Route + Sidebar-Button öffnen das Modul, Liste füllt sich', async ({ page }) => {
     await expect(page.locator('#resultsContainer')).toContainText('Hapax');
     await expect(page.locator('#showHapaxLegomenaBtn')).toBeVisible();

--- a/testing/tests/hapax-legomena.spec.js
+++ b/testing/tests/hapax-legomena.spec.js
@@ -91,10 +91,10 @@ test.describe('Issue #196: Echte Hapaxlegomena', () => {
   });
 
   test('Detail-Panel nennt Werktitel und Autor der Fundstelle (#196)', async ({ page }) => {
-    // KZW 28.07.: "wenn bei den Details auch noch direkt stehen wuerde, wer der
+    // KZW 28.07.: "wenn bei den Details auch noch direkt stehen würde, wer der
     // Autor ist. Das interessiert bei Hapax besonders auf den ersten Blick."
-    // Faellt ohne die Aenderung durch: vor #196 stand im Panel nur die Sigle
-    // in der Tabellenspalte, das Panel selbst hatte Konzepte und Woerterbuch.
+    // Fällt ohne die Änderung durch: vor #196 stand im Panel nur die Sigle
+    // in der Tabellenspalte, das Panel selbst hatte Konzepte und Wörterbuch.
     await page.waitForSelector('[data-hx-detail]', { state: 'visible', timeout: 60000 });
     await page.locator('[data-hx-detail]').first().click();
 
@@ -102,19 +102,50 @@ test.describe('Issue #196: Echte Hapaxlegomena', () => {
     await expect(panel).toContainText('Fundstellen:', { timeout: 15000 });
 
     // Werktitel als Reader-Link, und zwar der TITEL, nicht die Sigle. Ein
-    // Laengenvergleich reichte dafuer nicht: Siglen wie DJEM haben vier
-    // Zeichen und bestuenden ihn auch als Fallback.
+    // Längenvergleich reichte dafür nicht: Siglen wie DJEM haben vier
+    // Zeichen und bestünden ihn auch als Fallback.
     const zeile = panel.locator('li').first();
     const titel = (await zeile.locator('a').innerText()).trim();
     const sigle = (await zeile.locator('span.font-mono').innerText()).trim();
     await expect(zeile.locator('a')).toHaveAttribute('href', /korpus\.html\?textId=/);
     expect(titel).not.toBe(sigle);
 
-    // Autor per eigenem Attribut statt per Klammer-Regex: Werktitel duerfen
+    // Autor per eigenem Attribut statt per Klammer-Regex: Werktitel dürfen
     // selbst Klammern enthalten ("Wenzelsbibel (Pentateuch: ...)"), und 7 der
-    // 667 Texte haben gar keinen Autor. Deshalb ueber alle Fundstellen des
-    // Panels pruefen, nicht nur ueber die erste.
+    // 667 Texte haben gar keinen Autor. Deshalb über alle Fundstellen des
+    // Panels prüfen, nicht nur über die erste.
     expect(await panel.locator('li [data-hx-autor]').count()).toBeGreaterThan(0);
+  });
+
+  test('Fundstellen stehen auch bei Lemmata ohne Authority-Eintrag (#196)', async ({ page }) => {
+    // Zweiter Einsetzpunkt, eigener Test. Der Test darüber klickt den ersten
+    // Listeneintrag und trifft damit den Authority-Zweig; würde man
+    // `${fundstellenHtml}` aus dem Early Return für Lemmata OHNE
+    // lexicon.xml-Eintrag entfernen, bliebe er grün. Genau diese Lemmata sind
+    // aber Kuratierungs-Funde und ohne Fundort nicht nachverfolgbar.
+    //
+    // Ehrliche Einschränkung: mit dem Indexstand vom 28.07. greift dieser Test
+    // NICHT. Es gibt 24 Lemma-IDs mit Korpusfrequenz 1 ohne lexicon.xml-Eintrag
+    // (lemma_78708 ff.), sie sortieren aber nach ihrer ID, landen damit unter
+    // "l" und liegen bei 16.630 Hapaxen und 100 Zeilen pro Seite tief in der
+    // Paginierung. Eine Buchstaben- oder Wortart-Facette hilft nicht: für
+    // Lemmata ohne Eintrag liefert passesFilters nur bei "alle/alle" true.
+    // Der Test skippt deshalb sichtbar, statt still grün zu sein, und greift,
+    // sobald ein solcher Eintrag auf Seite 1 auftaucht.
+    await page.waitForSelector('[data-hx-detail]', { state: 'visible', timeout: 60000 });
+
+    const zeile = page.locator('tr', { hasText: 'ohne Authority-Eintrag' }).first();
+    if (await zeile.count() === 0) {
+      test.skip(true, 'Kein Lemma ohne Authority-Eintrag auf Seite 1; '
+        + 'der Early-Return-Zweig ist über die Oberfläche nicht erreichbar '
+        + '(24 solcher Lemmata existieren, sortieren aber tief in die Liste).');
+      return;
+    }
+
+    await zeile.locator('[data-hx-detail]').click();
+    const panel = page.locator('[id^="hxDetailCell-"]', { hasText: 'Kandidat für die Kuratierung' }).first();
+    await expect(panel).toContainText('Fundstellen:', { timeout: 15000 });
+    await expect(panel.locator('li a').first()).toHaveAttribute('href', /korpus\.html\?textId=/);
   });
 
   test('Route + Sidebar-Button öffnen das Modul, Liste füllt sich', async ({ page }) => {


### PR DESCRIPTION
Ersetzt #234, das durch das Löschen des Base-Branchs beim Merge von #233 automatisch geschlossen wurde. Inhaltlich identisch, nur auf `main` umbasiert; die Review-Historie steht in #234.

KZW in #140: „wer der Autor ist ... interessiert bei Hapax besonders auf den ersten Blick."

## Was sich ändert

Das Detail-Panel eines Hapax zeigt jetzt einen Block „Fundstellen" mit Werktitel, Autor in Klammern, Versangabe und Sigle, jeweils verlinkt in die Leseansicht mit Highlight. Die Tabellenspalte zeigt weiterhin nur die Sigle, weil sie in eine Zeile passen muss.

Drei Punkte, die beim Bauen aufgefallen sind:

- **Der Block steht vor dem Early Return** für Lemmata ohne Authority-Eintrag. Gerade die Kuratierungsfunde („Lemma-ID wird im Korpus referenziert, fehlt aber im Authority-File") sind ohne Fundort nicht nachverfolgbar.
- **660 der 667 Texte tragen einen Autor** im Korpus-Index. Die übrigen bekommen gar keinen Klammerzusatz statt eines leeren.
- **Versangabe über `verseForPosition`**, mit Rückfall auf die Position, wenn der Text keine `lineStarts` hat (Prosa).

Dazu der Stil-Fix aus der #233-Review (Runde 5): Doppelpunkt statt Komma nach dem Dateinamen, analog zur gleichen Konstruktion 130 Zeilen darüber.

## Verifikation

`hapax-legomena.spec.js` hat jetzt 7 Tests. **Sie sind nicht gelaufen** (Absprache: vor Playwright fragen); die frühere Angabe 6/6 in diesem Body war falsch.

Korrektur zur ersten Fassung: der Test zur zweiten Einsetzstelle prüfte beide Inhalte, aber nur einen Code-Zweig, und skippte dabei **immer**. Einträge ohne Authority-Eintrag sortieren über den Fallback-Schlüssel `lemma_NNNNN` und können bei 100 Zeilen pro Seite nie auf Seite 1 stehen. Er steuert die Seite jetzt gezielt an.

Dazu: sieben Texte tragen ein leeres `<author ref="#person_N"/>` und sahen dadurch autorlos aus. Der Autor wird jetzt über die Personen-Referenz aufgelöst (Mönch von Heilsbronn, Boppe, Herger, Burggraf von Riedenburg). Die leeren `<author/>`-Elemente gehören trotzdem im TEI gefüllt, das ist ein eigener Vorgang.

Refs #196
