### PR TITLE
#28: Fremdsprachen-Phasenplan auf die Grenzziehungs-Entscheidungen umgestellt

### DIFF
--- a/docs/features/FREMDSPRACHEN-PHASENPLAN-28.md
+++ b/docs/features/FREMDSPRACHEN-PHASENPLAN-28.md
@@ -1,51 +1,77 @@
 # Fremdsprachen-Annotation: Daten-Phasenplan (#28)
 
-Temporal Artifact zu Issue #28 (Suche nach fremdsprachigen Passagen). Grundlage: KZW-Freigabe vom 29.05. für den Weg „LLM + Begriffssystem `concept_23123000` + externe Wörterbücher", der Audit-Befund „0 Token-Annotationen im Korpus" und Julias Bestätigung, dass auch WZB kein `xml:lang` auf Token-Ebene trägt. Nach Umsetzung: Kernwissen in DATA-MODEL/TEI-MODEL/CONTRACTS überführen, Datei löschen (CLAUDE.md → Temporal Artifacts).
+Temporal Artifact zu Issue #28 (Suche nach fremdsprachigen Passagen). Grundlage: KZW-Freigabe vom 29.05. für den Weg „LLM + Begriffssystem `concept_23123000` + externe Wörterbücher", der Audit-Befund „0 Token-Annotationen im Korpus", Julias Bestätigung, dass auch WZB kein `xml:lang` auf Token-Ebene trägt, sowie die KZW-Entscheidungen vom 29.07. (siehe „Entscheidungen"). Nach Umsetzung: Kernwissen in DATA-MODEL/TEI-MODEL/CONTRACTS überführen, Datei löschen (CLAUDE.md → Temporal Artifacts).
 
 ## Ausgangslage (verifiziert)
 
 - 0 `<w xml:lang>`, 0 `@foreign`, 0 `<foreign>`-Wrapper im gesamten Korpus (Body-Ebene); `xml:lang` existiert nur in Header-Metadaten.
-- Schema: `<w>` erlaubt `@xml:lang` BEREITS (mhdbdb.rnc, w-Definition) — Phase 3 braucht dafür keine Schema-Änderung. `@foreign` ist NICHT im Schema; da `xml:lang` die Information vollständig trägt, wird `@foreign` nicht eingeführt (Entscheidungspunkt, Empfehlung: weglassen).
-- Die `<etym>`-Komponenten in lexicon.xml lösen intern auf (alle Komponenten sind selbst MHD-Lemmata) — daraus ist Fremdsprachlichkeit NICHT ableitbar (Befund 28.05.).
+- Schema: `<w>` erlaubt `@xml:lang` BEREITS (mhdbdb.rnc, w-Definition). `@foreign` ist NICHT im Schema und wird nicht eingeführt, da `xml:lang` die Information trägt. Für mehrwortige Passagen fehlt `<foreign>` im Schema und muss in Phase 3 ergänzt werden.
+- Die `<etym>`-Komponenten in lexicon.xml lösen intern auf (alle Komponenten sind selbst MHD-Lemmata) – daraus ist Fremdsprachlichkeit NICHT ableitbar (Befund 28.05.).
 - Zielsprachen laut KZW: gmh (Default), la, fr, ar, he, grc, it, es, en, yi, x-rotw.
 
-## Grundsatzentscheidung: Lemma-Ebene führt
+## Entscheidungen (KZW, 29.07.)
 
-Annotiert wird primär in `lexicon.xml` (`@xml:lang` am `<entry>` bzw. an der Lemma-Form), NICHT direkt an Millionen Token. Token-Annotation wird dann deterministisch über `@lemmaRef` abgeleitet. Vorteile: 43.879 Entscheidungen statt 7,5 Mio. (7.533.447 annotierte Tokens, Corpus-Index v4.1.5); Kuratierbarkeit; eine Quelle der Wahrheit; der Data-Change-Lifecycle bleibt beherrschbar. Token-AUSNAHMEN (ein im Kontext lateinisches Zitat eines sonst-mhd Lemmas) bleiben als manuelle Overrides möglich (direktes `<w xml:lang>`), werden aber nicht systematisch erzeugt.
+Anlass war die Frage, wo die Grenze Lehnwort/Fremdwort verläuft (26 Beispielfälle, Kategorien ZITAT / FACH / FACH-Hybrid / INT / UR). Ergebnis:
 
-Kein Widerspruch zu CONTRACTS §F.1 („Corpus Leads, Authority Follows"): §F regelt, dass Lemma-Existenz und -Zählung aus dem Korpusbestand abgeleitet werden und `lexicon.xml` dabei Index ist. Die Sprachzuordnung ist dagegen eine NEUE, eigenständig kuratierte Eigenschaft, die im Korpus nirgends vorhanden ist (0 Token-Annotationen) — `lexicon.xml` ist dafür die Erfassungsoberfläche. Das ist eine bewusste, auf dieses Feature begrenzte Festlegung, keine Änderung der generellen Authority-Source-Regel.
+1. **Zwei getrennte Sachverhalte, nicht ein Feld.** `@xml:lang` ist nach TEI die Sprache des Elementinhalts, also Code-Switching im Text. Wortherkunft ist eine Lexikon-Eigenschaft. Das wurde vorher vermischt; die Kategorien FACH/INT ließen sich deshalb nicht entscheiden.
+2. **Die Grenze FACH/INT wird nicht gezogen.** Für das Mhd. existiert dazu kein Konsens in der Fachliteratur (Integrationskontinuum statt Dichotomie; „Fremdwort" ist ein Begriff des 19. Jh.). Eine Projektfestlegung dazu würde publiziert (`tei/`, `api/`, Zenodo) und wäre nicht belegbar.
+3. **Kein Integrationsgrad-Urteil in den Daten.** Statt eines kuratierten Werts nur Herkunftsangabe + Quelle der Zuschreibung + gemessene Zahlen (Belege, Streuung, Reimbindung). Der Integrationsgrad wird daraus sichtbar, aber nirgends behauptet.
+4. **Auszeichnungsregel für `@xml:lang`:** ZITAT vollständig; FACH nur pro Token nach der Drei-Punkte-Prüfung (unten); INT und UR gar nicht.
+5. **Frontend: ein Einstieg, kein Kategorien-Filter.** Umbrella „Fremdsprachigkeit und Lehnwortschatz". Begründung KZW: publizierte Kategorien-Filter sind fachlich angreifbar, die Nutzerinnen sollen selbst interpretieren, entscheidend ist die Auffindbarkeit.
 
-## Phase 0: Zielformat + Policy (S)
+**Drei-Punkte-Prüfung pro Token (FACH-Fälle):** auszuzeichnen ist nur, was (1) keine mhd. Flexion trägt, (2) nicht im Reim mit Erbwörtern gebunden ist (messbar über `lineEnds[]`) und (3) unflektiert in fremder Lautgestalt steht, typischerweise im Verbund mit weiteren fremden Wörtern. Kalibrier-Beispiel: `kurteis` in TAN („der knabe der wart kurteis") wird NICHT ausgezeichnet (flektiert, reimgebunden); eine zusammenhängende französische Phrase in PZ wird ausgezeichnet.
 
-- `@xml:lang`-Werte-Set fixieren (BCP-47: la, fr, ar, he, grc, it, es, en, yi, x-rotw; gmh bleibt impliziter Default und wird NICHT ausgezeichnet).
-- Festlegen: Lehnwort-vs.-Fremdwort-Grenze (z. B. „blêmensier" = integriertes Lehnwort → fr markieren? Empfehlung: ja, mit Konfidenz-Feld; KZW entscheidet die Grenzziehung an ~20 Beispielfällen).
-- lexicon.xml-Kodierung: `<form type="lemma"><orth xml:lang="fr">…` vs. `@xml:lang` am `<entry>` — Schema-Check + TEI-MODEL-AUTH-FILES-Eintrag.
-- Deliverable: 1-Seiten-Policy als Ergänzung in TEI-MODEL-AUTH-FILES.md.
+**Asymmetrie als Grund für den strikten Start:** Ausweiten kostet später einen Skriptlauf; eine zurückgenommene Massenauszeichnung steht bis dahin im zitierbaren Datensatz.
+
+## Zwei Schichten
+
+**Schicht A: `@xml:lang` / `<foreign>` im Korpus (Code-Switching).** Token- und passagenbezogen, NICHT lemmagetrieben, weil dieselbe Lemma-ID mal fremd und mal integriert auftritt. Größenordnung: einige hundert bis wenige tausend Stellen (lateinische Zitatsätze wie PKP „deus ego sum et ego memet ipsum", französische Phrasen bei Wolfram, lateinische und tschechische Passagen in WZB). Nachprüfbar am Beleg, deshalb hart.
+
+**Schicht B: Herkunft in `lexicon.xml` (`<etym>`).** Quellsprache + Quelle der Zuschreibung (Lexer/MWB/Kluge/LLM mit Konfidenz), kein Projekturteil über Integration. Diese Schicht ist lemmagetrieben und trägt die Masse (43.879 Lemmata als Entscheidungsraum).
+
+Damit ist die frühere Grundsatzentscheidung „Lemma-Ebene führt" auf Schicht B eingeschränkt. Kein Widerspruch zu CONTRACTS §F.1 („Corpus Leads, Authority Follows"): §F regelt Lemma-Existenz und -Zählung; die Herkunftsangabe ist eine neue, eigenständig kuratierte Eigenschaft, für die `lexicon.xml` die Erfassungsoberfläche ist.
+
+## Phase 0: Zielformat + Policy (S) – inhaltlich entschieden, Kodierung offen
+
+- `@xml:lang`-Werte-Set: BCP-47 (la, fr, ar, he, grc, it, es, en, yi, x-rotw); gmh bleibt impliziter Default und wird NICHT ausgezeichnet.
+- Kodierung Schicht A: `<w xml:lang>` für Einzeltoken (schema-konform), `<foreign>` für mehrwortige Passagen (Schema-Ergänzung nötig, siehe Phase 3).
+- Kodierung Schicht B: `<etym>`-Erweiterung in lexicon.xml mit Quellsprache und Quellenangabe; Variante `<orth xml:lang>` scheidet aus, weil sie Schicht A und B wieder vermischen würde. Schema-Check + Eintrag in TEI-MODEL-AUTH-FILES.
+- Deliverable: 1-Seiten-Policy als Ergänzung in TEI-MODEL-AUTH-FILES.md, inklusive der Drei-Punkte-Prüfung als normativer Regel.
 
 ## Phase 1: Kandidaten-Generierung (M, dreigleisig, unabhängig parallelisierbar)
 
-1. **Begriffssystem:** Lemmata, deren senses auf den `concept_23123000`-Subtree zeigen (Einzelsprachen) — Achtung: das sind Lemmata, die Sprachen BEZEICHNEN (latîn, kriechisch), plus laut KZW viel bereits Abgedecktes; Liste extrahieren, als Kandidaten-Quelle A mit eigener Herkunfts-Markierung.
-2. **LLM-Klassifikation:** Batch über alle 43.879 Lemmata (Form + Bedeutungen/Konzepte als Kontext): „Lehnwort/Fremdwort? Quellsprache? Konfidenz?" Output als CSV mit (lemma_id, lang, confidence, Begründung). Modell-Doppellauf (2 Modelle oder 2 Prompts) für Konfidenz-Kalibrierung.
-3. **Wörterbuch-Crawl:** Lexer/MWB via Wörterbuchnetz-API (Pattern #73): Etymologie-Abschnitte nach Sprach-Markern (mlat., afrz., hebr., …) parsen; Treffer als Quelle C.
+**Vorbedingung:** Lemma-Lookup reparieren. Die Recherche zu den Beispielfällen fand `blâmensier`, `missa` und `Messias` nicht, obwohl sie im Lexikon stehen (KZW-Befund 08.07.). Vor Phase 1 klären, ob das an Normalisierung, Suchpfad oder Datenzugriff liegt, sonst zieht sich der Fehler durch die gesamte Kandidatenmenge.
+
+1. **Begriffssystem:** Lemmata, deren senses auf den `concept_23123000`-Subtree zeigen (Einzelsprachen). Achtung: das sind zunächst Lemmata, die Sprachen BEZEICHNEN (latîn, kriechisch). Liste als Quelle A mit eigener Herkunfts-Markierung.
+2. **LLM-Klassifikation (Schicht B):** Batch über alle Lemmata (Form + Bedeutungen/Konzepte als Kontext). Output: (lemma_id, Quellsprache, Konfidenz, Begründung). Kein Integrationsurteil. Doppellauf für Konfidenz-Kalibrierung.
+3. **Wörterbuch-Crawl (Schicht B):** Lexer/MWB via Wörterbuchnetz-API (Pattern #73), Etymologie-Abschnitte nach Sprach-Markern (mlat., afrz., hebr., …) parsen; Quelle C. Diese Quelle ist zugleich die Kontrollinstanz für die LLM-Zuschreibungen.
+4. **Schicht-A-Kandidaten separat:** Korpus-Scan nach Passagen mit mehreren aufeinanderfolgenden Token ohne mhd. Flexion bzw. ohne Lemma-Anbindung, plus die Drei-Punkte-Prüfung auf FACH-Token. Ergebnis ist eine Belegliste, keine Lemma-Liste.
 
 ## Phase 2: Kuratierung (M, Mensch im Loop)
 
-- Merge der 3 Quellen: Übereinstimmung 2+ Quellen → Auto-Accept-Kandidat; nur-LLM mit hoher Konfidenz → Stichprobe; Konflikte → Review-Liste.
-- Review-Paket für KZW/Linda: sortierte Tabelle mit Beleg-Kontexten (KWIC aus dem Korpus), geschätzt einige hundert Grenzfälle.
-- Abnahme-Kriterium definieren (z. B. Stichproben-Präzision ≥ 95 % pro Sprache).
+- Schicht B: Merge der Quellen A/B/C; Übereinstimmung von 2+ Quellen → Auto-Accept; nur-LLM mit hoher Konfidenz → Stichprobe; Konflikte → Review-Liste.
+- Schicht A: vollständiges Review durch KZW/Julia, da klein und hart publiziert. Sortierte Belegtabelle mit KWIC-Kontext.
+- Abnahme-Kriterium: Stichproben-Präzision ≥ 95 % pro Sprache (Schicht B); Schicht A vollständig gesichtet.
 
 ## Phase 3: Anwendung (M)
 
-- lexicon.xml: `xml:lang` an akzeptierte Lemmata (Skript, deterministisch, mit Provenienz-Log unter `ingest/foreign-lang/`).
-- Token-Ableitung: build-corpus-index erweitert um `foreignTokens[]` pro Text (position, lang) via lemmaRef-Lookup — KEINE Massen-Edits an `tei/*.xml` nötig. (Entscheidungspunkt: Token-`@xml:lang` zusätzlich physisch ins TEI schreiben? Empfehlung: nein, die Index-Ableitung genügt fürs Feature; TEI-Schreibung nur, wenn FAIR/Export es verlangt — dann eigener Bulk-Lauf mit Schema-Validierung.)
-- Data-Change-Lifecycle: Authority-Index-Bump (lexicon-Feld additiv `lang`), Corpus-Index-Bump (`foreignTokens`), API-Rebuild. CONTRACTS: das additive API-Feld `lang` in §G.3 (Full-Record-Schema) nachtragen; der Ableitungs-Contract selbst (Lemma-Ebene führt, Token via `lemmaRef` abgeleitet, Overrides gewinnen) kommt als NEUE §H — §G ist vollständig der statischen JSON-API (#45) gewidmet und darf nicht mit dem Sprach-Contract vermischt werden.
+- Schema: `<foreign>` für mehrwortige Passagen in `mhdbdb.rnc` ergänzen (Schicht A). `@foreign` wird weiterhin nicht eingeführt.
+- Schicht A ins TEI schreiben (Skript mit Provenienz-Log unter `ingest/foreign-lang/`, Schema-Validierung).
+- Schicht B in lexicon.xml schreiben (`<etym>` mit Sprache + Quelle), ebenfalls mit Provenienz-Log.
+- Corpus-Index: `foreignTokens[]` pro Text aus Schicht A (Position, Sprache) plus die aus Schicht B über `@lemmaRef` ableitbare Herkunftsangabe, getrennt gehalten und im Index als getrennte Herkunft erkennbar.
+- Data-Change-Lifecycle: Authority-Index-Bump (additives Lexikon-Feld), Corpus-Index-Bump, API-Rebuild. CONTRACTS: additives API-Feld in §G.3 nachtragen; der Ableitungs-Contract (zwei Schichten, Token-Ebene führt für Schicht A, Lemma-Ebene für Schicht B) als NEUE §H, nicht in §G (dort ausschließlich statische JSON-API, #45).
 
 ## Phase 4: Frontend (L, = ursprüngliches #28-Feature)
 
-- Playground-Modul `foreign-language-search.js` (DESIGN.md-Pattern): Sprach-Selector (nur real vorkommende Sprachen), Trefferliste mit Kontext analog Multi-Lemma.
-- Token-Detailansicht: „Sprache: Französisch" wo lang gesetzt.
-- Tests analog rhyme-dictionary.spec.js.
+**Ein Playground-Eintrag „Fremdsprachigkeit und Lehnwortschatz"**, kein Kategorien-Filter (KZW-Entscheidung 5). Sprachauswahl, eine Trefferliste, gespeist aus beiden Schichten; die Herkunft der Angabe wird im Treffer sichtbar, ist aber keine Filterbedingung.
+
+- Pro Treffer werden Befunde angezeigt, keine Urteile: Quellsprache mit Quellenangabe („Lexer: afrz."), Belegzahl und Streuung („2.912 Belege in 118 Texten"), Reimbindung wo messbar, Hinweis bei zusammenhängenden anderssprachigen Passagen.
+- Keine Anzeige eines Integrationsgrads, kein „Fremdwort: ja/nein".
+- Standardsortierung nach Auffälligkeit im Text (zusammenhängende Passagen, dann seltene, dann häufige Belege), umschaltbar auf Alphabet und Belegzahl. Begründung: ohne Filter braucht die Liste eine Ordnung, sonst ertrinken bei „Latein" die Zitatstellen in den Lemmata lateinischer Herkunft. Sortierung ordnet, ohne zu behaupten.
+- Token-Detailansicht: Sprachangabe, wo Schicht A gesetzt ist.
+- Hilfeseite: kurzer methodischer Absatz (fließende Grenze, Herkunft aus Wörterbüchern, keine Entscheidung über „noch fremd"), plus Hinweis auf maschinelle Erzeugung mit Stichprobenprüfung, analog zur Attribution beim Figurenbezeichnungs-Werkzeug (#59).
+- Tests analog `rhyme-dictionary.spec.js`.
 
 ## Aufwand und Reihenfolge
 
-Phase 0+1 zusammen eine Session; Phase 2 hängt an KZW/Linda-Kapazität; Phase 3+4 je eine Session. Kein Blocker außer der Kuratierungs-Kapazität.
+Lemma-Lookup-Fix zuerst. Danach Phase 0+1 zusammen eine Session; Phase 2 hängt an KZW/Julia-Kapazität; Phase 3+4 je eine Session. Kein Blocker außer der Kuratierungs-Kapazität.


### PR DESCRIPTION
Überarbeitet den Fremdsprachen-Phasenplan (`docs/features/FREMDSPRACHEN-PHASENPLAN-28.md`) auf die Entscheidungen von KZW vom 29.07. Nur Doku, keine Daten- oder Code-Änderung.

Hintergrund und Begründung ausführlich im Issue: #28 (Kommentar vom 29.07.).

## Changes

- **Neuer Abschnitt „Entscheidungen (KZW, 29.07.)"**: Herkunft und Sprache des Textes werden getrennt; die Grenze FACH/INT wird nicht gezogen (kein Konsens in der Fachliteratur, und die Festlegung würde über `api/`, `tei/` und Zenodo publiziert); kein Integrationsgrad-Urteil in den Daten.
- **Neuer Abschnitt „Zwei Schichten"**: Schicht A = `@xml:lang`/`<foreign>` im Korpus, nur Code-Switching, token- und passagenbezogen. Schicht B = Herkunft in `lexicon.xml`, lemmagetrieben, mit Quellenangabe. Die frühere Grundsatzentscheidung „Lemma-Ebene führt" gilt nur noch für B.
- **Drei-Punkte-Prüfung pro Token** als normative Regel für die FACH-Fälle (keine mhd. Flexion, keine Reimbindung, unflektiert in fremder Lautgestalt), mit Kalibrier-Beispiel `kurteis` in TAN.
- **Phase 0**: inhaltlich entschieden, offen nur noch die Kodierung. `<orth xml:lang>` fällt raus, weil es die beiden Schichten wieder vermischen würde.
- **Phase 1**: Lemma-Lookup-Fix als Vorbedingung (`blâmensier`, `missa`, `Messias` wurden nicht gefunden, KZW-Hinweis vom 08.07.); vierter Strang für Schicht-A-Belege per Korpus-Scan; LLM liefert Sprache plus Quelle plus Konfidenz statt eines Urteils.
- **Phase 2**: Schicht A vollständiges Review, Schicht B Stichprobe.
- **Phase 3**: `<foreign>` muss ins Schema (`@foreign` weiterhin nicht); beide Schichten getrennt im Index.
- **Phase 4**: ein Playground-Einstieg „Fremdsprachigkeit und Lehnwortschatz" statt Kategorien-Filter; Befunde statt Urteile pro Treffer; Standardsortierung nach Auffälligkeit; methodischer Hinweis auf der Hilfeseite.

Kein Rebuild nötig (Doku).
