### PR TITLE
XPath-Tabelle um die drei kuratierten Lexikon-Produktionen ergaenzen (#278)

### DIFF
--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -440,8 +440,11 @@ Build properties: deterministic on the #125 principle (no timestamps, compact JS
 | | | `.//tei:form[@type="lemma"]/tei:orth` | Lemma text |
 | | | `.//tei:pos` | Part(s) of speech |
 | | | `.//tei:etym[@type="morphological"]//tei:seg[@type="component"]` | Etymology components + `@corresp` |
+| | | `.//tei:etym[@type="borrowing"]`, darin `./tei:lang` und `./tei:note[@type="attribution"]` | `lemma.origin`: Herkunftssprachen (`@norm` → `code`), optionale Attribution samt `@resp`. Kuratiert, siehe unten |
 | | | `.//tei:sense` | Senses (with `@xml:id`; concept pointers per sense) |
-| | | `.//tei:sense/tei:ptr[contains(@target,"concepts.xml#")]` | Concept pointers per sense |
+| | | `.//tei:ptr[contains(@target,"concepts.xml#")]` *(relativ zum `<sense>`)* | Concept pointers per sense |
+| | | `./tei:def` *(relativ zum `<sense>`)* | `sense.definition` + `sense.definitionResp` aus `@resp`. Kuratiert, siehe unten |
+| | | `./tei:note[@type="comment"]` *(relativ zum `<sense>`)* | `sense.comment` + `sense.commentResp` aus `@resp`. Kuratiert, siehe unten |
 | | persons.xml | `//tei:person` | Person records |
 | | | `.//tei:persName[@type="preferred"]` | Canonical name |
 | | | `.//tei:idno[@type="GND"]` | GND identifier |
@@ -471,6 +474,10 @@ Build properties: deterministic on the #125 principle (no timestamps, compact JS
 | | | `//tei:keywords/tei:term[@type="genre"]/text()`, Fallback `//tei:term[@type="genre"]/text()` | Genre |
 | | | `//tei:body//tei:w[@lemmaRef]` *(logical; real code: single-pass `iterwalk`)* | All words with positions (see [CONTRACTS.md](CONTRACTS.md#b-position-counting-contract)) |
 | | | `//tei:body//tei:l` *(im selben `iterwalk`)* | `lineStarts`/`lineEnds`, Wortindex des ersten und letzten indizierten `<w>` je Vers |
+
+#### Kuratierte Lexikon-Felder (#268, seit Authority-Index v1.7.0)
+
+Die drei mit „Kuratiert" markierten Produktionen (`etym[@type="borrowing"]`, `def`, `note[@type="comment"]`) tragen als einzige im Lexikon redaktionelle Prosa statt Klassifikation. Der Build schreibt die zugehörigen Index-Felder **nur dort, wo sie im XML tatsächlich stehen**: 43.879 Einträge mit leeren Schlüsseln würden Index und API ohne Nutzen aufblähen. Stand 2026-07-31 ist genau ein Lemma kuratiert (`lemma_37818` „Abba"), Konsumenten müssen die Felder deshalb als optional behandeln, nie als Zusage pro Datensatz. Normativ: [CONTRACTS.md §G.3](CONTRACTS.md#g3-field-schemas). Die `@resp`-Werte landen unverändert als `contributors.xml#contrib_N` im Index; auflösen lässt sich die ID nur über die XML-Datei, denn `contributors.xml` ist bewusst nicht indexiert.
 
 #### Namespace Handling
 
@@ -788,7 +795,7 @@ Die beiden Checklisten unten beschreiben den **Maximalfall**. Nicht jede Änderu
 
 - `build-corpus-index.py` liest aus `tei/` den Dateinamen und fünf Kopfangaben (Sigle aus `idno[@type="sigle"]`, Titel, Autor samt `@ref`, `msIdentifier/@corresp`, Genre-Term) sowie jedes `<w @lemmaRef>` mit nicht-leerem Text im `<body>` samt Dokumentreihenfolge und die `<l>`-Grenzen. Alles andere im TEI ist für ihn unsichtbar, insbesondere `@pos` und `@ana` sowie `<div>`, `<lg>` und `<pb>`. XPaths: [Build Script XPath Reference](#build-script-xpath-reference).
 - `extract-variants.py` liest aus `tei/` nur `<w>`, die **beides** tragen, `@lemmaRef` und ein `@corresp="variants.xml#type_N"`, und davon Lemma-ID, Type-ID und Wortlaut. Dazu die Zahl der Korpusdateien, die im Kopf von `variants.xml` steht.
-- `build-authority-index.py` liest ausschließlich `authority-files/` (die sieben indizierten Dateien inkl. `variants.xml`, ohne `contributors.xml`). `tei/` liest er nicht.
+- `build-authority-index.py` liest ausschließlich `authority-files/` (die sieben indizierten Dateien inkl. `variants.xml`, ohne `contributors.xml`). `tei/` liest er nicht. Anders als beim Korpus-Index entscheidet hier die Datei, nicht das Element: jede inhaltliche Änderung in einer der sieben Dateien verlangt den Rebuild. Welches Markup dabei im Index landet, steht in der [Build Script XPath Reference](#build-script-xpath-reference).
 - `build-api.py` liest ausschließlich die beiden gebauten `data/*.json.gz`, weder `tei/` noch `authority-files/`.
 
 **Routing nach Änderungstyp:**


### PR DESCRIPTION
Die Tabelle „Build Script XPath Reference" in `docs/DATA-MODEL.md` kannte die drei Produktionen nicht, die #268 für Authority-Index v1.7.0 ergänzt hat. Wer nach #268 wissen wollte, ob `<def>` indexiert wird, musste ins Skript.

## Ergänzte Zeilen, jeweils gegen den Code verifiziert

Verifiziert wurde gegen `scripts/build-authority-index.py` im Stand dieses Branches, nicht gegen das Issue.

| Neue Tabellenzeile | Fundstelle im Skript |
|---|---|
| `.//tei:etym[@type="borrowing"]`, darin `./tei:lang` und `./tei:note[@type="attribution"]` | Z. 122, Kinder Z. 125 und Z. 133; gesetzt als `lemma.origin` Z. 133–141 |
| `./tei:def` relativ zum `<sense>` | Z. 167; `sense.definition` + `definitionResp` Z. 168–173 |
| `./tei:note[@type="comment"]` relativ zum `<sense>` | Z. 175; `sense.comment` + `commentResp` Z. 176–181 |

Das Issue nennt für `<def>` „Z. ~168", der `xpath()`-Aufruf steht auf Z. 167.

## Zusätzlich korrigiert (im Issue benannt)

Die Concept-Pointer-Zeile stand als `.//tei:sense/tei:ptr[contains(@target,"concepts.xml#")]` in der Doku. Das Skript wertet auf Z. 152 `.//tei:ptr[contains(@target, "concepts.xml#")]` **relativ zum `<sense>`** aus. Ergebnis identisch, aber die Doku war enger als der Code; jetzt steht der Code-Pfad da, mit der Basis als Kursiv-Zusatz.

## Neuer Kurzabschnitt „Kuratierte Lexikon-Felder"

Die drei Felder sind optional: der Build schreibt sie nur dort, wo im XML tatsächlich etwas steht. Gemessen in `authority-files/lexicon.xml`: je genau ein Vorkommen von `etym type="borrowing"`, `<def` und `note type="comment"`, also ein kuratiertes Lemma (`lemma_37818`). Der Abschnitt verweist normativ auf CONTRACTS §G.3 und hält fest, dass `@resp` unaufgelöst als `contributors.xml#contrib_N` im Index landet, weil `contributors.xml` nicht indexiert ist.

## Routing-Abschnitt nachgezogen

Die Aufzählung „Was die vier Builds lesen" wird durch die neuen Zeilen **nicht falsch**: der Korpus-Bullet zählt Elemente auf, der Authority-Bullet ist datei-granular („liest ausschließlich `authority-files/`"), und das bleibt für die drei neuen Produktionen richtig. Ergänzt ist nur, was die Asymmetrie explizit macht: beim Authority-Index entscheidet die Datei und nicht das Element über den Rebuild, und der Bullet verlinkt jetzt wie der Korpus-Bullet daneben die XPath-Tabelle.

## Restliche Tabellenzeilen geprüft

Alle übrigen Einträge gegen die beiden Build-Skripte durchgesehen. Übereinstimmend: `//tei:entry` (Z. 77), `form[@type="lemma"]/orth` (85), `pos` (96), morphologische Komponenten (106/108), `sense` (144), persons (242/250/259/263), works `idno[@type="sigle"]` (359), `ptr` genres (374), `biblStruct` (387), `idno` handschriftencensus/GND/wikidata (404/408/419), `catDesc//term` in concepts/genres/names (476/483 u. a.), `ptr[@type="broader"]` (811–813), names-Concept-Refs (652), `.//tei:form` in variants (702). Alle sechs Korpus-Zeilen stimmen ebenfalls: Sigle (`build-corpus-index.py:111`), Titel (116), Autor (122), `msIdentifier` (130), Genre samt Fallback (137/139), `<w>`/`<l>` im `iterwalk` (190).

Drei Abweichungen sind mir aufgefallen, die nicht zu #278 gehören und deshalb **nicht** stillschweigend mitkorrigiert sind, sondern als Issue #293 abgelegt: `./tei:author` in der Doku gegen `.//tei:author` im Code, das nicht durchgesetzte „children of `listBibl`" und die für `variants.xml` behauptete, im Code nicht vorhandene Nicht-Namespace-Behandlung.

## Verifikation

Nur `docs/DATA-MODEL.md` angefasst, ein Commit. Neue Zeilen von Hand auf Em-Dash geprüft (`git diff` gefiltert, keine Treffer); `check-no-em-dash.py` deckt `docs/**/*.md` nicht ab. Kein Rebuild, kein Test-Lauf: reine Doku-Änderung ohne Daten- oder Code-Berührung.

Bezieht sich auf #278, schließt es nicht (Abnahme durch KZW nach Merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzWk9ShinfAHZoUMkwCX4M

