### PR TITLE
#251: Auswahl im Wortbestandteil-Modus als Modell halten statt aus dem DOM ableiten

### DIFF
--- a/playground/js/ui/authority/authority-ui.js
+++ b/playground/js/ui/authority/authority-ui.js
@@ -115,6 +115,10 @@ export class AuthorityUI {
     this.lemmaExplorer.toggleComponentMorphFilter(an);
   }
 
+  toggleComponentPick(wert, an) {
+    this.lemmaExplorer.toggleComponentPick(wert, an);
+  }
+
   sendWordComponentSelection() {
     this.lemmaExplorer.sendWordComponentSelection();
   }

--- a/playground/js/ui/authority/lemma-explorer.js
+++ b/playground/js/ui/authority/lemma-explorer.js
@@ -448,10 +448,9 @@ export class LemmaExplorer {
 
   /**
    * Filter „nur belegte Wortbildungen" umschalten und dieselbe Suche neu
-   * rendern. Vorher werden Auswahl und aufgeklappte Gruppen gesichert: der
-   * wahrscheinlichste Ablauf ist ankreuzen, dann filtern, dann weiter
-   * ankreuzen, und ein kommentarloser Verlust der Häkchen wäre echter
-   * Arbeitsverlust.
+   * rendern. Gesichert wird dabei nur der Aufklapp-Zustand der Gruppen; die
+   * Auswahl braucht keine Sicherung mehr, weil sie seit #251 im Modell
+   * `componentPicked` lebt und nicht mehr im DOM.
    */
   toggleComponentMorphFilter(an) {
     this.rememberComponentViewState();
@@ -495,15 +494,41 @@ export class LemmaExplorer {
   }
 
   /**
-   * Die Zahl der ausgewählten Lemmata sichtbar halten. Nötig, seit die Auswahl den
-   * Render überlebt: sonst gäbe es Häkchen, die zählen, aber gerade nicht zu sehen
-   * sind (ausgewählt, dann weggefiltert), und die Übergabe käme überraschend.
+   * Die Auswahl sichtbar halten. Nötig, seit sie den Render überlebt: sonst gäbe
+   * es Häkchen, die zählen, aber gerade nicht zu sehen sind (ausgewählt, dann
+   * weggefiltert), und die Übergabe käme überraschend.
+   *
+   * Gezählt werden **Schreibformen**, nicht Häkchen. Bei Homographen ist das ein
+   * Unterschied: „sal" trägt vier gleichschreibende Lemmata, also vier Häkchen,
+   * die eine einzige Anfrage an die Multi-Lemma-Suche ergeben. „1 ausgewählt"
+   * neben vier gesetzten Häkchen sähe nach einem Fehler aus, deshalb benennt der
+   * Text die Einheit.
    */
+  /**
+   * Beschriftung der Auswahl-Checkbox. Bei Homographen tragen mehrere Kontrollen
+   * dieselbe Schreibform; nur mit Wortart und Bedeutungszahl sind sie fuer
+   * Screenreader unterscheidbar. Sie schalten trotzdem gemeinsam, weil die
+   * Uebergabe Formen kennt und keine IDs, deshalb sagt der Zusatz "gemeinsam
+   * mit gleichlautenden".
+   */
+  componentPickLabel(lemma, mehrfach) {
+    const teile = [`${lemma.lemma} auswählen`];
+    const pos = (lemma.posAll || [lemma.pos]).filter(Boolean).join(" ");
+    if (pos) teile.push(`Wortart ${pos}`);
+    if (lemma.senseCount) teile.push(`${lemma.senseCount} Bedeutungen`);
+    if (mehrfach) teile.push("gemeinsam mit gleichlautenden Lemmata");
+    return teile.join(", ");
+  }
+
+  static pickCountLabel(n) {
+    if (!n) return "";
+    return n === 1 ? "1 Schreibform ausgewählt" : `${n} Schreibformen ausgewählt`;
+  }
+
   updateComponentPickCount() {
     const el = document.getElementById("componentPickCount");
     if (!el) return;
-    const n = this.componentPicked.size;
-    el.textContent = n ? `${n} ausgewählt` : "";
+    el.textContent = LemmaExplorer.pickCountLabel(this.componentPicked.size);
   }
 
   rememberComponentViewState() {
@@ -538,9 +563,11 @@ export class LemmaExplorer {
   }
 
   restoreComponentViewState() {
-    // Die Häkchen stellt der Render selbst aus `componentPicked` her (#251),
-    // hier bleibt nur der Aufklapp-Zustand der Gruppen.
-    this.updateComponentPickCount();
+    // Die Häkchen stellt der Render selbst aus `componentPicked` her (#251), den
+    // Zähler schreibt `buildComponentHeaderHTML` im selben Durchgang inline.
+    // Hier bleibt nur der Aufklapp-Zustand der Gruppen: ein zweiter Aufruf von
+    // `updateComponentPickCount()` wäre harmlos, würde aber die Antwort auf
+    // „wer schreibt den Zähler" verwischen.
     if (this._componentOpen) {
       COMPONENT_GROUPS.forEach((g) => {
         const el = document.getElementById(`component-group-${g.key}`);
@@ -586,7 +613,7 @@ export class LemmaExplorer {
                   <input type="checkbox" class="component-pick" value="${this.escapeText(e.lemma.lemma)}"
                     ${this.componentPicked.has(e.lemma.lemma) ? "checked" : ""}
                     onchange="window.playground.ui.authorityExplorers.toggleComponentPick(this.value, this.checked)"
-                    aria-label="${this.escapeText(e.lemma.lemma)} auswählen" />
+                    aria-label="${this.escapeText(this.componentPickLabel(e.lemma, gruppen.exakt.length > 1))}" />
                   <a href="../lemma/?id=${e.lemma.id.replace(/^lemma_/, "")}" target="_blank" rel="noopener" class="font-semibold text-brand-700 hover:underline">${this.escapeText(e.lemma.lemma)}</a>
                 </label>`
             )
@@ -632,8 +659,14 @@ export class LemmaExplorer {
             class="rounded-lg bg-brand-600 px-3 py-1 text-xs font-semibold text-white shadow-sm transition hover:bg-brand-700">
             Auswahl an die Multi-Lemma-Suche übergeben
           </button>
-          <span id="componentPickCount" class="text-xs font-medium text-brand-700">${
-            this.componentPicked.size ? `${this.componentPicked.size} ausgewählt` : ""
+          <!-- Live-Region: der Zähler ist das einzige Zeugnis einer Auswahl, die
+               der Filter gerade ausblendet. Ohne role/aria-live bliebe genau der
+               stille Verlust für Screenreader weiterhin still, und der
+               Fokus-Rückgabe-Fix im selben Durchgang adressiert dieselbe
+               Bedienart. -->
+          <span id="componentPickCount" role="status" aria-live="polite"
+            class="text-xs font-medium text-brand-700">${
+            LemmaExplorer.pickCountLabel(this.componentPicked.size)
           }</span>
           <span id="componentPickHint" class="text-xs text-slate-500">
             Lemmata ankreuzen und übergeben, um ihre Belege im Korpus zu suchen.
@@ -680,7 +713,7 @@ export class LemmaExplorer {
             <input type="checkbox" class="component-pick mt-1" value="${this.escapeText(lemma.lemma)}"
               ${this.componentPicked.has(lemma.lemma) ? "checked" : ""}
               onchange="window.playground.ui.authorityExplorers.toggleComponentPick(this.value, this.checked)"
-              aria-label="${this.escapeText(lemma.lemma)} auswählen" />
+              aria-label="${this.escapeText(this.componentPickLabel(lemma, false))}" />
             <div class="min-w-0">
               <p class="text-xs font-semibold uppercase tracking-wide text-brand-600">
                 ${formatMetadata([
@@ -736,7 +769,23 @@ export class LemmaExplorer {
     // Aus dem Modell, nicht aus dem DOM (#251): eine Auswahl, die der Filter
     // gerade ausblendet, ist trotzdem eine Auswahl. Der Zähler im Kopf macht sie
     // sichtbar, damit die Übergabe nicht mehr enthält, als jemand vor sich sieht.
-    const gewaehlt = Array.from(this.componentPicked);
+    //
+    // Sortiert wird nach Dokumentordnung, nicht nach Klickfolge. Drüben bestimmt
+    // die Termreihenfolge die Chip-Reihenfolge und die Hervorhebungsfarben, und
+    // vor #251 stand der Exakt-Treffer aus dem Kopf immer vorn, weil
+    // `querySelectorAll` in Dokumentordnung liefert. Ohne diese Sortierung wäre
+    // aus dem Umbau eine unbemerkte Verhaltensänderung geworden. Formen, deren
+    // Checkbox gerade weggefiltert ist, haben keine Position und hängen hinten an;
+    // `sort` ist stabil, sie behalten untereinander die Einfügereihenfolge.
+    const position = new Map();
+    document.querySelectorAll(".component-pick").forEach((box, i) => {
+      if (!position.has(box.value)) position.set(box.value, i);
+    });
+    const hinten = Number.MAX_SAFE_INTEGER;
+    const gewaehlt = Array.from(this.componentPicked).sort(
+      (a, b) => (position.has(a) ? position.get(a) : hinten) -
+                (position.has(b) ? position.get(b) : hinten)
+    );
     const meldung = document.getElementById("componentPickHint");
 
     if (gewaehlt.length === 0) {

--- a/playground/js/ui/authority/lemma-explorer.js
+++ b/playground/js/ui/authority/lemma-explorer.js
@@ -426,7 +426,12 @@ export class LemmaExplorer {
       renderToContainer(
         "lemmaResults",
         this.buildComponentHeaderHTML(
-          term, formen, quellen, gruppen, gefundenGesamt, belegteGesamt, angezeigt
+          term, formen, quellen, gruppen, gefundenGesamt, belegteGesamt, angezeigt,
+          // Im Leerzustand existieren nur die Exakt-Checkboxen; nur sie koennen
+          // hier gemeinsam schalten.
+          gruppen.exakt.reduce(
+            (m, e) => m.set(e.lemma.lemma, (m.get(e.lemma.lemma) || 0) + 1), new Map()
+          )
         ) +
         `<div class="rounded-2xl border border-dashed border-slate-200 bg-slate-50/70 p-6 text-center text-sm text-slate-500">
           ${meldung}
@@ -436,11 +441,34 @@ export class LemmaExplorer {
       return;
     }
 
+    // Wie oft kommt eine SCHREIBFORM im gleich folgenden Render vor? Das ist die
+    // Bedingung, unter der `toggleComponentPick` Checkboxen gemeinsam schaltet
+    // (Abgleich über `box.value`), und deshalb die einzige, die die Beschriftung
+    // behaupten darf. Die normalisierte Form taugt dafür nicht: 387 der 475
+    // Norm-Gruppen mit mehreren Lemmata haben unterschiedliche Schreibformen
+    // (`lît`/`lît`/`lit`, `schin`/`schîn`), dort schalten nur die gleich
+    // geschriebenen mit. Gezählt wird über die tatsächlich gerenderten Einträge,
+    // also nach Filter und nach Gruppendeckel.
+    const formZaehler = new Map();
+    const sichtbarProGruppe = {};
+    gruppen.exakt.forEach((e) =>
+      formZaehler.set(e.lemma.lemma, (formZaehler.get(e.lemma.lemma) || 0) + 1)
+    );
+    COMPONENT_GROUPS.forEach((g) => {
+      const sichtbar = gruppen[g.key].slice(0, COMPONENT_GROUP_LIMIT);
+      sichtbarProGruppe[g.key] = sichtbar;
+      sichtbar.forEach((e) =>
+        formZaehler.set(e.lemma.lemma, (formZaehler.get(e.lemma.lemma) || 0) + 1)
+      );
+    });
+
     renderToContainer(
       "lemmaResults",
       this.buildComponentHeaderHTML(
-        term, formen, quellen, gruppen, gefundenGesamt, belegteGesamt, angezeigt
-      ) + COMPONENT_GROUPS.map((g) => this.buildComponentGroupHTML(g, gruppen[g.key])).join("")
+        term, formen, quellen, gruppen, gefundenGesamt, belegteGesamt, angezeigt, formZaehler
+      ) + COMPONENT_GROUPS.map((g) =>
+        this.buildComponentGroupHTML(g, sichtbarProGruppe[g.key], gruppen[g.key].length, formZaehler)
+      ).join("")
     );
 
     this.restoreComponentViewState();
@@ -585,7 +613,7 @@ export class LemmaExplorer {
     }
   }
 
-  buildComponentHeaderHTML(term, formen, quellen, gruppen, gefundenGesamt, belegteGesamt, angezeigt) {
+  buildComponentHeaderHTML(term, formen, quellen, gruppen, gefundenGesamt, belegteGesamt, angezeigt, formZaehler = new Map()) {
     const gesucht = formen.map((f) => `<code>${this.escapeText(f)}</code>`).join(", ");
 
     // Anforderung 4: sichtbar machen, worauf tatsächlich gesucht wird. Ohne
@@ -613,7 +641,7 @@ export class LemmaExplorer {
                   <input type="checkbox" class="component-pick" value="${this.escapeText(e.lemma.lemma)}"
                     ${this.componentPicked.has(e.lemma.lemma) ? "checked" : ""}
                     onchange="window.playground.ui.authorityExplorers.toggleComponentPick(this.value, this.checked)"
-                    aria-label="${this.escapeText(this.componentPickLabel(e.lemma, gruppen.exakt.length > 1))}" />
+                    aria-label="${this.escapeText(this.componentPickLabel(e.lemma, (formZaehler.get(e.lemma.lemma) || 0) > 1))}" />
                   <a href="../lemma/?id=${e.lemma.id.replace(/^lemma_/, "")}" target="_blank" rel="noopener" class="font-semibold text-brand-700 hover:underline">${this.escapeText(e.lemma.lemma)}</a>
                 </label>`
             )
@@ -678,8 +706,7 @@ export class LemmaExplorer {
     `;
   }
 
-  buildComponentGroupHTML(gruppe, eintraege) {
-    const anzahl = eintraege.length;
+  buildComponentGroupHTML(gruppe, sichtbar, anzahl = sichtbar.length, formZaehler = new Map()) {
     const listenId = `component-group-${gruppe.key}`;
     const versteckt = gruppe.collapsed ? " hidden" : "";
 
@@ -694,7 +721,6 @@ export class LemmaExplorer {
     // Gekappt wird nach der Sortierung „belegte Wortbildung zuerst, dann
     // Bedeutungszahl": ein alphabetischer Schnitt würde bei häufigen
     // Bestandteilen wie „lich" ein beliebiges Präfix zeigen.
-    const sichtbar = eintraege.slice(0, COMPONENT_GROUP_LIMIT);
     const gekappt =
       anzahl > COMPONENT_GROUP_LIMIT
         ? `<p class="px-1 pb-2 text-xs text-slate-500">Angezeigt werden
@@ -713,7 +739,7 @@ export class LemmaExplorer {
             <input type="checkbox" class="component-pick mt-1" value="${this.escapeText(lemma.lemma)}"
               ${this.componentPicked.has(lemma.lemma) ? "checked" : ""}
               onchange="window.playground.ui.authorityExplorers.toggleComponentPick(this.value, this.checked)"
-              aria-label="${this.escapeText(this.componentPickLabel(lemma, false))}" />
+              aria-label="${this.escapeText(this.componentPickLabel(lemma, (formZaehler.get(lemma.lemma) || 0) > 1))}" />
             <div class="min-w-0">
               <p class="text-xs font-semibold uppercase tracking-wide text-brand-600">
                 ${formatMetadata([

--- a/playground/js/ui/authority/lemma-explorer.js
+++ b/playground/js/ui/authority/lemma-explorer.js
@@ -522,17 +522,6 @@ export class LemmaExplorer {
   }
 
   /**
-   * Die Auswahl sichtbar halten. Nötig, seit sie den Render überlebt: sonst gäbe
-   * es Häkchen, die zählen, aber gerade nicht zu sehen sind (ausgewählt, dann
-   * weggefiltert), und die Übergabe käme überraschend.
-   *
-   * Gezählt werden **Schreibformen**, nicht Häkchen. Bei Homographen ist das ein
-   * Unterschied: „sal" trägt vier gleichschreibende Lemmata, also vier Häkchen,
-   * die eine einzige Anfrage an die Multi-Lemma-Suche ergeben. „1 ausgewählt"
-   * neben vier gesetzten Häkchen sähe nach einem Fehler aus, deshalb benennt der
-   * Text die Einheit.
-   */
-  /**
    * Beschriftung der Auswahl-Checkbox. Bei Homographen tragen mehrere Kontrollen
    * dieselbe Schreibform; nur mit Wortart und Bedeutungszahl sind sie fuer
    * Screenreader unterscheidbar. Sie schalten trotzdem gemeinsam, weil die
@@ -548,6 +537,18 @@ export class LemmaExplorer {
     return teile.join(", ");
   }
 
+  /**
+   * Beschriftung des Auswahl-Zählers. Er hält die Auswahl sichtbar, seit sie den
+   * Render überlebt: sonst gäbe es Häkchen, die zählen, aber gerade nicht zu
+   * sehen sind (ausgewählt, dann weggefiltert), und die Übergabe käme
+   * überraschend.
+   *
+   * Gezählt werden **Schreibformen**, nicht Häkchen. Bei Homographen ist das ein
+   * Unterschied: „sal" trägt vier gleichschreibende Lemmata, also vier Häkchen,
+   * die eine einzige Anfrage an die Multi-Lemma-Suche ergeben. „1 ausgewählt"
+   * neben vier gesetzten Häkchen sähe nach einem Fehler aus, deshalb benennt der
+   * Text die Einheit.
+   */
   static pickCountLabel(n) {
     if (!n) return "";
     return n === 1 ? "1 Schreibform ausgewählt" : `${n} Schreibformen ausgewählt`;
@@ -706,6 +707,18 @@ export class LemmaExplorer {
     `;
   }
 
+  /**
+   * Eine Positionsgruppe rendern.
+   *
+   * **Vorbedingung:** `sichtbar` ist bereits gekappt. Der Deckel sitzt seit dem
+   * `formZaehler` im Aufrufer (`searchWordComponents`), weil dort über genau die
+   * Menge gezählt werden muss, die auch gerendert wird; sonst behauptet die
+   * Checkbox-Beschriftung Mitschalten für eine Box, die der Deckel abgeschnitten
+   * hat. `anzahl` ist die Gesamtzahl VOR dem Kappen und speist nur die Meldung.
+   * Wer hier die ungekappte Liste hereingibt, rendert alles und meldet daneben
+   * eine Kappung, die nicht stattgefunden hat; deshalb nennt die Meldung unten
+   * `sichtbar.length` statt der Konstanten.
+   */
   buildComponentGroupHTML(gruppe, sichtbar, anzahl = sichtbar.length, formZaehler = new Map()) {
     const listenId = `component-group-${gruppe.key}`;
     const versteckt = gruppe.collapsed ? " hidden" : "";
@@ -722,9 +735,9 @@ export class LemmaExplorer {
     // Bedeutungszahl": ein alphabetischer Schnitt würde bei häufigen
     // Bestandteilen wie „lich" ein beliebiges Präfix zeigen.
     const gekappt =
-      anzahl > COMPONENT_GROUP_LIMIT
+      anzahl > sichtbar.length
         ? `<p class="px-1 pb-2 text-xs text-slate-500">Angezeigt werden
-             ${COMPONENT_GROUP_LIMIT} von ${anzahl} Treffern dieser Gruppe: erst die
+             ${sichtbar.length} von ${anzahl} Treffern dieser Gruppe: erst die
              belegten Wortbildungen, dann die Lemmata mit den meisten Bedeutungen.</p>`
         : "";
 

--- a/playground/js/ui/authority/lemma-explorer.js
+++ b/playground/js/ui/authority/lemma-explorer.js
@@ -476,6 +476,21 @@ export class LemmaExplorer {
     } else {
       this.componentPicked.delete(wert);
     }
+
+    // Homographen gleichschreibend zusammenhalten. 102 der 43.765 Schreibformen
+    // gehören mehr als einem Lemma (`sal`, `wal`, `sin` je vier), und das Modell
+    // hält Formen, nicht IDs, weil die Multi-Lemma-Route Formen erwartet. Zwei
+    // Checkboxen können deshalb denselben `value` tragen. Ohne diesen Abgleich
+    // liefe die Anzeige auseinander: das Abwählen der einen leert das Modell,
+    // während die andere bis zum nächsten Render angehakt bliebe, und die
+    // Übergabe verlangte ein Häkchen, das sichtbar gesetzt ist. Der Vergleich
+    // läuft über `box.value` statt über einen Attribut-Selektor, weil Formen wie
+    // `z'âsen` und `m'amie` im Lexikon stehen.
+    const gesetzt = this.componentPicked.has(wert);
+    document.querySelectorAll(".component-pick").forEach((box) => {
+      if (box.value === wert) box.checked = gesetzt;
+    });
+
     this.updateComponentPickCount();
   }
 

--- a/playground/js/ui/authority/lemma-explorer.js
+++ b/playground/js/ui/authority/lemma-explorer.js
@@ -56,6 +56,17 @@ export class LemmaExplorer {
   constructor(authorityData) {
     this.authorityData = authorityData;
     this.searchMode = "lemma";
+    /**
+     * Auswahl im Wortbestandteil-Modus als Modell (#251). Vorher wurde sie beim
+     * Filterwechsel aus dem DOM gelesen und beim nächsten Render einmalig
+     * eingelöst; ein Häkchen überlebte damit genau einen Render und ging auf dem
+     * Weg durch einen leeren Zwischenzustand still verloren. Gehalten werden die
+     * Originalformen, weil die Multi-Lemma-Route Schreibformen erwartet;
+     * Homographen mit gleicher Schreibform fallen deshalb zusammen, genau wie
+     * bei der alten DOM-Auswahl.
+     */
+    this.componentPicked = new Set();
+    this.lastComponentTerm = null;
   }
 
   showLemmata() {
@@ -321,6 +332,10 @@ export class LemmaExplorer {
       return;
     }
 
+    // Ein anderer Suchbegriff beginnt eine neue Auswahl. Ohne diesen Schnitt
+    // wanderten Häkchen der vorigen Suche in die Übergabe, sichtbar erst dort.
+    // Der Filterwechsel sucht mit demselben Begriff weiter und behält sie.
+    if (term !== this.lastComponentTerm) this.componentPicked.clear();
     this.lastComponentTerm = term;
 
     const { formen, quellen } = this.resolveComponentForms(term);
@@ -441,13 +456,42 @@ export class LemmaExplorer {
   toggleComponentMorphFilter(an) {
     this.rememberComponentViewState();
     this.componentOnlyMorph = !!an;
+    // Der Filter rendert den ganzen Kopf neu, also auch die Checkbox, an der die
+    // Bedienung gerade hängt. Ohne diese Rückgabe landet der Tastaturfokus auf
+    // <body>, und die Umschaltung ist mit der Tastatur nur einmal möglich.
+    const lagAufFilter = document.activeElement?.id === "componentOnlyMorph";
     if (this.lastComponentTerm) this.searchWordComponents(this.lastComponentTerm);
+    if (lagAufFilter) document.getElementById("componentOnlyMorph")?.focus();
+  }
+
+  /**
+   * Ein Häkchen wurde gesetzt oder entfernt. Die Wahrheit steht im Modell, nicht
+   * im DOM: der nächste Render liest sie von hier, egal ob der Eintrag durch den
+   * Filter, den Gruppendeckel oder einen Leerzustand zwischenzeitlich verschwindet.
+   */
+  toggleComponentPick(wert, an) {
+    if (an) {
+      this.componentPicked.add(wert);
+      this.resetComponentPickHint();
+    } else {
+      this.componentPicked.delete(wert);
+    }
+    this.updateComponentPickCount();
+  }
+
+  /**
+   * Die Zahl der ausgewählten Lemmata sichtbar halten. Nötig, seit die Auswahl den
+   * Render überlebt: sonst gäbe es Häkchen, die zählen, aber gerade nicht zu sehen
+   * sind (ausgewählt, dann weggefiltert), und die Übergabe käme überraschend.
+   */
+  updateComponentPickCount() {
+    const el = document.getElementById("componentPickCount");
+    if (!el) return;
+    const n = this.componentPicked.size;
+    el.textContent = n ? `${n} ausgewählt` : "";
   }
 
   rememberComponentViewState() {
-    this._componentPicked = new Set(
-      Array.from(document.querySelectorAll(".component-pick:checked")).map((b) => b.value)
-    );
     // Nur Gruppen erfassen, die es im aktuellen Render überhaupt gab, und den
     // Zustand je Gruppe ablegen statt als Menge der offenen. Der Unterschied
     // entscheidet den Rückweg aus dem Leerzustand: dort existiert keine
@@ -467,24 +511,21 @@ export class LemmaExplorer {
   }
 
   /**
-   * Gesicherten Ansichtszustand wegwerfen. Nötig in jedem Pfad, der die
-   * Trefferliste verlässt, ohne sie neu aufzubauen: die Sicherung wird sonst
-   * von der NÄCHSTEN Suche eingelöst und setzt dort Häkchen, die zu einem
-   * anderen Suchbegriff gehören. Sichtbar würde das erst bei der Übergabe an
-   * die Multi-Lemma-Suche, also zu spät.
+   * Ansichtszustand UND Auswahl wegwerfen. Nötig in jedem Pfad, der die
+   * Trefferliste verlässt, ohne sie neu aufzubauen: Häkchen eines anderen
+   * Suchbegriffs würden sonst in die Übergabe an die Multi-Lemma-Suche wandern,
+   * und sichtbar wäre das erst dort, also zu spät.
    */
   discardComponentViewState() {
-    this._componentPicked = null;
+    this.componentPicked.clear();
+    this.lastComponentTerm = null;
     this._componentOpen = null;
   }
 
   restoreComponentViewState() {
-    if (this._componentPicked) {
-      document.querySelectorAll(".component-pick").forEach((box) => {
-        if (this._componentPicked.has(box.value)) box.checked = true;
-      });
-      this._componentPicked = null;
-    }
+    // Die Häkchen stellt der Render selbst aus `componentPicked` her (#251),
+    // hier bleibt nur der Aufklapp-Zustand der Gruppen.
+    this.updateComponentPickCount();
     if (this._componentOpen) {
       COMPONENT_GROUPS.forEach((g) => {
         const el = document.getElementById(`component-group-${g.key}`);
@@ -528,6 +569,8 @@ export class LemmaExplorer {
             .map(
               (e) => `<label class="inline-flex items-center gap-1">
                   <input type="checkbox" class="component-pick" value="${this.escapeText(e.lemma.lemma)}"
+                    ${this.componentPicked.has(e.lemma.lemma) ? "checked" : ""}
+                    onchange="window.playground.ui.authorityExplorers.toggleComponentPick(this.value, this.checked)"
                     aria-label="${this.escapeText(e.lemma.lemma)} auswählen" />
                   <a href="../lemma/?id=${e.lemma.id.replace(/^lemma_/, "")}" target="_blank" rel="noopener" class="font-semibold text-brand-700 hover:underline">${this.escapeText(e.lemma.lemma)}</a>
                 </label>`
@@ -574,6 +617,9 @@ export class LemmaExplorer {
             class="rounded-lg bg-brand-600 px-3 py-1 text-xs font-semibold text-white shadow-sm transition hover:bg-brand-700">
             Auswahl an die Multi-Lemma-Suche übergeben
           </button>
+          <span id="componentPickCount" class="text-xs font-medium text-brand-700">${
+            this.componentPicked.size ? `${this.componentPicked.size} ausgewählt` : ""
+          }</span>
           <span id="componentPickHint" class="text-xs text-slate-500">
             Lemmata ankreuzen und übergeben, um ihre Belege im Korpus zu suchen.
             Mehrere Lemmata werden dort UND-verknüpft, also als Texte gesucht,
@@ -617,6 +663,8 @@ export class LemmaExplorer {
         return `
           <article class="result-item flex items-start gap-3 rounded-2xl border border-slate-200 bg-white/95 p-3 shadow-sm">
             <input type="checkbox" class="component-pick mt-1" value="${this.escapeText(lemma.lemma)}"
+              ${this.componentPicked.has(lemma.lemma) ? "checked" : ""}
+              onchange="window.playground.ui.authorityExplorers.toggleComponentPick(this.value, this.checked)"
               aria-label="${this.escapeText(lemma.lemma)} auswählen" />
             <div class="min-w-0">
               <p class="text-xs font-semibold uppercase tracking-wide text-brand-600">
@@ -670,9 +718,10 @@ export class LemmaExplorer {
    * auch so beschriftet. Sie laufen dort durch Stufe 1 der Auflösung.
    */
   sendWordComponentSelection() {
-    const gewaehlt = Array.from(document.querySelectorAll(".component-pick:checked")).map(
-      (box) => box.value
-    );
+    // Aus dem Modell, nicht aus dem DOM (#251): eine Auswahl, die der Filter
+    // gerade ausblendet, ist trotzdem eine Auswahl. Der Zähler im Kopf macht sie
+    // sichtbar, damit die Übergabe nicht mehr enthält, als jemand vor sich sieht.
+    const gewaehlt = Array.from(this.componentPicked);
     const meldung = document.getElementById("componentPickHint");
 
     if (gewaehlt.length === 0) {
@@ -692,9 +741,9 @@ export class LemmaExplorer {
         }
         meldung.textContent = "Bitte zuerst mindestens ein Lemma ankreuzen.";
         meldung.className = "text-xs font-medium text-red-600";
-        document.querySelectorAll(".component-pick").forEach((box) =>
-          box.addEventListener("change", () => this.resetComponentPickHint(), { once: true })
-        );
+        // Keine eigenen Listener mehr: `toggleComponentPick` nimmt den
+        // Fehlerzustand beim nächsten Häkchen zurück und überlebt im Gegensatz
+        // zu einmaligen Listenern auch einen Neuaufbau der Trefferliste.
       }
       return;
     }

--- a/testing/tests/word-component-search.spec.js
+++ b/testing/tests/word-component-search.spec.js
@@ -385,3 +385,34 @@ test.describe('#239: Modus-Umschaltung und Regression der normalen Lemmasuche', 
         expect(modus).toBe('lemma');
     });
 });
+
+test.describe('#251: Homographen mit gleicher Schreibform', () => {
+    // Das Modell hält Schreibformen, nicht IDs, weil die Multi-Lemma-Route
+    // Formen erwartet und sie in der Ergebnisanzeige auch so beschriftet.
+    // 102 der 43.765 Schreibformen gehören mehr als einem Lemma; „sal" ist mit
+    // vier der größte Fall. Vier Checkboxen tragen damit denselben `value` und
+    // sind zwangsläufig eine einzige Auswahl. Der Test hält fest, dass die
+    // Anzeige das auch zeigt, statt auseinanderzulaufen.
+    test('vier gleichschreibende Checkboxen wirken als eine Auswahl', async ({ page }) => {
+        await page.goto(`${KOMPONENTEN_ROUTE}&q=sal`);
+        await playgroundBereit(page);
+        await page.waitForSelector('.component-pick');
+
+        const salBoxen = page.locator('.component-pick[value="sal"]');
+        await expect(salBoxen).toHaveCount(4);
+
+        await salBoxen.nth(0).check();
+        for (let i = 0; i < 4; i++) {
+            await expect(salBoxen.nth(i)).toBeChecked();
+        }
+        // Eine Auswahl, nicht vier: die vier Lemmata teilen dieselbe Form.
+        await expect(page.locator('#componentPickCount')).toHaveText('1 ausgewählt');
+
+        // Abwählen über eine ANDERE Checkbox derselben Form nimmt alle mit.
+        await salBoxen.nth(2).uncheck();
+        for (let i = 0; i < 4; i++) {
+            await expect(salBoxen.nth(i)).not.toBeChecked();
+        }
+        await expect(page.locator('#componentPickCount')).toHaveText('');
+    });
+});

--- a/testing/tests/word-component-search.spec.js
+++ b/testing/tests/word-component-search.spec.js
@@ -238,6 +238,52 @@ test.describe('#239: Belegte Wortbildungen aus lemma.etymology', () => {
         await expect(page.locator('#component-group-anfang')).toBeHidden();
     });
 
+    test('#251: ein Häkchen überlebt das Wegfiltern und Wiederkommen', async ({ page }) => {
+        // Der Fall, der die Auswahl vorher still verschluckt hat. „winter" ist
+        // KEINE belegte Wortbildung: mit Filter verschwindet seine Checkbox aus
+        // dem DOM. Vorher wurde die Auswahl beim Umschalten aus dem DOM gelesen
+        // und einmalig eingelöst, ein weggefiltertes Häkchen war damit weg,
+        // bemerkbar erst an der Trefferzahl drüben in der Multi-Lemma-Suche.
+        await page.locator('#component-group-ende .component-pick[value="ôsterwîn"]').check();
+        await page.locator('#component-group-anfang .component-pick[value="winter"]').check();
+        await expect(page.locator('#componentPickCount')).toHaveText('2 ausgewählt');
+
+        await page.locator('#componentOnlyMorph').check();
+        await expect(page.locator('#component-group-anfang .component-pick[value="winter"]'))
+            .toHaveCount(0);
+        // Der Zähler beweist, dass die Auswahl weiterlebt, obwohl sie unsichtbar ist.
+        await expect(page.locator('#componentPickCount')).toHaveText('2 ausgewählt');
+
+        await page.locator('#componentOnlyMorph').uncheck();
+        await expect(page.locator('#component-group-anfang .component-pick[value="winter"]'))
+            .toBeChecked();
+        await expect(page.locator('#component-group-ende .component-pick[value="ôsterwîn"]'))
+            .toBeChecked();
+    });
+
+    test('#251: die Übergabe nimmt auch eine weggefilterte Auswahl mit', async ({ page }) => {
+        await page.locator('#component-group-anfang .component-pick[value="winter"]').check();
+        await page.locator('#componentOnlyMorph').check();
+
+        await page.getByRole('button', { name: /Auswahl an die Multi-Lemma-Suche/ }).click();
+        await expect(page).toHaveURL(/#multi-lemma&lemmata=/);
+        expect(decodeURIComponent(new URL(page.url()).hash)).toContain('winter');
+    });
+
+    test('#251: ein neuer Suchbegriff beginnt eine neue Auswahl', async ({ page }) => {
+        // Gegenprobe zum Modell: es darf nicht ZU lange leben. Häkchen des
+        // vorigen Begriffs in der Übergabe wären ein stiller Fremdkörper.
+        await page.locator('#component-group-ende .component-pick[value="ôsterwîn"]').check();
+        await expect(page.locator('#componentPickCount')).toHaveText('1 ausgewählt');
+
+        await page.fill('#lemmaSearch', 'winkel');
+        // Auf den Kopf des neuen Begriffs warten, nicht auf eine Gruppe: eine
+        // Gruppe ohne Treffer wird ohne id gerendert und existiert dann nicht.
+        await expect(page.locator('#lemmaResults'))
+            .toContainText('enthalten den Bestandteil "winkel"');
+        await expect(page.locator('#componentPickCount')).toHaveText('');
+    });
+
     test('der Filter bleibt abschaltbar, wenn er alles wegfiltert', async ({ page }) => {
         // Sackgassen-Probe. „lantwîn" hat genau einen weiteren Treffer, und der
         // ist keine belegte Wortbildung: mit Filter ist die Anzeigemenge leer.

--- a/testing/tests/word-component-search.spec.js
+++ b/testing/tests/word-component-search.spec.js
@@ -446,3 +446,38 @@ test.describe('#251: Reihenfolge der Übergabe', () => {
         expect(terme).toEqual(['wîn', 'ôsterwîn']);
     });
 });
+
+test.describe('#251: Beschriftung behauptet nur, was das Verhalten hält', () => {
+    test('der Zusatz „gemeinsam mit gleichlautenden" steht genau bei mehrfach vergebenen Schreibformen', async ({ page }) => {
+        // Der Zusatz darf sich nicht auf die NORMALISIERTE Form stützen:
+        // 387 der 475 Norm-Gruppen mit mehreren Lemmata haben unterschiedliche
+        // Schreibformen. Bei der Eingabe „lit" stehen `lît` (zweimal) und `lit`
+        // (einmal) zusammen im Kopf; mitgeschaltet werden nur die beiden `lît`,
+        // weil toggleComponentPick über `box.value` abgleicht.
+        await page.goto(`${KOMPONENTEN_ROUTE}&q=lit`);
+        await playgroundBereit(page);
+        await page.waitForSelector('.component-pick');
+
+        const befund = await page.evaluate(() => {
+            const boxen = [...document.querySelectorAll('.component-pick')];
+            const zaehler = {};
+            boxen.forEach(b => { zaehler[b.value] = (zaehler[b.value] || 0) + 1; });
+            return boxen.map(b => ({
+                wert: b.value,
+                anzahl: zaehler[b.value],
+                sagtGemeinsam: /gemeinsam mit gleichlautenden/.test(b.getAttribute('aria-label') || '')
+            }));
+        });
+
+        // Die Invariante, unabhängig von konkreten Lemmata: der Zusatz steht
+        // genau dann, wenn die Schreibform mehr als eine Checkbox hat.
+        for (const b of befund) {
+            expect(b.sagtGemeinsam, `${b.wert} (${b.anzahl}x)`).toBe(b.anzahl > 1);
+        }
+
+        // Und der Test darf nicht leer bestehen: beide Fälle müssen vorkommen,
+        // sonst prüft die Schleife oben nichts (Handwerksregel 4 im Playbook).
+        expect(befund.some(b => b.anzahl > 1), 'kein mehrfach vergebener Wert im Render').toBe(true);
+        expect(befund.some(b => b.anzahl === 1), 'kein einzeln vergebener Wert im Render').toBe(true);
+    });
+});

--- a/testing/tests/word-component-search.spec.js
+++ b/testing/tests/word-component-search.spec.js
@@ -246,13 +246,13 @@ test.describe('#239: Belegte Wortbildungen aus lemma.etymology', () => {
         // bemerkbar erst an der Trefferzahl drüben in der Multi-Lemma-Suche.
         await page.locator('#component-group-ende .component-pick[value="ôsterwîn"]').check();
         await page.locator('#component-group-anfang .component-pick[value="winter"]').check();
-        await expect(page.locator('#componentPickCount')).toHaveText('2 ausgewählt');
+        await expect(page.locator('#componentPickCount')).toHaveText('2 Schreibformen ausgewählt');
 
         await page.locator('#componentOnlyMorph').check();
         await expect(page.locator('#component-group-anfang .component-pick[value="winter"]'))
             .toHaveCount(0);
         // Der Zähler beweist, dass die Auswahl weiterlebt, obwohl sie unsichtbar ist.
-        await expect(page.locator('#componentPickCount')).toHaveText('2 ausgewählt');
+        await expect(page.locator('#componentPickCount')).toHaveText('2 Schreibformen ausgewählt');
 
         await page.locator('#componentOnlyMorph').uncheck();
         await expect(page.locator('#component-group-anfang .component-pick[value="winter"]'))
@@ -274,7 +274,7 @@ test.describe('#239: Belegte Wortbildungen aus lemma.etymology', () => {
         // Gegenprobe zum Modell: es darf nicht ZU lange leben. Häkchen des
         // vorigen Begriffs in der Übergabe wären ein stiller Fremdkörper.
         await page.locator('#component-group-ende .component-pick[value="ôsterwîn"]').check();
-        await expect(page.locator('#componentPickCount')).toHaveText('1 ausgewählt');
+        await expect(page.locator('#componentPickCount')).toHaveText('1 Schreibform ausgewählt');
 
         await page.fill('#lemmaSearch', 'winkel');
         // Auf den Kopf des neuen Begriffs warten, nicht auf eine Gruppe: eine
@@ -399,20 +399,50 @@ test.describe('#251: Homographen mit gleicher Schreibform', () => {
         await page.waitForSelector('.component-pick');
 
         const salBoxen = page.locator('.component-pick[value="sal"]');
-        await expect(salBoxen).toHaveCount(4);
+        // Keine feste Kardinalitaet: das Lexikon waechst durch laufenden Ingest
+        // (CLAUDE.md), und ein neues sal-Lemma wuerde diesen Test aus einem
+        // Grund rot machen, der nichts mit dem gesicherten Verhalten zu tun hat.
+        // Abgesichert wird „alle Boxen derselben Form schalten gemeinsam und
+        // zaehlen als eine". Heute sind es vier.
+        const anzahl = await salBoxen.count();
+        expect(anzahl).toBeGreaterThanOrEqual(2);
 
         await salBoxen.nth(0).check();
-        for (let i = 0; i < 4; i++) {
+        for (let i = 0; i < anzahl; i++) {
             await expect(salBoxen.nth(i)).toBeChecked();
         }
-        // Eine Auswahl, nicht vier: die vier Lemmata teilen dieselbe Form.
-        await expect(page.locator('#componentPickCount')).toHaveText('1 ausgewählt');
+        // Eine Auswahl, nicht vier: die Lemmata teilen dieselbe Form.
+        await expect(page.locator('#componentPickCount')).toHaveText('1 Schreibform ausgewählt');
 
         // Abwählen über eine ANDERE Checkbox derselben Form nimmt alle mit.
-        await salBoxen.nth(2).uncheck();
-        for (let i = 0; i < 4; i++) {
+        await salBoxen.nth(anzahl - 1).uncheck();
+        for (let i = 0; i < anzahl; i++) {
             await expect(salBoxen.nth(i)).not.toBeChecked();
         }
         await expect(page.locator('#componentPickCount')).toHaveText('');
+    });
+});
+
+test.describe('#251: Reihenfolge der Übergabe', () => {
+    test('die Übergabe folgt der Dokumentordnung, nicht der Klickfolge', async ({ page }) => {
+        // Vor der Modell-Umstellung las die Übergabe das DOM, `querySelectorAll`
+        // liefert in Dokumentordnung, und der Exakt-Treffer aus dem Kopf stand
+        // damit immer vorn. Drüben in der Multi-Lemma-Suche bestimmt die
+        // Termreihenfolge Chip-Reihenfolge und Hervorhebungsfarben, deshalb wird
+        // beim Absenden wieder nach Position sortiert.
+        await page.goto(`${KOMPONENTEN_ROUTE}&q=wein`);
+        await playgroundBereit(page);
+        await page.waitForSelector('#component-group-ende', { timeout: 30000 });
+
+        // Bewusst in umgekehrter Reihenfolge anklicken: erst ein Kompositum aus
+        // der Gruppe, dann das Grundwort im Kopf.
+        await page.locator('#component-group-ende .component-pick[value="ôsterwîn"]').check();
+        await page.locator('#lemmaResults .component-pick[value="wîn"]').check();
+        await page.getByRole('button', { name: /Auswahl an die Multi-Lemma-Suche/ }).click();
+
+        await expect(page).toHaveURL(/#multi-lemma&lemmata=/);
+        const hash = decodeURIComponent(new URL(page.url()).hash);
+        const terme = hash.replace(/^#multi-lemma&lemmata=/, '').split('&')[0].split(',');
+        expect(terme).toEqual(['wîn', 'ôsterwîn']);
     });
 });


### PR DESCRIPTION
Setzt #251 um. Frontend-only, keine Datenänderung, kein Index-Bump.

## Das Problem

Die Auswahl im Wortbestandteil-Modus wurde beim Filterwechsel per `querySelectorAll(".component-pick:checked")` aus dem DOM gelesen und beim nächsten Render einmalig eingelöst. Ein Häkchen überlebte damit genau **einen** Render. Wer mit gesetzter Auswahl so filterte, dass der Eintrag ausgeblendet wurde, verlor ihn still: die Checkbox existiert dann nicht mehr, der Schnappschuss wurde beim Render verbraucht und auf `null` gesetzt. Bemerkbar wurde das erst an der Trefferzahl drüben in der Multi-Lemma-Suche.

## Die Lösung

`componentPicked` (ein `Set`) ist jetzt die Wahrheit. Der Render setzt `checked` daraus, `toggleComponentPick()` pflegt es am `change`-Ereignis, und `sendWordComponentSelection()` liest es statt des DOM.

| Änderung | Warum |
|---|---|
| Modell statt DOM-Schnappschuss | eine Auswahl, die der Filter gerade ausblendet, ist trotzdem eine Auswahl |
| Zähler „N ausgewählt" im Kopf | Folge des Modells: ohne ihn gäbe es Häkchen, die zählen, aber nicht zu sehen sind. Die Übergabe soll nicht mehr enthalten, als man vor sich hat |
| Begriffswechsel leert die Auswahl | sonst wandern Häkchen der vorigen Suche in die Übergabe, sichtbar erst dort |
| Fokus bleibt auf der Filter-Checkbox | der Filter rendert den Kopf samt Checkbox neu; vorher landete die Tastaturbedienung auf `<body>` und war einmalig |
| `rememberComponentViewState()` hält nur noch den Aufklapp-Zustand | die Häkchen braucht es dort nicht mehr |

## Verifikation

- **Playwright 23/23** in `word-component-search.spec.js`, aus `report.json` ausgezählt (der Vollauf davor: 262 Tests, 261 grün, siehe unten)
- **Chrome** gegen den lokalen Stand, fünf Wege einzeln gemessen: zwei Häkchen setzen (Zähler „2 ausgewählt"), Filter an (`winter` fällt aus dem DOM, Zähler bleibt 2), Filter aus (beide Häkchen wieder gesetzt), Begriffswechsel (Modell auf 0), Übergabe mit weggefiltertem Häkchen (`#multi-lemma&lemmata=winter&mode=document`)
- Drei Regressionstests ergänzt, die genau diese Wege festnageln
- Keine neuen Tailwind-Klassen (`text-xs`, `font-medium`, `text-brand-700` sind im gepurgten Output vorhanden), kein CSS-Rebuild nötig

## Der Fund, der den Vollauf gelohnt hat

Der erste Vollauf war 261 von 262 grün. Der Fehlschlag war ein **bestehender** Test aus #239 („auch das Grundwort selbst ist ankreuzbar und übergebbar"), und er hat eine echte Regression meiner Änderung nachgewiesen: `.component-pick` wird an **zwei** Stellen gerendert, in der Gruppenliste und im Kopf für den Exakt-Treffer. Nur die erste hatte den neuen `onchange`-Handler. Das Häkchen am Grundwort erreichte das Modell also nicht, und weil die Übergabe jetzt aus dem Modell liest, verschwand es.

Zwei Lehren daraus: wer die Quelle der Wahrheit umstellt, muss alle Produzenten mitziehen, nicht nur den, an dem er gerade arbeitet. Und meine Chrome-Prüfung hatte es nicht gefangen, weil ich dort die Gruppen-Checkboxen geprüft hatte, nicht die im Kopf. Nachträglich: der Lauf endete trotz des roten Tests mit **Exit 0**, die Zahl kam aus `report.json`.

## Nicht enthalten

Kein `Closes #251`: das Issue bleibt für KZWs Abnahme am Live-Stand offen.

Hängt inhaltlich an #239. Falls dort entschieden wird, den Filter „nur belegte Wortbildungen" standardmäßig einzuschalten, wird der Leerzustand zum Regelfall und dieser Fix damit dringender (siehe die Fragen in #239).
