### PR TITLE
Status-Icon im Playground: Groesse an die Box binden statt in den Text laufen zu lassen

### DIFF
--- a/playground/css/style.css
+++ b/playground/css/style.css
@@ -5,8 +5,8 @@
 
 /* Status-Icon im Authority-Files-Header.
  * Die Icons kommen per innerHTML aus ui-helpers.js (updateStatus); deren
- * Tailwind-Groessen driften vom Container weg (w-6 h-6 in einer w-3.5-Box hat
- * das Icon in den Text laufen lassen). Groesse deshalb hier erzwingen, analog
+ * Tailwind-Größen driften vom Container weg (w-6 h-6 in einer w-3.5-Box hat
+ * das Icon in den Text laufen lassen). Größe deshalb hier erzwingen, analog
  * zu .help-icon in shared.css. flex-shrink verhindert ein gequetschtes Icon,
  * wenn der Statustext bei schmalem Viewport umbricht. */
 .status-indicator {

--- a/playground/css/style.css
+++ b/playground/css/style.css
@@ -3,6 +3,26 @@
  * This file contains only playground-specific components
  */
 
+/* Status-Icon im Authority-Files-Header.
+ * Die Icons kommen per innerHTML aus ui-helpers.js (updateStatus); deren
+ * Tailwind-Groessen driften vom Container weg (w-6 h-6 in einer w-3.5-Box hat
+ * das Icon in den Text laufen lassen). Groesse deshalb hier erzwingen, analog
+ * zu .help-icon in shared.css. flex-shrink verhindert ein gequetschtes Icon,
+ * wenn der Statustext bei schmalem Viewport umbricht. */
+.status-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 0.875rem;
+  height: 0.875rem;
+  flex-shrink: 0;
+}
+
+.status-indicator svg {
+  width: 0.875rem;
+  height: 0.875rem;
+}
+
 /* Drag & drop visual feedback */
 #uploadZone.dragover {
   border-color: var(--accent-primary) !important;

--- a/playground/index.html
+++ b/playground/index.html
@@ -206,16 +206,16 @@
                 <div id="authorityOverview" class="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
                     <button id="authorityToggle" type="button" class="w-full flex items-center justify-between cursor-pointer" onclick="document.getElementById('authorityStats').classList.toggle('hidden'); document.getElementById('authorityChevron').classList.toggle('rotate-180')">
                         <h3 class="text-sm font-semibold text-slate-800">Authority Files</h3>
-                        <div class="flex items-center gap-2">
-                            <div id="authorityStatus" class="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-slate-500">
-                                <div id="statusIndicator" class="w-3.5 h-3.5 text-slate-600">
+                        <div class="flex min-w-0 items-center gap-2">
+                            <div id="authorityStatus" class="flex min-w-0 items-center gap-2 text-xs font-medium uppercase tracking-wide text-slate-500">
+                                <div id="statusIndicator" class="status-indicator text-slate-600">
                                     <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"></path>
                                     </svg>
                                 </div>
-                                <span id="statusText" class="text-slate-600">Lade...</span>
+                                <span id="statusText" class="text-left text-slate-600">Lade...</span>
                             </div>
-                            <svg id="authorityChevron" class="w-4 h-4 text-slate-400 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+                            <svg id="authorityChevron" class="w-4 h-4 flex-shrink-0 text-slate-400 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
                         </div>
                     </button>
                     <div id="authorityStats" class="mt-2 space-y-1 text-xs text-slate-600 hidden"></div>

--- a/playground/js/data/authority-manager.js
+++ b/playground/js/data/authority-manager.js
@@ -251,17 +251,4 @@ export class AuthorityFilesManager {
     return [...startsWith, ...includes].slice(0, maxSuggestions);
   }
 
-  // ==================== UTILITY METHODS ====================
-
-  updateStatus(indicator, text) {
-    const statusIndicator = document.getElementById("statusIndicator");
-    const statusText = document.getElementById("statusText");
-
-    if (statusIndicator) statusIndicator.textContent = indicator;
-    if (statusText) statusText.textContent = text;
-
-    // Enhanced logging with cache information
-    console.log(`${indicator} ${text}`);
-  }
-
 }

--- a/playground/js/ui/core/file-display.js
+++ b/playground/js/ui/core/file-display.js
@@ -93,7 +93,7 @@ export function displayFileItem(data, container) {
     <div class="flex items-start justify-between gap-3">
       <div class="flex-1 min-w-0">
         <div class="file-name flex items-center gap-2">
-          <span class="${statusColor}">${statusIcon}</span>
+          <span class="inline-flex flex-shrink-0 items-center ${statusColor}">${statusIcon}</span>
           <span class="truncate">${escapeHtml(filename)}</span>
         </div>
         ${displayTitle}

--- a/playground/js/ui/core/ui-helpers.js
+++ b/playground/js/ui/core/ui-helpers.js
@@ -63,9 +63,9 @@ export function updateStatus(indicator, text) {
 
   if (statusIndicator) {
     // Map emoji indicators to Heroicons.
-    // Groesse muss zur .status-indicator-Box passen (14px): die frueheren
+    // Größe muss zur .status-indicator-Box passen (14px): die früheren
     // w-6/h-6-Icons sind aus der Box gelaufen und haben den Abstand zum
-    // Statustext aufgefressen. .status-indicator svg erzwingt es zusaetzlich.
+    // Statustext aufgefressen. .status-indicator svg erzwingt es zusätzlich.
     const iconMap = {
       '🔄': '<svg class="w-3.5 h-3.5 animate-spin" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path></svg>',
       '✅': '<svg class="w-3.5 h-3.5 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>',

--- a/playground/js/ui/core/ui-helpers.js
+++ b/playground/js/ui/core/ui-helpers.js
@@ -62,12 +62,15 @@ export function updateStatus(indicator, text) {
   const statusText = document.getElementById('statusText');
 
   if (statusIndicator) {
-    // Map emoji indicators to Heroicons
+    // Map emoji indicators to Heroicons.
+    // Groesse muss zur .status-indicator-Box passen (14px): die frueheren
+    // w-6/h-6-Icons sind aus der Box gelaufen und haben den Abstand zum
+    // Statustext aufgefressen. .status-indicator svg erzwingt es zusaetzlich.
     const iconMap = {
-      '🔄': '<svg class="w-6 h-6 animate-spin" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path></svg>',
-      '✅': '<svg class="w-6 h-6 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>',
-      '📥': '<svg class="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 12l3 3m0 0l3-3m-3 3V9"></path></svg>',
-      '🗂️': '<svg class="w-6 h-6 text-slate-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"></path></svg>'
+      '🔄': '<svg class="w-3.5 h-3.5 animate-spin" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path></svg>',
+      '✅': '<svg class="w-3.5 h-3.5 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>',
+      '📥': '<svg class="w-3.5 h-3.5 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 12l3 3m0 0l3-3m-3 3V9"></path></svg>',
+      '🗂️': '<svg class="w-3.5 h-3.5 text-slate-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"></path></svg>'
     };
 
     const svgIcon = iconMap[indicator] || iconMap['🗂️']; // fallback to folder icon
@@ -110,7 +113,7 @@ export function updateAuthorityOverview(authorityData) {
             return `
             <div class="flex items-center justify-between rounded-lg bg-white/80 px-3 py-1 ring-1 ring-slate-200/70">
               <dt class="flex items-center gap-2 text-xs text-slate-600">
-                <span class="w-3.5 h-3.5 [&>svg]:w-3.5 [&>svg]:h-3.5">${icon}</span>
+                <span class="inline-flex w-3.5 h-3.5 flex-shrink-0 items-center [&>svg]:w-3.5 [&>svg]:h-3.5">${icon}</span>
                 ${explorerLink}
                 ${ghLink}
               </dt>
@@ -145,7 +148,7 @@ export function updateTEIOverview(teiData) {
             ({ icon, label, value }) => `
               <div class="flex items-center justify-between rounded-xl bg-white/80 px-4 py-2 shadow-sm ring-1 ring-brand-100/80">
                 <dt class="flex items-center gap-3 text-sm font-medium text-slate-600">
-                  <span class="text-lg">${icon}</span>
+                  <span class="inline-flex w-4 h-4 flex-shrink-0 items-center">${icon}</span>
                   <span>${label}</span>
                 </dt>
                 <dd class="text-base font-bold text-brand-700">${value}</dd>


### PR DESCRIPTION
Das Ladestatus-Icon neben „7/7 Authority Files geladen" wurde mit `w-6 h-6` (24 px) in einen 14-px-Container injiziert. Das SVG lief aus seiner Box und überlappte den Text: gemessener Abstand Icon → Text **−4 px**, vertikal 5 px versetzt.

## Änderungen

- `.status-indicator` in `playground/css/style.css`: Box- und `svg`-Größe erzwungen (analog `.help-icon` in `shared.css`), `flex-shrink: 0`. Damit kann kein künftig injiziertes Icon die Box mehr sprengen.
- `ui-helpers.js` `updateStatus`: alle vier Icons `w-6 h-6` → `w-3.5 h-3.5`
- `playground/index.html`: Abstand `gap-1.5` → `gap-2`, `min-w-0` am Statusblock, `text-left` am Statustext (Buttons zentrieren sonst beim Umbruch), `flex-shrink-0` am Chevron
- Icon-Wrapper der Authority-/TEI-Statistikzeilen und der Dateiliste auf `inline-flex` + `flex-shrink-0`: verhindert gequetschte Icons in Flex-Zeilen
- `authority-manager.js`: tote `updateStatus` entfernt, die per `textContent` ein rohes Emoji in dasselbe Element geschrieben hätte

## Verifikation (Chrome, gegen lokalen Server)

- Nachher: Icon 14×14, Abstand zum Text +8 px, vertikale Mittenabweichung 0 px
- Aufgeklappte Authority-Liste: alle 7 Zeilen Icon 14×14, Gap 8 px
- Responsiveness: Karte künstlich auf 320 / 240 / 180 px verengt, Icon bleibt 14×14 (kein Squash), Text bricht um, kein horizontaler Overflow; auch bei Fensterbreite 1200 px stabil

Kein `npm run build:css` nötig: alle verwendeten Utility-Klassen sind bereits im gepurgten Output, die neue Regel liegt in `style.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)