### PR TITLE
Korpus-Index und variants.xml parallel parsen (#284)

### DIFF
--- a/scripts/build-corpus-index.py
+++ b/scripts/build-corpus-index.py
@@ -46,6 +46,7 @@ Notes on lineStarts/lineEnds (added in v4.1.0 for #47.3):
 """
 
 import argparse
+import concurrent.futures
 import json
 import gzip
 import subprocess
@@ -76,6 +77,19 @@ OUTPUT_FILE = DATA_DIR / 'corpus-index.json.gz'
 
 # TEI namespace
 TEI_NS = {'tei': 'http://www.tei-c.org/ns/1.0'}
+
+# Worker-Obergrenze (#284). Nicht cpu_count(): jeder Worker haelt einen
+# kompletten lxml-Baum im Speicher, und der Elternprozess muss jedes Ergebnis
+# entpicken und behalten (der fertige Index sind rund 200 MB JSON).
+#
+# Gemessen am 2026-07-31, 667 Dateien, 16 Kerne, Hash jedes Mal identisch:
+#   jobs= 1  183,5 s     jobs= 4   56,1 s     jobs=12   39,9 s
+#   jobs= 2   97,9 s     jobs= 8   45,8 s     jobs=16   42,4 s
+# Ab 8 ist die Kurve flach, ab 12 kippt sie (Ueberbuchung). Der Rest sind
+# rund 16 s Serialisieren und Gzippen, die niemand parallelisiert. 8 holt
+# damit den Grossteil des Gewinns bei halbem Speicherbedarf von 16; wer mehr
+# will, nimmt --jobs. Auf kleineren Maschinen greift min(cap, cpu_count).
+DEFAULT_JOBS_CAP = 8
 
 
 def extract_metadata(filepath):
@@ -254,7 +268,33 @@ def process_tei_file(filepath):
     return text_data
 
 
-def build_corpus_index():
+def iter_processed(tei_files, jobs):
+    """Yield process_tei_file(f) for each f, IN INPUT ORDER (#284).
+
+    Parallelisiert wird ausschliesslich das Parsen. process_tei_file liest genau
+    eine Datei und liefert ein reines dict aus JSON-Typen zurueck; lxml-Objekte
+    ueberleben eine Prozessgrenze nicht und werden hier auch nicht gebraucht.
+
+    Die Reduktion (texts, lemma_index) bleibt im Elternprozess UND in
+    Dateireihenfolge, denn an dieser Reihenfolge haengen die Index-Bytes: die
+    Schluessel- und Wertereihenfolge von lemmaIndex ist die Reihenfolge des
+    Erstauftretens ueber die sortierte Dateiliste (#125). Deshalb executor.map
+    (geordnet) und ausdruecklich NICHT as_completed.
+
+    chunksize=1: die Dateiliste ist alphabetisch, und die groessten Texte des
+    Korpus (OVG, PL1, PL2) stehen darin unmittelbar nebeneinander. Groessere
+    Chunks wuerden sie demselben Worker zuteilen und die Laufzeit ans Ende
+    haengen. Bei rund einer Viertelsekunde Parse-Zeit pro Datei ist der
+    Dispatch-Overhead pro Task dagegen vernachlaessigbar.
+    """
+    if jobs <= 1:
+        yield from map(process_tei_file, tei_files)
+        return
+    with concurrent.futures.ProcessPoolExecutor(max_workers=jobs) as pool:
+        yield from pool.map(process_tei_file, tei_files, chunksize=1)
+
+
+def build_corpus_index(jobs=1):
     """Build complete corpus index from all TEI files."""
     print("\n🔨 Building corpus index...")
     print(f"TEI directory: {TEI_DIR}")
@@ -277,15 +317,15 @@ def build_corpus_index():
     lemma_index = defaultdict(list)  # lemma_id -> list of text IDs
 
     start_time = time.time()
+    print(f"Parsing with {jobs} worker process(es)")
 
-    for idx, filepath in enumerate(tei_files, 1):
+    for idx, text_data in enumerate(iter_processed(tei_files, jobs), 1):
         if idx % 10 == 0 or idx == total_files:
             elapsed = time.time() - start_time
             rate = idx / elapsed if elapsed > 0 else 0
             remaining = (total_files - idx) / rate if rate > 0 else 0
             print(f"   Processing {idx}/{total_files} ({rate:.1f} files/sec, ~{remaining:.0f}s remaining)...")
 
-        text_data = process_tei_file(filepath)
         if not text_data:
             continue
 
@@ -395,7 +435,14 @@ def main():
         '--allow-dirty', action='store_true',
         help="Build even if tei/ has untracked or modified files (use for local tests)."
     )
+    parser.add_argument(
+        '--jobs', type=int, default=min(DEFAULT_JOBS_CAP, os.cpu_count() or 1),
+        help="Worker-Prozesse fuer das Parsen (1 = sequentiell). Das Ergebnis ist "
+             "von diesem Wert unabhaengig und byte-identisch (#284)."
+    )
     args = parser.parse_args()
+    if args.jobs < 1:
+        parser.error('--jobs muss mindestens 1 sein')
 
     print("=" * 60)
     print("MHDBDB Corpus Index Builder")
@@ -405,7 +452,7 @@ def main():
 
     try:
         # Build index
-        index = build_corpus_index()
+        index = build_corpus_index(jobs=args.jobs)
 
         # Save index
         save_index(index)

--- a/scripts/build-corpus-index.py
+++ b/scripts/build-corpus-index.py
@@ -86,9 +86,14 @@ TEI_NS = {'tei': 'http://www.tei-c.org/ns/1.0'}
 #   jobs= 1  183,5 s     jobs= 4   56,1 s     jobs=12   39,9 s
 #   jobs= 2   97,9 s     jobs= 8   45,8 s     jobs=16   42,4 s
 # Ab 8 ist die Kurve flach, ab 12 kippt sie (Ueberbuchung). Der Rest sind
-# rund 16 s Serialisieren und Gzippen, die niemand parallelisiert. 8 holt
-# damit den Grossteil des Gewinns bei halbem Speicherbedarf von 16; wer mehr
-# will, nimmt --jobs. Auf kleineren Maschinen greift min(cap, cpu_count).
+# rund 16 s Serialisieren und Gzippen, die niemand parallelisiert.
+#
+# Speicher-Peak ueber alle Python-Prozesse, gleiche Messung:
+#   jobs=1  1.344 MB       jobs=8  3.893 MB
+# Also rund 320 MB je zusaetzlichem Worker, linear. Bei 16 waeren es ueber
+# 6 GB fuer 6 gesparte Sekunden. Deshalb 8: der Grossteil des Gewinns zum
+# halben Aufschlag. Wer mehr Kerne als Sorgen hat, nimmt --jobs. Auf
+# kleineren Maschinen greift min(cap, cpu_count).
 DEFAULT_JOBS_CAP = 8
 
 
@@ -281,11 +286,17 @@ def iter_processed(tei_files, jobs):
     Erstauftretens ueber die sortierte Dateiliste (#125). Deshalb executor.map
     (geordnet) und ausdruecklich NICHT as_completed.
 
-    chunksize=1: die Dateiliste ist alphabetisch, und die groessten Texte des
-    Korpus (OVG, PL1, PL2) stehen darin unmittelbar nebeneinander. Groessere
-    Chunks wuerden sie demselben Worker zuteilen und die Laufzeit ans Ende
-    haengen. Bei rund einer Viertelsekunde Parse-Zeit pro Datei ist der
-    Dispatch-Overhead pro Task dagegen vernachlaessigbar.
+    chunksize=1, weil die Kosten pro Datei ueber Groessenordnungen streuen:
+    zwischen wenigen KB und 66 MB (OVG). Statisches Chunking teilt Nachbarn
+    derselben sortierten Liste demselben Worker zu und kann damit mehrere
+    teure Dateien hintereinander an einem Worker aufhaengen, waehrend die
+    anderen leerlaufen. Bei rund einer Viertelsekunde Parse-Zeit pro Datei ist
+    der Dispatch-Overhead pro Task dagegen vernachlaessigbar.
+
+    Kein cancel_futures noetig, anders als in extract-variants.py: der von
+    map() zurueckgegebene Generator canceled die offenen Futures in seinem
+    eigenen finally, sobald er geschlossen wird oder eine Exception
+    durchreicht. Der with-Block danach findet nichts mehr zu warten.
     """
     if jobs <= 1:
         yield from map(process_tei_file, tei_files)

--- a/scripts/sync/extract-variants.py
+++ b/scripts/sync/extract-variants.py
@@ -106,20 +106,13 @@ def collect(base_files, jobs=1):
 
     Parallelisiert wird nur das Parsen (#284); summiert wird im Elternprozess.
 
-    Die Reihenfolge von executor.map ist hier KEINE Kosmetik fuer die
-    Fortschrittsausgabe, sondern Teil der Determinismus-Zusicherung aus #125.
-    resolve() bricht Gleichstaende fast immer explizit (haeufigste Form, dann
-    alphabetisch; haeufigstes Lemma, dann kleinste Lemma-Nummer), aber der
-    Lemma-Sortkey faellt fuer nicht-numerische Lemma-IDs auf einen konstanten
-    Wert zurueck. Zwei solche IDs mit gleicher Haeufigkeit unter derselben
-    type_id entscheidet dann der stabile Sort, also die Insertion-Order des
-    Counters, also die Merge-Reihenfolge. Geordnetes map reproduziert dafuer
-    exakt die Dateireihenfolge des sequentiellen Laufs.
-
-    Deshalb NICHT auf as_completed umstellen. Der Bruch waere unsichtbar: der
-    heutige Korpus hat keine nicht-numerischen Lemma-IDs, ein Hash-Vergleich
-    wuerde also gruen bleiben, bis ein kuenftiger Ingest eine schraege
-    @lemmaRef mitbringt.
+    Die Summen sind ordnungsunabhaengig, und resolve() bricht seit #284 jeden
+    Gleichstand explizit (haeufigste Form, dann alphabetisch; haeufigstes
+    Lemma, dann lemma_key). Vorher tat es das nicht ganz: der Lemma-Sortkey
+    kollabierte nicht-numerische IDs auf einen konstanten Wert, womit die
+    Merge-Reihenfolge mitentschied. Das war der Grund, dieses map geordnet zu
+    halten; der Grund ist jetzt weg, die Ordnung bleibt trotzdem, weil sie die
+    Fortschrittsausgabe in Dateireihenfolge haelt und nichts kostet.
     """
     type_form = defaultdict(Counter)
     type_lemma = defaultdict(Counter)
@@ -165,8 +158,17 @@ def resolve(type_form, type_lemma):
         if len(lemmas) > 1:
             multi_lemma += 1
         # most frequent; ties -> alphabetical form / smallest lemma number
+        # lemma_key statt des frueheren 1<<62-Fallbacks (#284): der kollabierte
+        # ALLE nicht-numerischen Lemma-IDs auf denselben Sortkey, womit der
+        # stabile Sort entschied, also die Einfuegereihenfolge des Counters,
+        # also die Reihenfolge, in der die Korpusdateien gelesen wurden. Beim
+        # sequentiellen Lauf faellt das nicht auf; es macht die Ausgabe aber
+        # von etwas abhaengig, das sie nicht sein sollte. lemma_key bricht den
+        # Gleichstand alphabetisch und ist damit vollstaendig explizit.
+        # Der heutige Korpus hat keine solchen IDs, das Artefakt ist
+        # unveraendert (per Hash geprueft).
         form = sorted(forms.items(), key=lambda kv: (-kv[1], kv[0]))[0][0]
-        lemma = sorted(lemmas.items(), key=lambda kv: (-kv[1], int(LEMMA_NUM_RE.match(kv[0]).group(1)) if LEMMA_NUM_RE.match(kv[0]) else 1 << 62))[0][0]
+        lemma = sorted(lemmas.items(), key=lambda kv: (-kv[1], lemma_key(kv[0])))[0][0]
         type_to_form[type_id] = form
         type_to_lemma[type_id] = lemma
         lemma_to_types[lemma].append(type_id)

--- a/scripts/sync/extract-variants.py
+++ b/scripts/sync/extract-variants.py
@@ -25,8 +25,11 @@ Negative type ids (legacy punctuation codes, #115) are skipped. The two
 Usage:
     python scripts/sync/extract-variants.py            # dry-run -> authority-files/variants.regen.xml
     python scripts/sync/extract-variants.py --apply    # overwrite authority-files/variants.xml
+    python scripts/sync/extract-variants.py --jobs 1   # sequentiell parsen (Default: bis 8 Prozesse)
 """
 
+import concurrent.futures
+import os
 import re
 import sys
 from collections import Counter, defaultdict
@@ -47,6 +50,11 @@ TYPE_POS_RE = re.compile(r'^type_\d+$')        # positive type id only
 TYPE_NUM_RE = re.compile(r'^type_(\d+)$')
 LEMMA_NUM_RE = re.compile(r'^lemma_(\d+)$')
 
+# Worker-Obergrenze (#284): jeder Worker haelt einen lxml-Baum im Speicher,
+# und der Elternprozess summiert alle Teilergebnisse allein. Siehe die
+# gleichlautende Konstante in scripts/build-corpus-index.py.
+DEFAULT_JOBS_CAP = 8
+
 PI_MODEL = [
     ('xml-model', 'href="../schema/mhdbdb-authority.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"'),
     ('xml-model', 'href="../schema/tei_all.rng"'),
@@ -59,33 +67,82 @@ def fragment(value):
     return tok.split('#', 1)[1] if '#' in tok else None
 
 
-def collect(base_files):
-    """type_id -> Counter(form), type_id -> Counter(lemma_id)."""
+def collect_one(fp):
+    """Eine Korpusdatei parsen (#284: Worker-Funktion, muss modullevel sein).
+
+    Rueckgabe sind zwei einfache dicts type_id -> {wert: anzahl}. Bewusst keine
+    lxml-Objekte: die ueberleben eine Prozessgrenze nicht. Counter waere
+    picklebar, plain dict ist kleiner und wird beim Mergen ohnehin in einen
+    Counter gefuettert.
+    """
     type_form = defaultdict(Counter)
     type_lemma = defaultdict(Counter)
-    for i, fp in enumerate(base_files):
-        if (i + 1) % 100 == 0:
-            print(f'  {i + 1}/{len(base_files)}...', flush=True)
-        tree = etree.parse(str(fp))
-        for w in tree.iter(f'{TEI}w'):
-            lemma_ref = w.get('lemmaRef')
-            corresp = w.get('corresp')
-            if not lemma_ref or not corresp:
+    tree = etree.parse(str(fp))
+    for w in tree.iter(f'{TEI}w'):
+        lemma_ref = w.get('lemmaRef')
+        corresp = w.get('corresp')
+        if not lemma_ref or not corresp:
+            continue
+        lemma_id = fragment(lemma_ref)
+        if not lemma_id:
+            continue
+        form = ''.join(w.itertext()).strip()
+        if not form:
+            continue
+        for token in corresp.split():
+            if not token.startswith('variants.xml#'):
                 continue
-            lemma_id = fragment(lemma_ref)
-            if not lemma_id:
-                continue
-            form = ''.join(w.itertext()).strip()
-            if not form:
-                continue
-            for token in corresp.split():
-                if not token.startswith('variants.xml#'):
-                    continue
-                type_id = token.split('#', 1)[1]
-                if not TYPE_POS_RE.match(type_id):
-                    continue  # negative/malformed -> skip (#115)
-                type_form[type_id][form] += 1
-                type_lemma[type_id][lemma_id] += 1
+            type_id = token.split('#', 1)[1]
+            if not TYPE_POS_RE.match(type_id):
+                continue  # negative/malformed -> skip (#115)
+            type_form[type_id][form] += 1
+            type_lemma[type_id][lemma_id] += 1
+    return ({t: dict(c) for t, c in type_form.items()},
+            {t: dict(c) for t, c in type_lemma.items()})
+
+
+def collect(base_files, jobs=1):
+    """type_id -> Counter(form), type_id -> Counter(lemma_id).
+
+    Parallelisiert wird nur das Parsen (#284); summiert wird im Elternprozess.
+
+    Die Reihenfolge von executor.map ist hier KEINE Kosmetik fuer die
+    Fortschrittsausgabe, sondern Teil der Determinismus-Zusicherung aus #125.
+    resolve() bricht Gleichstaende fast immer explizit (haeufigste Form, dann
+    alphabetisch; haeufigstes Lemma, dann kleinste Lemma-Nummer), aber der
+    Lemma-Sortkey faellt fuer nicht-numerische Lemma-IDs auf einen konstanten
+    Wert zurueck. Zwei solche IDs mit gleicher Haeufigkeit unter derselben
+    type_id entscheidet dann der stabile Sort, also die Insertion-Order des
+    Counters, also die Merge-Reihenfolge. Geordnetes map reproduziert dafuer
+    exakt die Dateireihenfolge des sequentiellen Laufs.
+
+    Deshalb NICHT auf as_completed umstellen. Der Bruch waere unsichtbar: der
+    heutige Korpus hat keine nicht-numerischen Lemma-IDs, ein Hash-Vergleich
+    wuerde also gruen bleiben, bis ein kuenftiger Ingest eine schraege
+    @lemmaRef mitbringt.
+    """
+    type_form = defaultdict(Counter)
+    type_lemma = defaultdict(Counter)
+    if jobs <= 1:
+        results = map(collect_one, base_files)
+        pool = None
+    else:
+        pool = concurrent.futures.ProcessPoolExecutor(max_workers=jobs)
+        results = pool.map(collect_one, base_files, chunksize=1)
+    try:
+        for i, (file_form, file_lemma) in enumerate(results):
+            if (i + 1) % 100 == 0:
+                print(f'  {i + 1}/{len(base_files)}...', flush=True)
+            for type_id, forms in file_form.items():
+                type_form[type_id].update(forms)
+            for type_id, lemmas in file_lemma.items():
+                type_lemma[type_id].update(lemmas)
+    finally:
+        if pool is not None:
+            # cancel_futures: map() reicht alle 667 Tasks sofort ein. Ohne das
+            # wartet ein Abbruch (z. B. XMLSyntaxError in Datei 3) erst die
+            # restlichen Dateien ab, bevor der Traceback erscheint.
+            pool.shutdown(cancel_futures=True)
     return type_form, type_lemma
 
 
@@ -188,11 +245,39 @@ def read_existing():
     return out, date_text, name_text
 
 
+def parse_jobs(argv):
+    """--jobs N aus argv lesen. Default: bis DEFAULT_JOBS_CAP Prozesse.
+
+    Bewusst kein argparse: das Skript liest seine Flags seit jeher direkt aus
+    sys.argv, und ein halber Umstieg waere die schlechtere Variante.
+    """
+    eq = [a for a in argv if a.startswith('--jobs=')]
+    if eq:
+        # Sonst laeuft `--jobs=1` still mit dem Default-Parallelbetrieb, und
+        # genau diese Schreibweise nimmt man zum sequentiellen Debuggen.
+        raw = eq[0].split('=', 1)[1]
+    elif '--jobs' in argv:
+        i = argv.index('--jobs')
+        if i + 1 >= len(argv):
+            sys.exit('--jobs braucht eine Zahl')
+        raw = argv[i + 1]
+    else:
+        return min(DEFAULT_JOBS_CAP, os.cpu_count() or 1)
+    try:
+        jobs = int(raw)
+    except ValueError:
+        sys.exit(f'--jobs braucht eine Zahl, nicht {raw!r}')
+    if jobs < 1:
+        sys.exit('--jobs muss mindestens 1 sein')
+    return jobs
+
+
 def main():
     apply = '--apply' in sys.argv
+    jobs = parse_jobs(sys.argv)
     base_files = sorted(f for f in TEI_DIR.glob('*.tei.xml') if '.disamb.' not in f.name)
-    print(f'Scanning {len(base_files)} corpus files for <w @lemmaRef @corresp>...')
-    type_form, type_lemma = collect(base_files)
+    print(f'Scanning {len(base_files)} corpus files for <w @lemmaRef @corresp>... ({jobs} Prozesse)')
+    type_form, type_lemma = collect(base_files, jobs=jobs)
     lemma_to_types, type_to_form, type_to_lemma, multi_form, multi_lemma = resolve(type_form, type_lemma)
 
     n_types = len(type_to_form)


### PR DESCRIPTION
Setzt #284 um. Nur `scripts/`, keine Build-Artefakte im Diff.

## Ergebnis

| Schritt | sequentiell | 8 Prozesse | Faktor |
|---|---|---|---|
| `build-corpus-index.py` | 183,5 s | 45,8 s | 4,0 |
| `extract-variants.py --apply` | 96,8 s | 22,9 s | 4,2 |
| `build-authority-index.py` | 12,4 s | 12,1 s | unveraendert |
| `build-api.py` | 4,0 s | 4,4 s | unveraendert |
| **volle Kette** | **296,7 s** | **84,0 s** | **3,5** |

Gemessen am 2026-07-31 auf 16 Kernen, 667 Korpusdateien, beide Laeufe hintereinander im selben frischen Worktree auf `5a2ee4718`.

## Byte-Identitaet, der eigentliche Beweis

Die Zusicherung aus #125 ist wichtiger als die Beschleunigung. Beide Laeufe vor und nach der Aenderung erzeugen exakt die committeten Artefakte:

```
sha256 (16), unveraendert ueber alle Laeufe:
  34eaf88592e4bd01  data/corpus-index.json.gz
  39caca2e8dcea67c  authority-files/variants.xml
  2d5732d5ac2b5093  data/authority-index.json.gz
  b0a338cd2e8b47b3  api/**/*.json (Sammelhash ueber alle 2.742 Dateien)
git status danach: sauber
```

Zusaetzlich bei jeder gemessenen Worker-Zahl (1, 2, 4, 8, 12, 16) derselbe Korpus-Index-Hash.

## Warum das deterministisch ist

`executor.map` liefert in **Eingabe**reihenfolge, nicht in Fertigstellungsreihenfolge. Damit ist die Konsumreihenfolge im Elternprozess identisch zum sequentiellen Lauf, und daran haengen die Bytes:

- `lemmaIndex` hat seine Schluessel in Erstauftretens- und seine Werte in Dateireihenfolge. Beides geht direkt in die JSON-Bytes.
- In `extract-variants.py` sind die Summen zwar ordnungsunabhaengig, aber `resolve()` bricht **nicht** jeden Gleichstand explizit (siehe unten).

Die Worker geben nur JSON-Typen zurueck, keine lxml-Objekte: die ueberleben eine Prozessgrenze nicht. Pickle erhaelt die Insertion-Order von dicts. Keine Floats, keine set-Iteration im Ausgabepfad, keine `PYTHONHASHSEED`-Abhaengigkeit.

## Aus der Fable-Zweitmeinung uebernommen

1. **Der latente Fallstrick.** Mein Docstring behauptete, das Ergebnis haenge nicht an der Merge-Reihenfolge. Das stimmt nicht: der Lemma-Sortkey in `resolve()` faellt fuer nicht-numerische Lemma-IDs auf einen konstanten Wert zurueck, dann entscheidet der stabile Sort, also die Counter-Insertion-Order, also die Merge-Reihenfolge. Der heutige Korpus hat keine solchen IDs, ein Hash-Vergleich bliebe also gruen, waehrend die Behauptung einen spaeteren Umbau auf `as_completed` legitimiert haette. Genau die Konstellation, nach der ich gefragt hatte: besteht den Test, ist trotzdem kaputt. Docstring korrigiert, mit ausdruecklichem Verbot von `as_completed`.
2. **`pool.shutdown(cancel_futures=True)`.** `map()` reicht alle 667 Tasks sofort ein; ohne das wartet ein Abbruch (etwa ein `XMLSyntaxError` in Datei 3) erst die restlichen Dateien ab, bevor der Traceback erscheint. Bis zu zwei Minuten scheinbares Haengen nach dem Fehler.
3. **`--jobs=8` wurde still ignoriert.** `extract-variants.py` liest seine Flags direkt aus `sys.argv`; mein erster Parser kannte nur `--jobs 8`. Wer `--jobs=1` schrieb, um sequentiell zu debuggen, bekam kommentarlos acht Prozesse. Jetzt werden beide Schreibweisen unterstuetzt, geprueft gegen acht Eingabeformen inkl. `--jobs` ohne Wert, `0`, `abc`, `--jobs=`.

## Entscheidungen

**Cap 8, nicht `cpu_count()`.** Gemessene Kurve auf 16 Kernen: `1 = 183,5 s, 2 = 97,9, 4 = 56,1, 8 = 45,8, 12 = 39,9, 16 = 42,4`. Ab 8 ist die Kurve flach, bei 16 kippt sie (Ueberbuchung). Der verbleibende Sockel sind rund 16 s Serialisieren und Gzippen, die niemand parallelisiert. 8 holt den Grossteil des Gewinns bei halbem Speicherbedarf; jeder Worker haelt einen lxml-Baum, und der Elternprozess muss ohnehin alles entpicken und behalten (rund 200 MB JSON). Wer die 6 s will, nimmt `--jobs 12`. Auf kleineren Maschinen und auf CI-Runnern greift `min(cap, cpu_count)`.

**`chunksize=1`.** Die Dateiliste ist alphabetisch, und die groessten Texte des Korpus (OVG, PL1, PL2) stehen darin unmittelbar nebeneinander. Groessere Chunks wuerden sie demselben Worker zuteilen und die Laufzeit ans Ende haengen. Bei rund einer Viertelsekunde Parse-Zeit pro Datei ist der Dispatch-Overhead vernachlaessigbar.

**Nicht angefasst:** `build-corpus-index.py` parst jede Datei zweimal (einmal fuer die Metadaten, einmal fuer die Wortdaten). Ein einziger Parse wuerde noch einmal deutlich sparen, ist aber eine andere Aenderung mit anderem Risikoprofil und gehoert nicht in denselben PR.

## Doku

Die Bauzeiten in der Routing-Tabelle aus PR #286 sind die sequentiellen. Sobald #286 gelandet ist, ziehe ich sie hier nach.

## JOURNAL-Eintrag (uebernimmt Session C oder der Merger)

**2026-07-31 – Index-Builds parallelisiert (#284).** `build-corpus-index.py` und `extract-variants.py` parsen die 667 Korpusdateien jetzt in einem Prozess-Pool; die Reduktion bleibt sequentiell und in Dateireihenfolge, weil daran die Index-Bytes haengen. Volle Rebuild-Kette 296,7 s auf 84,0 s, alle Artefakte byte-identisch, bei jeder gemessenen Worker-Zahl. Die Zweitmeinung fand die einzige echte Gefahr: die Gleichstandsaufloesung in `resolve()` ist nicht vollstaendig explizit, ein spaeterer Umbau auf `as_completed` waere auf heutigen Daten unentdeckbar nichtdeterministisch geworden.
