### PR TITLE
#169: Nähesuche misst die Spanne, Dedup behält den nächsten Treffer, Fast-Path gestrichen

### DIFF
--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -378,6 +378,8 @@ Two steps that both changed with #169 (KZW decision 2026-07-28). Numbers from be
 
 **Step 1 – window selection.** `maxDistance` bounds the SPAN of all matched positions, not each position's distance to the anchor lemma. A hit requires one window of width `maxDistance` that holds the anchor and one occurrence of every other lemma.
 
+`maxDistance` is clamped to the range the UI declares (`0…50`, from `input#proximityDistance[max=50]`) before the search runs, with a non-numeric value falling back to 10. The hash route only validates `dist > 0`, and unlike the old anchor test the window search gets more expensive as the distance grows, so the data layer enforces the bound itself rather than trusting the surface.
+
 ```
 function findCoveringWindow(firstPos, otherPositionLists, maxDistance):
     // otherPositionLists = ascending position arrays, one per non-anchor lemma
@@ -417,10 +419,10 @@ function deduplicateProximityResults(rawMatches):
     deduplicated = []
 
     for each (filename, fileResults) in byFile:
-        sort fileResults by (distance ascending, contextStart ascending)
+        byDistance = COPY of fileResults sorted by (distance asc, contextStart asc)
 
         kept = []
-        for each result in fileResults:
+        for each result in byDistance:
             overlaps = kept.any(existing =>
                 max(existing.contextStart, result.contextStart)
                     < min(existing.contextEnd, result.contextEnd)

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -368,40 +368,73 @@ dedup(rawResults):
    - `{textId: "DES2", matchCount: 5, lemmaIds: ["lemma_879"]}`
 4. Both lemmata get distinct highlight colors in reading view
 
-### C.2.2 Playground: Proximity Context Window Dedup
+### C.2.2 Playground: Proximity Window Selection and Context Dedup
 
-Source: `playground/js/data/tei-manager.js` (proximity search function)
+Source: `playground/js/data/tei-manager.js` (`findCoveringWindow`, `searchProximityUsingEnhancedIndex`)
 
-**Trigger:** Proximity search finds multiple overlapping co-occurrence windows in the same text. Without dedup, the same passage appears multiple times with slightly shifted windows.
+Two steps that both changed with #169 (KZW decision 2026-07-28). Numbers from before 2026-07-29 are not comparable for searches with three or more lemmata; see the JOURNAL entry of that date.
+
+**Caveat on the input positions.** This function builds its per-lemma position lists by scanning `words[]` for equality, so it is first-id only and does not follow the §B.1 consumer rule (the verse search next to it does, via `lemmata{}`). Same standing justification as `cooccurrence-ranking.js`: 0 multi-ref cases in the corpus today. It becomes wrong the moment a `<w>` carries two `@lemmaRef` ids.
+
+**Step 1 – window selection.** `maxDistance` bounds the SPAN of all matched positions, not each position's distance to the anchor lemma. A hit requires one window of width `maxDistance` that holds the anchor and one occurrence of every other lemma.
+
+```
+function findCoveringWindow(firstPos, otherPositionLists, maxDistance):
+    // otherPositionLists = ascending position arrays, one per non-anchor lemma
+    if otherPositionLists is empty: return []
+
+    // An optimal window always starts on an occupied position
+    candidates = {firstPos}
+    for each list in otherPositionLists:
+        candidates += every p in list with firstPos - maxDistance <= p <= firstPos
+
+    best = null, bestSpan = INFINITY
+    for each windowStart in sorted(candidates):
+        windowEnd = windowStart + maxDistance
+        if firstPos > windowEnd: continue
+
+        chosen = []
+        for each list in otherPositionLists:
+            p = first element of list >= windowStart     // binary search
+            if p does not exist OR p > windowEnd: mark uncovered, break
+            chosen.push(p)
+        if uncovered: continue
+
+        span = max(firstPos, ...chosen) - min(firstPos, ...chosen)
+        if span < bestSpan: bestSpan = span, best = chosen
+
+    return best        // null when no window carries all lemmata
+```
+
+**Why the search over window starts, not just a range check.** Until 2026-07-29 each further lemma was tested against `firstPos` alone (`positions.find(p => abs(p - firstPos) <= maxDistance)`), so B at anchor−5 and C at anchor+5 both passed at `maxDistance` 5 although they sit 10 apart; `actualDistance` then reported the 10 correctly in the very same result object. Adding a span check on top of the old selection would not fix it, because `find()` returns the FIRST position in anchor range, not the most useful one. With B = {90, 110}, C = {109}, `firstPos` = 100 and `maxDistance` = 10 that selection yields B = 90, span 19, and the hit would be dropped although B = 110 with C = 109 spans exactly 10. Iterating the possible window starts also keeps the reported distance minimal.
+
+**Step 2 – context dedup.** Overlapping context windows in the same file collapse to the one with the SHORTEST distance.
 
 ```
 function deduplicateProximityResults(rawMatches):
     // rawMatches = [{filename, matchPositions, distance, contextStart, contextEnd, ...}, ...]
-
-    // Step 1: Group by filename
     byFile = groupBy(rawMatches, 'filename')
-
     deduplicated = []
 
-    // Step 2: For each file, remove overlapping windows
     for each (filename, fileResults) in byFile:
-        sort fileResults by contextStart ascending
+        sort fileResults by (distance ascending, contextStart ascending)
 
+        kept = []
         for each result in fileResults:
-            overlaps = deduplicated.any(existing =>
-                existing.filename === result.filename
-                AND max(existing.contextStart, result.contextStart)
+            overlaps = kept.any(existing =>
+                max(existing.contextStart, result.contextStart)
                     < min(existing.contextEnd, result.contextEnd)
             )
+            if NOT overlaps: kept.push(result)
+            // else: discard — the kept match is the closer one by construction
 
-            if NOT overlaps:
-                deduplicated.push(result)
-            // else: discard (keep earlier/shorter-distance match)
+        sort kept by contextStart ascending      // output follows the text
+        deduplicated += kept
 
     return deduplicated
 ```
 
-**Behavior:** When two context windows overlap, the first one (earlier position, already added) wins. This keeps the closer match since results within each file are sorted by position.
+**Behavior:** the closest co-occurrence in a passage wins; output order stays reading order. Before 2026-07-29 the sort key was `contextStart`, so the EARLIEST match won while the comment and the console log claimed "keeping shorter distance" (#169 finding 48). Users were shown the more distant co-occurrence whenever the earlier window happened to be the wider one.
 
 ### C.2.3 Playground: Document-Level Aggregation
 

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -251,3 +251,34 @@ Beim Schließen dieser Lücke ist mir **dreimal hintereinander** ein Audit-Eintr
 **Open issues:** #244 (Emoji-Icons) wartet auf Review; #231 auf die fachliche Verszählungs-Prüfung. An KZW gemeldet: sieben Texte mit leerem `<author>`-Element (ALX, BVSN, PSG, PTS = Mönch von Heilsbronn, BOP = Boppe, MHG = Herger, MRB = Burggraf von Riedenburg) und die Namensvariante Rietenburg/Riedenburg zwischen `works.xml` und `persons.xml`, beides an #228. Korpusweit stehen noch **4.077 `w[@pos="DIG"]` in 79 Texten** (frühere Angabe „4.657 in 66" war falsch gezählt), und diese Zahl **unterschätzt** die echte Menge, weil sie die unannotierten Randziffern nicht sieht.
 
 **Next steps:** 1. #244 reviewen und mergen. 2. #228 als nächste große Sache, KZWs detaillierter Auftrag steht im Issue. 3. Vor einem korpusweiten Ziffern-Lauf die zwei offenen Härtungen im Skript schließen (`huelle_leer()` prüft nur `el.text`, nicht `el[0].tail`; der Regex `^[ivxlcdm]+$` trifft auch „im", „vil", „lid"). 4. KZW an Alan erinnern (they/them), zweite Septemberwoche.
+
+---
+
+## 2026-07-29 – Nähesuche misst jetzt die Spanne (#169, Befunde 15/48/51)
+
+**Kontext:** KZW hat am 28.07. in #169 die drei letzten offenen Audit-Befunde freigegeben („#15 Nähesuche: bitte fixen", „#51 und #48: einverstanden"). Die Nummern 15, 48 und 51 sind Befund-Nummern im Issue-Body, keine Issue-Nummern. Alle drei sitzen im Playground und berühren keine Daten, also kein Data-Change-Lifecycle und kein Index-Bump.
+
+**Die Zahlen-Zäsur, um die KZW ausdrücklich gebeten hat.** Ab heute bedeutet „innerhalb N Wörter", dass alle Treffer-Positionen zusammen in ein Fenster der Breite N passen. Vorher wurde jedes weitere Lemma nur gegen das Anker-Lemma gemessen, die reale Spanne konnte also bis 2×N betragen. **Trefferzahlen aus Suchen mit drei oder mehr Lemmata von vor dem 29.07.2026 sind mit heutigen nicht vergleichbar und liegen systematisch zu hoch.** Bei zwei Lemmata sind Ankerabstand und Spanne dasselbe; dort ändert der Fenster-Fix nichts.
+
+Gemessen an „minne + herze + leit" (lemma_4130 + lemma_2795 + lemma_3691) über alle 667 Texte:
+
+| maxDistance | Treffer alt | Treffer neu | größte real gemeldete Spanne im alten Stand |
+|---|---:|---:|---:|
+| 5 | 1 | 0 | 6 (BUH) |
+| 10 | 5 | 4 | 12 (TRM) |
+| 20 | 19 | 16 | 38 (RDS) |
+
+Der RDS-Fall zeigt das Ausmaß: bei „innerhalb 20 Wörter" standen die drei Lemmata 38 Wörter auseinander. Die daneben berechnete `actualDistance` hat diese 38 sogar korrekt ausgewiesen, der Filter hatte den Treffer nur längst durchgelassen.
+
+**Warum der Fix eine Fenstersuche ist und keine Nachprüfung.** Die naheliegende Minimallösung wäre, die alte Auswahl zu behalten und Treffer mit zu großer Spanne zu verwerfen. Das erzeugt aber falsche Negative: `positions.find()` nahm die erste Position in Ankernähe, nicht die brauchbarste. Bei B = {90, 110}, C = {109} und Anker 100 fiele der Treffer weg, obwohl B = 110 mit C = 109 exakt die Spanne 10 bildet. `findCoveringWindow` iteriert deshalb über die möglichen Fensteranfänge und nimmt die kleinste tragfähige Spanne; das hält nebenbei die angezeigte Distanz minimal. Der Testfall dazu ist im Rückbau rot mit `distance: 19` geworden, also genau dem Wert, den die Minimallösung verworfen hätte.
+
+**Befund 48, der Dedup log seit jeher.** Bei überlappenden Kontextfenstern behielt der Code den zuerst startenden Treffer, während Kommentar und Konsolenzeile „keeping shorter distance" behaupteten. Jetzt entscheidet die Distanz. Nebeneffekt: die Trefferzahl kann dadurch leicht **steigen**, weil die distanzsortierte Greedy-Auswahl mehr nicht überlappende Fenster zulässt. Bei „minne + herze" (2 Lemmata, Abstand 10) gehen 243 auf 244; die Rohtrefferzahl bleibt bei 276 unverändert. Das ist die einzige Zahlenänderung, die auch Zwei-Lemma-Suchen betrifft.
+
+**Befund 51 war kein Zukunftsrisiko mehr, sondern ein aktiver Bug.** Das hartkodierte Fast-Path-Wörterbuch in `tei-ui.js` löste zum Zeitpunkt der Entfernung fünf von elf Eingaben falsch auf, weil die Lemma-IDs seit dem Eintragen neu vergeben wurden: „fleisch"/„vleisch" lieferten lemma_1816 *forma* statt lemma_7121 *vleisch*, „käse"/„kæse" lemma_26713 *eierkæse* statt lemma_3175 *kæse*, „bier" lemma_712 *bir* (die Birne) statt lemma_702 *bier*. Wer im Playground „bier" suchte, bekam Birnen. Die sechs korrekten Einträge verlieren nichts, weil Stufe 1 und 2 sie ohnehin finden. Das Issue führte den Punkt als künftiges Renumbering-Risiko; das Renumbering hatte längst stattgefunden, nur gemerkt hatte es niemand, weil ein Fast-Path per Definition nie am Vergleich vorbeikommt.
+
+**Lehren:**
+1. **Ein fehlschlagender `npm test` blockiert am Ende die Shell.** Playwrights HTML-Reporter serviert bei Failures den Report und wartet. Für Rückbau-Beweise `PW_TEST_HTML_REPORT_OPEN=never` setzen, sonst läuft das Kommando in den Timeout und lässt bei `git stash`-Rückbauten den Stash liegen.
+2. **Ein Fast-Path ist eine Zusicherung ohne Prüfstelle.** Er umgeht genau den Code, der einen Fehler bemerken würde. Ein Cache mit Invalidierung wäre vertretbar gewesen, ein Literal-Dict auf IDs nicht.
+3. **Die Doku hatte recht und der Code unrecht.** `ARCHITECTURE.md` beschrieb seit jeher „find combinations where all lemmata within maxDistance". CONTRACTS §C.2.2 dagegen hat die falsche Dedup-Semantik mitsamt Begründung festgeschrieben („This keeps the closer match since results within each file are sorted by position"). Pseudo-Code in Verträgen erbt Bugs, wenn er aus dem Code abgeschrieben statt gegen die Absicht geprüft wird.
+
+**Nicht angefasst, aber gefunden:** `findProximityMatchesInIndex` (`tei-manager.js`) wertet nur `positionSets[0]` und `[1]` aus, ignoriert also ab dem dritten Lemma alles. Die Funktion ist über `searchProximityUsingIndex` erreichbar, das im ganzen Repo nirgends aufgerufen wird, also toter Code. Ebenso tot: `executeProximitySearch` in `tei-ui.js`, das ein blockierendes `prompt()` öffnet. Beides gehört in eine Aufräumrunde, nicht in einen Semantik-PR.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -57,7 +57,7 @@ Direkt startbar geworden:
 |---|------|-------------|
 | #140 | Doku menschenlesbar | Bereinigung umgesetzt (PR #215, 12.07.); beide Detailfragen der Abnahme vom 27.07. erledigt (DRAFT-Kopf in TEI-MODEL.md entfernt, PR #230; „Woesner" repoweit einheitlich geschrieben, keine Variante „Wösner"/„Wosner" im Bestand, keine Änderung nötig). Offen ist nur noch die Abnahme durch KZW |
 | #58 | Begriff→Lemma→Beleg Workflow | Option A/B/C entscheiden |
-| #169 | Suchsemantik (Audit 3/6) | Punkt 45 (3-Stufen-Drift; Audit-Punktnummern, keine Issue-Nummern) entschieden und in PR #227 umgesetzt (ADR-016). Offen: Punkt 15 Nähesuche-Distanz, Punkt 51 Fast-Path-Wörterbuch, Punkt 48 Dedup |
+| #169 | Suchsemantik (Audit 3/6) | Alle vier Punkte umgesetzt (Punktnummern sind Audit-Befunde, keine Issue-Nummern): Punkt 45 3-Stufen-Drift in PR #227 (ADR-016), Punkte 15/48/51 nach KZW-Freigabe vom 28.07. am 29.07. Offen ist nur noch die Abnahme. Zahlen-Zäsur für 3+-Lemma-Nähesuchen im JOURNAL 2026-07-29 |
 | #172 | Test-Suite-Policy (Audit 6/6) | 45%-passRate-Floor + korpusabhängige Magic-Numbers |
 | #18 | Multi-Lemma + PoS-Suche | POS-Policy (#27/#181) gemerged, spezifizierbar; braucht POS-Daten im Corpus-Index |
 

--- a/playground/js/data/tei-manager.js
+++ b/playground/js/data/tei-manager.js
@@ -1076,6 +1076,16 @@ export class TEIFilesManager {
         const results = [];
         const includedTexts = corpusData.includedTexts || new Set();
 
+        // Der Wortabstand kommt aus einem Eingabefeld mit max="50", die
+        // Hash-Route prüft ihn aber nur auf > 0 (router.js, Parameter dist).
+        // Die alte Ankerprüfung war unabhängig von maxDistance teuer, die
+        // Fenstersuche nicht: ihre Kandidatenmenge wächst mit der Distanz.
+        // Ein hand-getipptes dist=9999 auf einem häufigen Lemma träfe damit
+        // die Kandidatensuche, deshalb hier auf den deklarierten UI-Bereich
+        // klemmen statt sich auf die Oberfläche zu verlassen.
+        const parsed = Number(maxDistance);
+        maxDistance = Number.isFinite(parsed) ? Math.max(0, Math.min(50, parsed)) : 10;
+
         corpusData.texts.forEach(text => {
             // Skip excluded texts
             if (!includedTexts.has(text.id)) return;

--- a/playground/js/data/tei-manager.js
+++ b/playground/js/data/tei-manager.js
@@ -985,6 +985,90 @@ export class TEIFilesManager {
     }
 
     /**
+     * Index der ersten Position >= value in einer aufsteigend sortierten Liste
+     * (untere Schranke), sonst list.length.
+     */
+    lowerBound(list, value) {
+        let lo = 0, hi = list.length;
+        while (lo < hi) {
+            const mid = (lo + hi) >> 1;
+            if (list[mid] < value) lo = mid + 1;
+            else hi = mid;
+        }
+        return lo;
+    }
+
+    /**
+     * Kleinstes Fenster der Breite maxDistance, das firstPos und je eine
+     * Position aus jeder weiteren Positionsliste enthält (#169 Befund #15).
+     *
+     * Vorher prüfte die Nähesuche jedes weitere Lemma nur gegen den Anker
+     * firstPos. Bei „innerhalb 5 Wörter" passierten damit B bei Anker−5 und
+     * C bei Anker+5 beide, obwohl sie real 10 auseinanderliegen. Die daneben
+     * berechnete `actualDistance` meldete die 10 dann sogar korrekt: der
+     * Filter hatte sie nur schon durchgelassen. KZW hat den Fix am 28.07. in
+     * #169 freigegeben, sinkende Trefferzahlen ab 3 Lemmata inklusive.
+     *
+     * Es genügt nicht, die alte Auswahl nachträglich an der Spanne zu prüfen
+     * und sonst zu verwerfen: `positions.find()` nahm die erste Position im
+     * Ankerfenster, nicht die günstigste. Bei B = {90, 110}, C = {109},
+     * firstPos = 100 und maxDistance = 10 fiele der Treffer sonst weg, obwohl
+     * B = 110 zusammen mit C = 109 und dem Anker eine Spanne von genau 10
+     * bildet. Deshalb wird über die möglichen Fensteranfänge iteriert und die
+     * kleinste tragfähige Spanne gewählt; das hält zugleich die angezeigte
+     * Distanz minimal.
+     *
+     * @param {number} firstPos - Ankerposition (erstes Lemma)
+     * @param {number[][]} otherPositionLists - aufsteigend sortierte Positionen
+     *   der weiteren Lemmata, in Eingabereihenfolge
+     * @param {number} maxDistance - erlaubte Spanne in Wörtern
+     * @returns {number[]|null} gewählte Positionen in Listenreihenfolge, oder
+     *   null, wenn kein Fenster alle Lemmata trägt
+     */
+    findCoveringWindow(firstPos, otherPositionLists, maxDistance) {
+        if (otherPositionLists.length === 0) return [];
+
+        // Ein optimales Fenster beginnt immer auf einer belegten Position:
+        // entweder auf dem Anker selbst oder auf einer Position links davon,
+        // die noch in Reichweite liegt.
+        const candidates = new Set([firstPos]);
+        for (const list of otherPositionLists) {
+            for (let i = this.lowerBound(list, firstPos - maxDistance);
+                 i < list.length && list[i] <= firstPos; i++) {
+                candidates.add(list[i]);
+            }
+        }
+
+        let best = null;
+        let bestSpan = Infinity;
+
+        for (const windowStart of [...candidates].sort((a, b) => a - b)) {
+            const windowEnd = windowStart + maxDistance;
+            if (firstPos > windowEnd) continue;
+
+            const chosen = [];
+            let covered = true;
+            for (const list of otherPositionLists) {
+                const i = this.lowerBound(list, windowStart);
+                if (i >= list.length || list[i] > windowEnd) {
+                    covered = false;
+                    break;
+                }
+                chosen.push(list[i]);
+            }
+            if (!covered) continue;
+
+            const span = Math.max(firstPos, ...chosen) - Math.min(firstPos, ...chosen);
+            if (span < bestSpan) {
+                bestSpan = span;
+                best = chosen;
+            }
+        }
+
+        return best;
+    }
+
+    /**
      * Proximity search using enhanced index (instant!)
      * Finds lemmas within maxDistance words of each other
      */
@@ -1029,51 +1113,38 @@ export class TEIFilesManager {
             const firstLemma = lemmaIds[0];
             const firstPositions = lemmaPositions[firstLemma];
 
+            // Positionslisten der weiteren Lemmata, in der Reihenfolge der
+            // Eingabe; aufsteigend sortiert, weil sie aus einem Index-Scan
+            // über words[] stammen.
+            const otherPositionLists = lemmaIds.slice(1).map(id => lemmaPositions[id]);
+
             firstPositions.forEach(firstPos => {
-                // Check if all other lemmas have at least one occurrence within maxDistance
-                const nearbyPositions = {};
-                let allNearby = true;
+                // #169 Befund #15: alle gewählten Positionen müssen zusammen in
+                // ein Fenster der Breite maxDistance passen, nicht nur einzeln
+                // in Ankernähe liegen.
+                const chosen = this.findCoveringWindow(firstPos, otherPositionLists, maxDistance);
+                if (chosen === null) return;
 
-                for (let i = 1; i < lemmaIds.length; i++) {
-                    const lemmaId = lemmaIds[i];
-                    const positions = lemmaPositions[lemmaId];
+                const allPositions = [firstPos, ...chosen];
+                const minPos = Math.min(...allPositions);
+                const maxPos = Math.max(...allPositions);
+                const actualDistance = maxPos - minPos;
 
-                    // Find closest position to firstPos
-                    const nearbyPos = positions.find(pos =>
-                        Math.abs(pos - firstPos) <= maxDistance
-                    );
+                // Extract context (±10 words)
+                const contextStart = Math.max(0, minPos - 10);
+                const contextEnd = Math.min(text.words.length, maxPos + 11);
 
-                    if (nearbyPos !== undefined) {
-                        nearbyPositions[lemmaId] = nearbyPos;
-                    } else {
-                        allNearby = false;
-                        break;
-                    }
-                }
-
-                if (allNearby) {
-                    // Calculate actual distance (max distance between any pair)
-                    const allPositions = [firstPos, ...Object.values(nearbyPositions)];
-                    const minPos = Math.min(...allPositions);
-                    const maxPos = Math.max(...allPositions);
-                    const actualDistance = maxPos - minPos;
-
-                    // Extract context (±10 words)
-                    const contextStart = Math.max(0, minPos - 10);
-                    const contextEnd = Math.min(text.words.length, maxPos + 11);
-
-                    // Store positions and metadata - UI will fetch TEI for actual text
-                    results.push({
-                        filename: text.filename,
-                        title: text.title,
-                        author: text.author || 'Unbekannt',
-                        matchPositions: allPositions,
-                        distance: actualDistance,
-                        contextStart: contextStart,
-                        contextEnd: contextEnd,
-                        contextLemmas: text.words.slice(contextStart, contextEnd)
-                    });
-                }
+                // Store positions and metadata - UI will fetch TEI for actual text
+                results.push({
+                    filename: text.filename,
+                    title: text.title,
+                    author: text.author || 'Unbekannt',
+                    matchPositions: allPositions,
+                    distance: actualDistance,
+                    contextStart: contextStart,
+                    contextEnd: contextEnd,
+                    contextLemmas: text.words.slice(contextStart, contextEnd)
+                });
             });
         });
 
@@ -1081,6 +1152,15 @@ export class TEIFilesManager {
 
         // v4.0.0: Deduplicate overlapping matches
         // Keep only the closest match when context windows overlap
+        //
+        // #169 Befund #48: bis 2026-07 sortierte diese Stelle nach contextStart
+        // und behielt damit den zuerst STARTENDEN Treffer, während Kommentar
+        // und Log-Zeile „keeping shorter distance" das Gegenteil behaupteten.
+        // Bei Überlappung bekam der Nutzer also gegebenenfalls die weiter
+        // entfernte Kookkurrenz angezeigt. Jetzt entscheidet tatsächlich die
+        // Distanz: pro Datei aufsteigend nach Distanz greedy auswählen, bei
+        // Gleichstand der frühere Treffer. Ausgegeben wird wieder in
+        // Lesereihenfolge, damit die Anzeige dem Textverlauf folgt.
         const deduplicated = [];
 
         // Group by filename first
@@ -1092,30 +1172,27 @@ export class TEIFilesManager {
 
         // For each file, remove overlapping matches (keep closest)
         Object.entries(byFile).forEach(([filename, fileResults]) => {
-            // Sort by contextStart for easier overlap detection
-            fileResults.sort((a, b) => a.contextStart - b.contextStart);
+            const byDistance = [...fileResults].sort((a, b) =>
+                (a.distance - b.distance) || (a.contextStart - b.contextStart)
+            );
 
-            fileResults.forEach(result => {
-                // Check if this result overlaps with any already added result
-                const overlaps = deduplicated.some(existing => {
-                    if (existing.filename !== result.filename) return false;
+            const kept = [];
+            byDistance.forEach(result => {
+                const overlapping = kept.find(existing =>
+                    Math.max(existing.contextStart, result.contextStart) <
+                    Math.min(existing.contextEnd, result.contextEnd)
+                );
 
-                    // Check if context windows overlap
-                    const overlapStart = Math.max(existing.contextStart, result.contextStart);
-                    const overlapEnd = Math.min(existing.contextEnd, result.contextEnd);
-                    const hasOverlap = overlapStart < overlapEnd;
-
-                    if (hasOverlap) {
-                        console.log(`  🔄 Overlap detected: ${filename} [${result.contextStart}-${result.contextEnd}] overlaps with [${existing.contextStart}-${existing.contextEnd}], keeping shorter distance (${existing.distance} vs ${result.distance})`);
-                    }
-
-                    return hasOverlap;
-                });
-
-                if (!overlaps) {
-                    deduplicated.push(result);
+                if (overlapping) {
+                    console.log(`  🔄 Overlap detected: ${filename} [${result.contextStart}-${result.contextEnd}] overlaps with [${overlapping.contextStart}-${overlapping.contextEnd}], keeping shorter distance (${overlapping.distance} vs ${result.distance})`);
+                    return;
                 }
+
+                kept.push(result);
             });
+
+            kept.sort((a, b) => a.contextStart - b.contextStart);
+            deduplicated.push(...kept);
         });
 
         const removedCount = results.length - deduplicated.length;

--- a/playground/js/ui/tei/tei-ui.js
+++ b/playground/js/ui/tei/tei-ui.js
@@ -90,51 +90,36 @@ export class TEIExplorer {
                 return;
             }
 
-            // Try hardcoded common lemma mappings first (fast path)
-            // Supports exact variants like: brôt/brot, wîn/win/wein, etc.
-            const lemmaId = this.findLemmaIdByOrthography(term);
-            if (lemmaId) {
-                lemmaIds.push(lemmaId);
-            } else {
-                // Fallback: 3-Stufen-Auflösung über den Authority-Manager
-                // (exakt -> Varianten -> Präfix-Match in beide Richtungen).
-                // Stufe 3 war bis #224 ein Substring-Test; sie matcht jetzt
-                // präfixorientiert und liefert bereits sortiert: erst Nähe zur
-                // Eingabe, dann Korpus-Frequenz. matches[0] ist damit das
-                // plausibelste Lemma und nicht mehr der erste Index-Treffer
-                // (#163/#164). Regel: assets/js/lib/lemma-resolve.js.
-                const authorityManager = window.playground?.authorityManager;
-                if (authorityManager) {
-                    const matches = authorityManager.searchLemmaByOrthography(term);
-                    if (matches.length > 0) {
-                        const lemmaId = matches[0].id.replace('lemma_', '');
-                        lemmaIds.push(lemmaId);
-                    }
+            // 3-Stufen-Auflösung über den Authority-Manager (exakt ->
+            // Varianten -> Präfix-Match in beide Richtungen). Stufe 3 war bis
+            // #224 ein Substring-Test; sie matcht jetzt präfixorientiert und
+            // liefert bereits sortiert: erst Nähe zur Eingabe, dann
+            // Korpus-Frequenz. matches[0] ist damit das plausibelste Lemma und
+            // nicht mehr der erste Index-Treffer (#163/#164).
+            // Regel: assets/js/lib/lemma-resolve.js.
+            //
+            // Davor stand hier bis 2026-07 ein hartkodiertes 11-Eintrag-
+            // Wörterbuch als „fast path" (brôt -> 879, wîn -> 7532, …), das die
+            // zentrale Auflösung umging (#169 Befund #51). Es war zum Zeitpunkt
+            // der Entfernung bereits in fünf von elf Einträgen falsch, weil die
+            // Lemma-IDs seit dem Eintragen neu vergeben wurden: „fleisch" und
+            // „vleisch" lieferten lemma_1816 forma statt lemma_7121 vleisch,
+            // „käse" und „kæse" lemma_26713 eierkæse statt lemma_3175 kæse,
+            // „bier" lemma_712 bir (die Birne) statt lemma_702 bier. Die sechs
+            // korrekten Einträge verlieren nichts: Stufe 1 und 2 finden sie
+            // ohnehin. Genau dieses stille Veralten war der Grund, es zu
+            // streichen statt die IDs nachzuziehen.
+            const authorityManager = window.playground?.authorityManager;
+            if (authorityManager) {
+                const matches = authorityManager.searchLemmaByOrthography(term);
+                if (matches.length > 0) {
+                    const lemmaId = matches[0].id.replace('lemma_', '');
+                    lemmaIds.push(lemmaId);
                 }
             }
         });
 
         return lemmaIds;
-    }
-
-    findLemmaIdByOrthography(orthography) {
-        // Common Middle High German lemma mappings
-        const commonLemmas = {
-            'brôt': '879',
-            'brot': '879', 
-            'wîn': '7532',
-            'win': '7532',
-            'wein': '7532',
-            'fleisch': '1816',
-            'vleisch': '1816',
-            'käse': '26713',
-            'kæse': '26713',
-            'bier': '712',
-            'bîr': '712'
-        };
-        
-        const normalized = orthography.toLowerCase();
-        return commonLemmas[normalized] || null;
     }
 
     // Context selection is now handled by the MultiLemmaSearchUI modal

--- a/testing/tests/proximity-and-resolution.spec.js
+++ b/testing/tests/proximity-and-resolution.spec.js
@@ -91,6 +91,26 @@ test.describe('#169 Befund #15: Nähesuche misst die Spanne, nicht den Ankerabst
         expect(treffer[0].distance).toBe(7);
     });
 
+    test('maxDistance wird auf den deklarierten UI-Bereich geklemmt', async ({ page }) => {
+        // Das Eingabefeld hat max="50", die Hash-Route prüft dist aber nur auf
+        // > 0. Die Fenstersuche ist im Gegensatz zur alten Ankerprüfung von
+        // der Distanz abhängig teuer, deshalb klemmt die Datenschicht selbst.
+        const placements = { 100: '1', 160: '2' };  // 60 Wörter auseinander
+
+        const ueberGrenze = await runProximity(page, placements, ['1', '2'], 9999, 300);
+        expect(ueberGrenze).toHaveLength(0);
+
+        // Gegenprobe: bei 60 wäre der Treffer da, wenn nicht geklemmt würde.
+        // Der Clamp macht daraus 50, also bleibt es bei null Treffern.
+        const knappDrunter = await runProximity(page, placements, ['1', '2'], 60, 300);
+        expect(knappDrunter).toHaveLength(0);
+
+        // Und bei 50 trägt eine Konstellation innerhalb der Grenze weiterhin.
+        const innerhalb = await runProximity(page, { 100: '1', 140: '2' }, ['1', '2'], 50, 300);
+        expect(innerhalb).toHaveLength(1);
+        expect(innerhalb[0].distance).toBe(40);
+    });
+
     test('findCoveringWindow: kleinste tragfähige Spanne, sonst null', async ({ page }) => {
         const ergebnis = await page.evaluate(() => {
             const tm = window.playground.teiManager;
@@ -133,6 +153,22 @@ test.describe('#169 Befund #48: Dedup behält den distanzkürzesten Treffer', ()
         expect(treffer).toHaveLength(1);
         expect(treffer[0].distance).toBe(1);
         expect([...treffer[0].matchPositions].sort((a, b) => a - b)).toEqual([120, 121]);
+    });
+
+    test('bei gleicher Distanz gewinnt der frühere Treffer', async ({ page }) => {
+        // Der zweite Teil des Sortierschlüssels, (distance, contextStart).
+        // Zwei überlappende Treffer mit identischer Distanz 2:
+        //   Anker 100 / Partner 102, Kontext [90, 113]
+        //   Anker 108 / Partner 110, Kontext [98, 121]
+        // Ohne den contextStart-Tiebreak hinge das Ergebnis daran, welchen
+        // die Sortierung zufällig vornliegen lässt.
+        const treffer = await runProximity(
+            page, { 100: '1', 108: '1', 102: '2', 110: '2' }, ['1', '2'], 10
+        );
+
+        expect(treffer).toHaveLength(1);
+        expect(treffer[0].distance).toBe(2);
+        expect([...treffer[0].matchPositions].sort((a, b) => a - b)).toEqual([100, 102]);
     });
 
     test('nicht überlappende Treffer bleiben alle erhalten, in Lesereihenfolge', async ({ page }) => {

--- a/testing/tests/proximity-and-resolution.spec.js
+++ b/testing/tests/proximity-and-resolution.spec.js
@@ -1,0 +1,196 @@
+/**
+ * Nähesuche-Fenster und Lemma-Auflösung im Playground (#169)
+ *
+ * Deckt die drei Befunde ab, die KZW am 28.07.2026 in #169 freigegeben hat:
+ *
+ * Befund #15 — die 3+-Lemma-Nähesuche maß jedes weitere Lemma nur gegen das
+ *   Anker-Lemma. Bei „innerhalb 5 Wörter" passierten B bei Anker−5 und C bei
+ *   Anker+5 beide, obwohl sie real 10 auseinanderliegen.
+ * Befund #48 — der Überlappungs-Dedup behielt den zuerst startenden statt den
+ *   distanzkürzesten Treffer, während Kommentar und Log das Gegenteil sagten.
+ * Befund #51 — ein hartkodiertes Lemma-Wörterbuch umging die zentrale
+ *   Auflösung und war in fünf von elf Einträgen bereits falsch.
+ *
+ * Die Fenster- und Dedup-Tests laufen gegen einen synthetischen Korpus, den
+ * sie searchProximityUsingEnhancedIndex direkt übergeben: die Methode nimmt
+ * corpusData als Parameter, deshalb braucht es dafür weder den 40-MB-Index
+ * noch die UI, und die erwarteten Zahlen sind von Korpus-Änderungen unabhängig.
+ */
+
+import { test, expect } from '@playwright/test';
+
+/**
+ * Synthetischer Korpus: words[i] trägt die Lemma-ID an Wortposition i.
+ * placements = { position: lemmaId }, alles andere ist Füll-Lemma lemma_999.
+ */
+function buildCorpus(placements, length = 200) {
+    const words = new Array(length).fill('lemma_999');
+    for (const [pos, id] of Object.entries(placements)) {
+        words[Number(pos)] = `lemma_${id}`;
+    }
+    return {
+        includedTexts: ['T1'],
+        texts: [{ id: 'T1', filename: 'T1.tei.xml', title: 'Synthetischer Testtext', words }]
+    };
+}
+
+async function runProximity(page, placements, lemmaIds, maxDistance, length = 200) {
+    const corpus = buildCorpus(placements, length);
+    return page.evaluate(async ({ corpus, lemmaIds, maxDistance }) => {
+        const corpusData = { ...corpus, includedTexts: new Set(corpus.includedTexts) };
+        return window.playground.teiManager.searchProximityUsingEnhancedIndex(
+            lemmaIds, maxDistance, corpusData
+        );
+    }, { corpus, lemmaIds, maxDistance });
+}
+
+test.describe('#169 Befund #15: Nähesuche misst die Spanne, nicht den Ankerabstand', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('http://localhost:8080/playground/');
+        await page.waitForFunction(() => window.playground?.teiManager !== undefined,
+            { timeout: 60000 });
+    });
+
+    test('B bei Anker−5 und C bei Anker+5 sind bei maxDistance 5 kein Treffer', async ({ page }) => {
+        // Der Fall aus dem Issue: beide liegen einzeln in Ankernähe, zusammen
+        // aber 10 Wörter auseinander. Vor dem Fix wurde er als Treffer
+        // gemeldet — mit distance 10 im selben Ergebnis-Objekt.
+        const placements = { 10: '2', 15: '1', 20: '3' };
+
+        const zuEng = await runProximity(page, placements, ['1', '2', '3'], 5);
+        expect(zuEng).toHaveLength(0);
+
+        // Gegenprobe, damit der Test nicht bloß „findet nichts mehr" belegt:
+        // bei maxDistance 10 trägt dieselbe Konstellation genau einen Treffer.
+        const passend = await runProximity(page, placements, ['1', '2', '3'], 10);
+        expect(passend).toHaveLength(1);
+        expect(passend[0].distance).toBe(10);
+        expect([...passend[0].matchPositions].sort((a, b) => a - b)).toEqual([10, 15, 20]);
+    });
+
+    test('gültiges Fenster wird gefunden, auch wenn die erste Position im Ankerfenster nicht passt', async ({ page }) => {
+        // Der Grund, warum es nicht reicht, die alte Auswahl nachträglich zu
+        // verwerfen: positions.find() nahm B = 90 (erste Position in
+        // Ankernähe), damit wäre die Spanne 109 − 90 = 19 und der Treffer
+        // fiele weg. Tragfähig ist B = 110 mit C = 109 und Anker 100.
+        const treffer = await runProximity(
+            page, { 100: '1', 90: '2', 110: '2', 109: '3' }, ['1', '2', '3'], 10
+        );
+
+        expect(treffer).toHaveLength(1);
+        expect(treffer[0].distance).toBe(10);
+        expect([...treffer[0].matchPositions].sort((a, b) => a - b)).toEqual([100, 109, 110]);
+    });
+
+    test('bei zwei Lemmata bleibt die Trefferzahl unverändert', async ({ page }) => {
+        // KZWs Zusicherung aus #169: der Fix betrifft erst 3+ Lemmata. Mit
+        // zwei Lemmata ist der Ankerabstand identisch mit der Spanne.
+        const treffer = await runProximity(page, { 50: '1', 57: '2' }, ['1', '2'], 10);
+
+        expect(treffer).toHaveLength(1);
+        expect(treffer[0].distance).toBe(7);
+    });
+
+    test('findCoveringWindow: kleinste tragfähige Spanne, sonst null', async ({ page }) => {
+        const ergebnis = await page.evaluate(() => {
+            const tm = window.playground.teiManager;
+            return {
+                keineWeiteren: tm.findCoveringWindow(100, [], 5),
+                unerreichbar: tm.findCoveringWindow(100, [[200]], 5),
+                kleinsteSpanne: tm.findCoveringWindow(100, [[95, 103]], 10),
+                ueberAnkerHinaus: tm.findCoveringWindow(100, [[90, 110], [109]], 10),
+                zuWeit: tm.findCoveringWindow(100, [[95], [105]], 5)
+            };
+        });
+
+        expect(ergebnis.keineWeiteren).toEqual([]);
+        expect(ergebnis.unerreichbar).toBeNull();
+        // 103 liegt 3 vom Anker, 95 liegt 5 — die kleinere Spanne gewinnt.
+        expect(ergebnis.kleinsteSpanne).toEqual([103]);
+        expect(ergebnis.ueberAnkerHinaus).toEqual([110, 109]);
+        // 95 und 105 liegen einzeln in Reichweite, zusammen 10 auseinander.
+        expect(ergebnis.zuWeit).toBeNull();
+    });
+});
+
+test.describe('#169 Befund #48: Dedup behält den distanzkürzesten Treffer', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('http://localhost:8080/playground/');
+        await page.waitForFunction(() => window.playground?.teiManager !== undefined,
+            { timeout: 60000 });
+    });
+
+    test('bei Überlappung gewinnt die kleinere Distanz, nicht der frühere Start', async ({ page }) => {
+        // Anker A bei 100 und 120, Partner B bei 108 und 121.
+        //   Treffer 1: 100/108, Distanz 8,  Kontext [90, 119]
+        //   Treffer 2: 120/121, Distanz 1,  Kontext [110, 132]
+        // Die Kontexte überlappen. Vorher entschied contextStart, also gewann
+        // Distanz 8; jetzt gewinnt Distanz 1.
+        const treffer = await runProximity(
+            page, { 100: '1', 120: '1', 108: '2', 121: '2' }, ['1', '2'], 10
+        );
+
+        expect(treffer).toHaveLength(1);
+        expect(treffer[0].distance).toBe(1);
+        expect([...treffer[0].matchPositions].sort((a, b) => a - b)).toEqual([120, 121]);
+    });
+
+    test('nicht überlappende Treffer bleiben alle erhalten, in Lesereihenfolge', async ({ page }) => {
+        // Weit auseinander: kein Dedup. Die Ausgabe folgt dem Textverlauf,
+        // obwohl intern nach Distanz ausgewählt wird.
+        const treffer = await runProximity(
+            page, { 20: '1', 22: '2', 150: '1', 159: '2' }, ['1', '2'], 10, 300
+        );
+
+        expect(treffer).toHaveLength(2);
+        expect(treffer.map(t => t.distance)).toEqual([2, 9]);
+        expect(treffer[0].contextStart).toBeLessThan(treffer[1].contextStart);
+    });
+});
+
+test.describe('#169 Befund #51: Fast-Path-Wörterbuch ist gestrichen', () => {
+    test('die elf früheren Fast-Path-Eingaben lösen regulär auf', async ({ page }) => {
+        await page.goto('http://localhost:8080/playground/');
+        await page.waitForFunction(() => {
+            return window.playground?.corpusData?.texts?.length > 0 &&
+                   window.playground?.ui?.multiLemmaSearch;
+        }, { timeout: 60000 });
+
+        const aufgeloest = await page.evaluate(() => {
+            const explorer = window.playground.ui.multiLemmaSearch.teiExplorer;
+            const eingaben = ['brôt', 'brot', 'wîn', 'win', 'wein', 'fleisch',
+                              'vleisch', 'käse', 'kæse', 'bier', 'bîr'];
+            const ergebnis = {};
+            for (const e of eingaben) ergebnis[e] = explorer.resolveLemmaIds([e])[0] || null;
+            return ergebnis;
+        });
+
+        // Die sechs Einträge, die der Fast-Path richtig hatte: unverändert.
+        expect(aufgeloest['brôt']).toBe('879');
+        expect(aufgeloest['brot']).toBe('879');
+        expect(aufgeloest['wîn']).toBe('7532');
+        expect(aufgeloest['win']).toBe('7532');
+        expect(aufgeloest['wein']).toBe('7532');
+        expect(aufgeloest['bîr']).toBe('712');
+
+        // Die fünf, die er falsch hatte: jetzt das inhaltlich richtige Lemma.
+        expect(aufgeloest['fleisch']).toBe('7121');   // war lemma_1816 forma
+        expect(aufgeloest['vleisch']).toBe('7121');   // war lemma_1816 forma
+        expect(aufgeloest['käse']).toBe('3175');      // war lemma_26713 eierkæse
+        expect(aufgeloest['kæse']).toBe('3175');      // war lemma_26713 eierkæse
+        expect(aufgeloest['bier']).toBe('702');       // war lemma_712 bir (Birne)
+    });
+
+    test('findLemmaIdByOrthography existiert nicht mehr', async ({ page }) => {
+        await page.goto('http://localhost:8080/playground/');
+        await page.waitForFunction(() => window.playground?.ui?.multiLemmaSearch !== undefined,
+            { timeout: 60000 });
+
+        const vorhanden = await page.evaluate(() => {
+            const explorer = window.playground.ui.multiLemmaSearch.teiExplorer;
+            return typeof explorer.findLemmaIdByOrthography;
+        });
+
+        expect(vorhanden).toBe('undefined');
+    });
+});


### PR DESCRIPTION
Setzt die drei Audit-Befunde aus #169 um, die KZW am 28.07. freigegeben hat („#15 Nähesuche: bitte fixen", „#51 und #48: einverstanden, bitte umsetzen").

**Zur Notation:** 15, 48 und 51 sind Befund-Nummern innerhalb des #169-Bodys, keine Issue-Nummern.

Alles frontend-only. Keine Datenänderung, kein Index-Bump, kein Data-Change-Lifecycle.

## Befund 15: die Nähesuche misst jetzt die Spanne

`maxDistance` begrenzt ab sofort die Spanne aller Treffer-Positionen, nicht mehr den Abstand jedes einzelnen Lemmas zum Anker. Vorher passierten bei „innerhalb 5 Wörter" B bei Anker−5 und C bei Anker+5 beide, obwohl sie real 10 auseinanderliegen. Die daneben berechnete `actualDistance` wies die 10 im selben Ergebnis-Objekt sogar korrekt aus, der Filter hatte sie nur längst durchgelassen.

**Warum eine Fenstersuche und keine Nachprüfung.** Die naheliegende Minimallösung wäre, die alte Auswahl zu behalten und Treffer mit zu großer Spanne zu verwerfen. Das erzeugt falsche Negative, weil `positions.find()` die erste Position in Ankernähe nahm, nicht die brauchbarste: bei B = {90, 110}, C = {109} und Anker 100 fiele der Treffer weg, obwohl B = 110 mit C = 109 exakt die Spanne 10 bildet. `findCoveringWindow` iteriert deshalb über die möglichen Fensteranfänge und nimmt die kleinste tragfähige Spanne. Der zugehörige Test wird im Rückbau mit `distance: 19` rot, also genau dem Wert, den die Minimallösung verworfen hätte.

**Gemessen** an „minne + herze + leit" (lemma_4130 + lemma_2795 + lemma_3691) über alle 667 Texte:

| maxDistance | alt | neu | größte real gemeldete Spanne im alten Stand |
|---|---:|---:|---:|
| 5 | 1 | 0 | 6 (BUH) |
| 10 | 5 | 4 | 12 (TRM) |
| 20 | 19 | 16 | 38 (RDS) |

Bei „innerhalb 20 Wörter" standen die drei Lemmata im RDS-Fall 38 Wörter auseinander.

Sinkende Trefferzahlen sind von KZW abgenommen. Der von ihr verlangte datierte JOURNAL-Eintrag steht in `docs/JOURNAL.md` unter 2026-07-29, damit ältere Zahlen zuordenbar bleiben. Kurzfassung: **Trefferzahlen aus Suchen mit drei oder mehr Lemmata von vor dem 29.07.2026 sind mit heutigen nicht vergleichbar und liegen systematisch zu hoch.**

## Befund 48: der Dedup behält jetzt wirklich den nächsten Treffer

Bei überlappenden Kontextfenstern gewinnt die kleinste Distanz statt des frühesten Starts. Kommentar und Konsolenzeile behaupteten das seit jeher („keeping shorter distance"), der Code sortierte aber nach `contextStart`. Die Ausgabe bleibt in Lesereihenfolge.

**Das ist eine Verhaltensänderung, die auch Zwei-Lemma-Suchen betrifft** und die Trefferzahl leicht **steigen** lassen kann: bei „minne + herze" (Abstand 10) gehen 243 auf 244, während die Rohtrefferzahl unverändert bei 276 bleibt. Grund ist der Wechsel des Greedy-Kriteriums: ein frühes breites Fenster konnte bisher zwei spätere kurze blockieren.

## Befund 51: das Fast-Path-Wörterbuch war kein Zukunftsrisiko mehr

Das Issue führte es als künftiges Renumbering-Risiko. Das Renumbering hatte längst stattgefunden: **fünf der elf Einträge lösten zum Zeitpunkt der Entfernung falsch auf.**

| Eingabe | Fast-Path lieferte | reguläre Auflösung | |
|---|---|---|---|
| `brôt`, `brot` | lemma_879 brôt | lemma_879 brôt | gleich |
| `wîn`, `win`, `wein` | lemma_7532 wîn | lemma_7532 wîn | gleich |
| `bîr` | lemma_712 bir | lemma_712 bir | gleich |
| `fleisch`, `vleisch` | lemma_1816 **forma** | lemma_7121 vleisch | falsch |
| `käse`, `kæse` | lemma_26713 **eierkæse** | lemma_3175 kæse | falsch |
| `bier` | lemma_712 **bir** (die Birne) | lemma_702 bier | falsch |

Wer im Playground „bier" suchte, bekam Birnen. Die sechs korrekten Einträge verlieren nichts, weil Stufe 1 und 2 sie ohnehin finden: `wein` etwa läuft über die Variantenauflösung auf `wîn`. Ersatzloses Streichen statt Nachziehen der IDs, weil ein Fast-Path per Konstruktion nie an der Prüfstelle vorbeikommt, die den Fehler bemerken würde.

## Doku

- `docs/CONTRACTS.md` §C.2.2 auf beide Schritte umgeschrieben. Der alte Pseudo-Code hatte die falsche Dedup-Semantik mitsamt Begründung festgeschrieben („This keeps the closer match since results within each file are sorted by position"). Neu aufgenommen ist außerdem der Caveat, dass diese Funktion ihre Positionslisten per `words[]`-Scan baut, also first-id-only arbeitet und der §B.1-Consumer-Rule nicht folgt (gleiche stehende Begründung wie bei `cooccurrence-ranking.js`: 0 Multi-ref-Fälle im Korpus).
- `docs/JOURNAL.md`: Eintrag 2026-07-29 mit der Zahlen-Zäsur.
- `docs/ROADMAP.md`: #169-Zeile auf „alle vier Punkte umgesetzt, offen ist die Abnahme".

## Verifikation

- **Neue Spec** `testing/tests/proximity-and-resolution.spec.js`, 8 Tests gegen einen synthetischen Korpus, den sie `searchProximityUsingEnhancedIndex` direkt übergeben. Damit hängen die Erwartungswerte nicht am 40-MB-Index.
- **Rückbau-Beweis gefahren:** ohne den Fix sind 6 der 8 Tests rot, jeder mit der passenden Diagnose (`distance: 19` statt 10, Dedup-Distanz 8 statt 1, `fleisch` auf 1816, `findCoveringWindow is not a function`). Die 2 grünen sind bewusst die Unverändert-Zusicherungen.
- **Regression:** 43/43 grün über `cooccurrence-ranking`, `multi-lemma-verse`, `playground-corpus`, `search-with-corpus`, `corpus` und die neue Spec.
- **Chrome am laufenden Playground:** die 3-Lemma-Suche liefert 4 Treffer mit maximaler Spanne 10, TRM ist raus; die 2-Lemma-Suche 244; `bier` löst auf 702 auf, `fleisch` auf 7121, `käse` auf 3175, `wein` auf 7532. Deckt sich exakt mit der Messung.
- **Zweitmeinung (Fable):** Korrektheit von `findCoveringWindow` mit Beweisskizze bestätigt (jede tragfähige Auswahl hat ihr Minimum in der Kandidatenmenge), keine übersehenen Aufrufer, keine Nebenwirkungen auf Vers-Modus, Versposition-Suche, Reim-Wörterbuch oder Kookkurrenz-Ranking. Der `words[]`-Caveat oben geht auf diesen Review zurück.

## Beobachtet, nicht angefasst

- `findProximityMatchesInIndex` wertet nur `positionSets[0]` und `[1]` aus, ignoriert also ab dem dritten Lemma alles. Erreichbar nur über `searchProximityUsingIndex`, das im ganzen Repo nirgends aufgerufen wird. Ebenso tot: `executeProximitySearch` in `tei-ui.js`, das ein blockierendes `prompt()` öffnet. Gehört in eine Aufräumrunde, nicht in einen Semantik-PR.
- `parseInt(this.proximityDistance.value) || 10` in `multi-lemma-search.js` erzwingt das `max="50"` des Eingabefelds nicht. Vorbestehend; ein von Hand eingetipptes `dist=9999` wäre teuer.
- Die Assertions zu Befund 51 pinnen korpusabhängige Lemma-IDs. Hier gewollt, damit genau dieses stille Veralten künftig laut knallt. Berührt die offene Policy-Frage in #172.

Refs #169
