### PR TITLE
#140: drei Fail-opens und ein Fehlalarm im Em-Dash-Gate (Nachtrag zu #233)

### DIFF
--- a/scripts/audit/check-no-em-dash.py
+++ b/scripts/audit/check-no-em-dash.py
@@ -445,10 +445,23 @@ SELBSTTEST = [
      '<!--\n  Notiz ' + EM_DASH + ' erlaubt\n-->\n<p>sauber</p>\n', []),
     ('Kommentarende auf //-Zeile, danach sichtbarer Text', '.html',
      '<!--\n// Notiz -->\n<p>Hinweis ' + EM_DASH + ' sichtbar</p>\n', [3]),
+    # Alle sieben Eintraege aus EM_FORMEN einmal durchspielen. Vorher waren nur
+    # drei davon getestet (Literal, &mdash;, —); die beiden numerischen
+    # Entities und die beiden CSS-Escapes liessen sich aus EM_FORMEN loeschen,
+    # ohne dass ein einziger Fall rot wurde. Fail-open-Richtung, deshalb je ein
+    # Fall. Befund aus dem Review zu diesem PR.
     ('HTML-Entity statt Literal', '.html',
      '<p>Hinweis &mdash; sichtbar</p>\n', [1]),
+    ('numerische Entity, dezimal', '.html',
+     '<p>Hinweis &#8212; sichtbar</p>\n', [1]),
+    ('numerische Entity, hexadezimal', '.html',
+     '<p>Hinweis &#x2014; sichtbar</p>\n', [1]),
     ('JS-Escape statt Literal', '.js',
      "const s = 'Hinweis " + chr(92) + "u2014 sichtbar';\n", [1]),
+    ('CSS-Escape, vierstellig', '.css',
+     'a::after { content: "' + chr(92) + '2014"; }\n', [1]),
+    ('CSS-Escape, sechsstellig', '.css',
+     'a::after { content: "' + chr(92) + '002014"; }\n', [1]),
     ('nachgestellter Kommentar im Inline-Script', '.html',
      '<script>\n  laden();  // Grund ' + EM_DASH + ' nur intern\n</script>\n', []),
     # Geltungsbereich: ein // IM HTML-Kommentar darf den sichtbaren Rest
@@ -475,6 +488,14 @@ SELBSTTEST_DATEIEN = [
     # fest, sie fallen schon durch die nicht-rekursiven HTML-Globs heraus.
     ('playground/js/ui/tei/h.js', "const s = 'x " + EM_DASH + " y';\n", True),
     ('assets/css/i.css', 'a::after { content: "x ' + EM_DASH + ' y"; }\n', True),
+    # Die drei HTML-Globs ausserhalb des Wurzelverzeichnisses waren ungetestet:
+    # `api/*.html`, `lemma/**/*.html` und `playground/**/*.html` liessen sich
+    # einzeln aus GLOBS loeschen, ohne dass ein Fall rot wurde, obwohl unter
+    # api/ und playground/ ausgelieferte Seiten liegen. Befund aus dem Review.
+    # Der lemma-Fall prueft zugleich, dass das Glob rekursiv ist.
+    ('api/index.html', '<p>x ' + EM_DASH + ' y</p>\n', True),
+    ('playground/index.html', '<p>x ' + EM_DASH + ' y</p>\n', True),
+    ('lemma/lemma_1/index.html', '<p>x ' + EM_DASH + ' y</p>\n', True),
     # Kaputte Kodierung: 0x97 ist in CP-1252 selbst ein Em-Dash. Frueher fiel
     # so eine Datei still aus dem Scan, jetzt wird sie gemeldet.
     ('assets/js/j.js', b"const s = 'a \x97 b';\n", True),

--- a/scripts/audit/check-no-em-dash.py
+++ b/scripts/audit/check-no-em-dash.py
@@ -27,6 +27,23 @@ Zwei Anläufe davor sind gescheitert, beide an derselben Sorte Ehrgeiz:
    nicht besser, nur schwerer zu prüfen: 27 Fundstellen, die Mehrzahl
    Kommentarzeilen.
 
+Ein dritter Weg wurde erwogen und verworfen: **Totalverbot** von U+2014 in
+den Auslieferungsverzeichnissen, Kommentare eingeschlossen. Das Skript
+schrumpfte auf gut 15 Zeilen ohne Zustand und ohne Kommentar-Erkennung, und
+die gesamte Fehlerklasse dieses Gates wäre weg statt geflickt: alle
+gefundenen Fail-opens saßen ausnahmslos in der Kommentar-Ausnahme. Dagegen
+spricht, dass die Hausregel Em-Dashes in Code-Kommentaren ausdrücklich
+erlaubt; eine repo-lokale Verschärfung nur für dieses Verzeichnis wäre eine
+Regeländerung und keine Entscheidung, die ein Audit-Skript treffen darf.
+Wenn die Kommentar-Ausnahme je fällt, ist das hier die einfachere Lösung.
+
+Der Selbsttest ist gegen Mutationen abgesichert: mehrere Änderungen am
+Scanner (Reihenfolgebedingung `k < pos` entfernen, sichtbaren Text vor einem
+öffnenden Kommentar verwerfen, Kodierungsfehler still überspringen) haben
+eine frühere Fassung der Fälle vollständig bestanden und waren trotzdem
+Fail-opens. Wer hier Fälle ergänzt, prüfe sie so: Mutation einbauen, Fälle
+laufen lassen. Ein Fall, der jede Mutation überlebt, prüft nichts.
+
 Die schlichte Regel trifft alle real vorhandenen Fälle und ist in fünf
 Zeilen nachvollziehbar. Sie hat zwei bekannte blinde Flecken, beide zum
 Fail-open hin, beide im Bestand aktuell unbelegt:
@@ -65,6 +82,14 @@ ist `tailwind-output.css`: generiert, minifiziert, und über
 `tailwind-input.css` plus die HTML-Klassen ohnehin mitgeprüft. Nicht
 geprüft: `docs/`, `publications/`, `tei/`, `authority-files/`, `schema/`,
 `testing/` und Fremdcode unter `vendor/`.
+
+Wenn ein Em-Dash einmal als DATEN gebraucht wird und nicht als Typografie
+(Normalisierungstabelle, Interpunktions-Regex, Platzhalter-Glyphe), dann ist
+der vorgesehene Weg `String.fromCharCode(0x2014)` beziehungsweise in Python
+`chr(0x2014)`, nicht ein weiterer Eintrag in `SKIP_DATEIEN`. Eine ganze
+Datei blindzuschalten, um ein Zeichen zu erlauben, ist der teuerste
+denkbare Tausch. Ein nachgestelltes `// erlaubt` hilft nicht: die Ausnahme
+verlangt das `//` VOR dem Fund.
 
 Usage:
     python scripts/audit/check-no-em-dash.py            # Report + Exit-Code
@@ -156,9 +181,21 @@ def scanne_verzeichnis(wurzel=None):
     wurzel = wurzel or REPO
     fundstellen = []
     for pfad in sorted(set(relevante_dateien(wurzel))):
+        rel = pfad.relative_to(wurzel).as_posix()
         try:
             text = pfad.read_text(encoding='utf-8')
-        except (UnicodeDecodeError, OSError):
+        except UnicodeDecodeError:
+            # NICHT ueberspringen. Ein stiller `continue` war ein Fail-open
+            # genau in der Schicht, die schon zwei Fehler dieses Gates trug:
+            # eine Datei mit einem einzigen Fremd-Byte fiele samt aller
+            # korrekt kodierten Em-Dashes aus dem Scan. Der realistische Fall
+            # ist ausgerechnet der hier gesuchte: Copy-Paste aus Word liefert
+            # CP-1252, und dort IST 0x97 der Em-Dash. UTF-8 ist ohnehin harte
+            # Projektvorgabe, also wird das gemeldet statt geschluckt.
+            fundstellen.append((rel, 1, 'Datei ist nicht UTF-8 und konnte '
+                                        'nicht geprueft werden'))
+            continue
+        except OSError:
             continue
         # Vorfilter ueber ALLE Schreibweisen. Ein Filter nur auf das
         # Literalzeichen verwirft genau den Fall, fuer den die Entity-
@@ -166,7 +203,6 @@ def scanne_verzeichnis(wurzel=None):
         if not any(f in text for f in EM_FORMEN):
             continue
         scan = scanner_fuer(pfad.suffix)
-        rel = pfad.relative_to(wurzel).as_posix()
         for nr, zeile in scan(text):
             fundstellen.append((rel, nr, zeile))
     return fundstellen
@@ -334,7 +370,10 @@ def scanne_html(text):
         # zerteilt, ist der zusammengesetzte sichtbare Text kein
         # zusammenhaengender Teilstring mehr.
         sichtbarer_text = ''.join(s for s, _ in sichtbar)
-        if sichtbarer_text.lstrip().startswith(('//', '*')):
+        # `/*` gehoert dazu: Inline-<script>- und <style>-Bloecke tragen
+        # Blockkommentare, und ohne diesen Praefix meldete das Gate eine ganz
+        # normale `/* ... */`-Kommentarzeile darin als Fehlalarm.
+        if sichtbarer_text.lstrip().startswith(('//', '*', '/*')):
             continue
         # Nachgestellte JS-Kommentare im Inline-<script> genauso exempieren
         # wie in .js-Dateien. Entscheidend ist der Geltungsbereich: sowohl
@@ -360,6 +399,31 @@ def scanne_html(text):
 
 SELBSTTEST = [
     # (Name, Endung, Quelltext, erwartete Zeilennummern)
+    #
+    # Die naechsten vier Faelle nageln die REIHENFOLGE fest und sind
+    # nachtraeglich entstanden: ein Mutationstest hat gezeigt, dass drei
+    # Aenderungen am Scanner alle bis dahin vorhandenen Faelle bestanden und
+    # trotzdem Fail-opens waren. Ohne sie darf man `k < pos` durch `k != -1`
+    # ersetzen (jede Zeile mit irgendeinem `//` waere exempt) oder in
+    # `scanne_html` den sichtbaren Text VOR einem oeffnenden `<!--` verwerfen.
+    # Gemeinsamer Nenner: kein Fall hatte die Reihenfolge "Em-Dash zuerst,
+    # Kommentar danach", obwohl genau das die haeufigste Form im Bestand ist.
+    ('Em-Dash im String, Kommentar erst danach', '.js',
+     "const s = 'x " + EM_DASH + " y'; // Hinweis\n", [1]),
+    ('Em-Dash im Inline-Script, Kommentar danach', '.html',
+     '<script>\n  const s = "x ' + EM_DASH + ' y"; // Hinweis\n</script>\n', [2]),
+    ('sichtbarer Text, danach oeffnet ein HTML-Kommentar', '.html',
+     '<p>x ' + EM_DASH + ' y</p> <!-- ok -->\n', [1]),
+    ('CSS: content-String, danach oeffnet ein Kommentar', '.css',
+     'a::after { content: "' + EM_DASH + '"; } /* ok */\n', [1]),
+    # Gegenrichtung zum vorletzten Fall: derselbe Zeilenbau, aber der Em-Dash
+    # steht IM mittig geoeffneten Kommentar und darf nicht gemeldet werden.
+    ('Em-Dash im mittig geoeffneten HTML-Kommentar', '.html',
+     '<p>sichtbar</p> <!-- Anmerkung ' + EM_DASH + ' erlaubt -->\n', []),
+    # Blockkommentar in einem Inline-<script>: haeufige Form, war ein
+    # Fehlalarm, solange der HTML-Zweig nur `//` und `*` als Praefix kannte.
+    ('Blockkommentar im Inline-Script', '.html',
+     '<script>\n/* Hinweis ' + EM_DASH + ' erlaubt */\n</script>\n', []),
     # CSS-Zweig: der erste Fall faellt unter scanne_js durch (Zeile beginnt
     # mit dem Universalselektor `*`, den die Praefixregel fuer einen Kommentar
     # haelt) und ist damit der Grund, warum es scanne_css gibt.
@@ -411,6 +475,9 @@ SELBSTTEST_DATEIEN = [
     # fest, sie fallen schon durch die nicht-rekursiven HTML-Globs heraus.
     ('playground/js/ui/tei/h.js', "const s = 'x " + EM_DASH + " y';\n", True),
     ('assets/css/i.css', 'a::after { content: "x ' + EM_DASH + ' y"; }\n', True),
+    # Kaputte Kodierung: 0x97 ist in CP-1252 selbst ein Em-Dash. Frueher fiel
+    # so eine Datei still aus dem Scan, jetzt wird sie gemeldet.
+    ('assets/js/j.js', b"const s = 'a \x97 b';\n", True),
     # Der Fall prueft NUR den Ausschluss: ohne SKIP_DATEIEN wird die Datei
     # gemeldet, mit nicht. (Die urspruengliche Begruendung hier, eine Zeile mit
     # fuehrendem `*` falle ohnehin an der Praefixregel durch, gilt seit
@@ -439,7 +506,11 @@ def selbsttest():
         for rel, inhalt, _ in SELBSTTEST_DATEIEN:
             ziel = wurzel / rel
             ziel.parent.mkdir(parents=True, exist_ok=True)
-            ziel.write_text(inhalt, encoding='utf-8')
+            # bytes statt str erlaubt einen Fall mit kaputter Kodierung
+            if isinstance(inhalt, bytes):
+                ziel.write_bytes(inhalt)
+            else:
+                ziel.write_text(inhalt, encoding='utf-8')
         gemeldet = {p for p, _, _ in scanne_verzeichnis(wurzel)}
         for rel, _, erwartet in SELBSTTEST_DATEIEN:
             ok = (rel in gemeldet) == erwartet

--- a/scripts/audit/check-no-em-dash.py
+++ b/scripts/audit/check-no-em-dash.py
@@ -492,10 +492,34 @@ SELBSTTEST_DATEIEN = [
     # `api/*.html`, `lemma/**/*.html` und `playground/**/*.html` liessen sich
     # einzeln aus GLOBS loeschen, ohne dass ein Fall rot wurde, obwohl unter
     # api/ und playground/ ausgelieferte Seiten liegen. Befund aus dem Review.
-    # Der lemma-Fall prueft zugleich, dass das Glob rekursiv ist.
     ('api/index.html', '<p>x ' + EM_DASH + ' y</p>\n', True),
     ('playground/index.html', '<p>x ' + EM_DASH + ' y</p>\n', True),
     ('lemma/lemma_1/index.html', '<p>x ' + EM_DASH + ' y</p>\n', True),
+    # Die drei Faelle darunter schliessen zwei Luecken auf einmal (zweite
+    # Review-Runde, wieder per Mutation nachgewiesen):
+    #
+    # (a) REKURSIVITAET. `assets/js/**/*.js`, `playground/**/*.html` und
+    #     `assets/css/**/*.css` liessen sich auf die nicht-rekursive Form
+    #     verkuerzen, ohne dass ein Fall rot wurde: alle bisherigen Dateien
+    #     liegen im Wurzel ihres Teilbaums. Real liegen 10 von 13 JS-Dateien
+    #     unter assets/js/ in Unterordnern (lib/, search/, rendering/,
+    #     storage/). `playground/**/*.js` war als einziges schon gedeckt,
+    #     naemlich durch playground/js/ui/tei/h.js.
+    #
+    # (b) VORFILTER. Vor dem Scan steht ein `any(f in text for f in
+    #     EM_FORMEN)`. Die Zeilen-Faelle rufen den Scanner direkt auf und
+    #     umgehen ihn; auf Dateiebene trug bis hierher jeder Fall das
+    #     Literalzeichen oder `&mdash;`. Der Vorfilter liess sich also auf
+    #     diese zwei Formen verengen, und eine Datei mit ausschliesslich
+    #     `—`, `&#8212;` oder einem CSS-Escape waere still uebersprungen
+    #     worden: genau der Fail-open, den die Zeilen-Faelle eine Ebene
+    #     hoeher schliessen sollten. Deshalb tragen die drei Faelle je eine
+    #     NICHT-literale Schreibweise.
+    ('assets/js/lib/k.js',
+     "const s = 'x " + chr(92) + "u2014 y';\n", True),
+    ('playground/sub/x.html', '<p>x &#8212; y</p>\n', True),
+    ('assets/css/sub/m.css',
+     'a::after { content: "' + chr(92) + '2014"; }\n', True),
     # Kaputte Kodierung: 0x97 ist in CP-1252 selbst ein Em-Dash. Frueher fiel
     # so eine Datei still aus dem Scan, jetzt wird sie gemeldet.
     ('assets/js/j.js', b"const s = 'a \x97 b';\n", True),


### PR DESCRIPTION
Nachtrag zu #233. Nach dem Merge habe ich das Gate von einem unabhängigen Reviewer (Fable) prüfen lassen, weil neun CI-Runden in Folge jeweils einen neuen Fail-open gefunden hatten und ich wissen wollte, ob das Ding trägt. Es kamen drei weitere Fail-opens und ein Fehlalarm zurück, alle hier belegt.

## Der eigentliche Befund: der Selbsttest war blind

Der Reviewer behauptete, drei Änderungen am Scanner bestünden alle 25 Selbsttest-Fälle und wären trotzdem Fail-opens. Ich habe das nicht geglaubt, sondern nachgemessen: Mutation ins Skript einbauen, Selbsttest laufen lassen.

| Mutation | vor diesem PR | jetzt |
|---|---|---|
| `k < pos` in `scanne_js` weglassen (jede Zeile mit `//` exempt) | besteht | fällt durch |
| dasselbe in `scanne_html` | besteht | fällt durch |
| sichtbaren Text vor einem öffnenden `<!--` verwerfen | besteht | fällt durch |
| Kodierungsfehler still überspringen | besteht | fällt durch |
| `/*`-Präfix im HTML-Zweig entfernen | besteht | fällt durch |

Gemeinsamer Nenner der ersten drei: **kein einziger Fall hatte die Reihenfolge „Em-Dash zuerst, Kommentar danach"**, obwohl genau das die häufigste Form im Bestand ist (`corpus-loader.js`, `tei-cache-manager.js`). Sechs neue Fälle schließen das.

## Die einzelnen Fixes

**1. Kodierungsfehler wurden still verschluckt.** `read_text` mit `except UnicodeDecodeError: continue` warf eine Datei mit einem einzigen Fremd-Byte komplett aus dem Scan, samt aller korrekt kodierten Em-Dashes darin. Der realistische Fall ist ausgerechnet der gesuchte: Copy-Paste aus Word liefert CP-1252, und dort **ist** `0x97` der Em-Dash. Wird jetzt gemeldet. `check-no-cdn.py` las übrigens von Anfang an mit `errors='replace'`, dieses Gate nicht.

**2. Fehlalarm bei Blockkommentaren im Inline-`<script>`.** Der HTML-Zweig kannte nur `//` und `*` als Präfix. Eine normale `/* ... */`-Zeile in einem Inline-Script wurde gemeldet. Ein Fehlalarm ist harmloser als ein Fail-open, macht das Gate aber unglaubwürdig.

**3. Docstring.** Zwei Ergänzungen, die künftige Sessions Zeit sparen: der dritte, verworfene Ansatz (Totalverbot inklusive Kommentare, das Skript schrumpfte auf 15 Zeilen und die Fehlerklasse wäre weg) mit Begründung, warum ich mich dagegen entschieden habe, und der vorgesehene Ausweg für legitime Daten-Em-Dashes (`String.fromCharCode(0x2014)` statt eines weiteren Eintrags in `SKIP_DATEIEN`).

## Verifikation

Selbsttest 32/32, Repo-Scan sauber über HTML, JS und CSS, `check-no-cdn.py` grün. Das Mutationsskript liegt nicht im Repo; das Verfahren steht als Anweisung im Docstring, damit die nächste Person, die Fälle ergänzt, sie genauso prüft.

Refs #140