### PR TITLE
ROADMAP: Statuswiderspruch bei #187 aufgeloest

### DIFF
--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -632,3 +632,15 @@ Last gemessen und unkritisch: fünf parallele Requests kosten 31 bis 81 ms kalt,
 **Bewusst nicht angefasst:** die datierten Meilenstein-Einträge in `INDEX.md` (Z. 165, 166) und `ROADMAP.md` (Z. 107) nennen weiter „MWB/Lexer". Das ist die Beschreibung des Auslieferungsstands vom Juli, und das Projekt lässt solche Zahlen stehen (Z. 160 führt unverändert „damit 8 TEI-Analyse-Werkzeuge im Playground", inzwischen sind es zwölf). Wer sie retroaktiv umschreibt, macht aus einem Protokoll eine Momentaufnahme. Der Kommentar in `korpus.html:262` ist dagegen keine historische Aussage, sondern schlicht veraltet.
 
 **Phase:** Betrieb (frontend-only, kein Index- und kein API-Rebuild). Gepflegt: CONTRACTS §D.2, ARCHITECTURE (Wörterbuchnetz + MWB Online), FEATURES (Korpussuche, Hapax, neuer Abschnitt Lemma-Seite), `hilfe-daten.html`, `hilfe-korpussuche.html`, `hilfe-playground.html`, `impressum.html`, `lemma/index.html`, `README.md`. Issue #258 bleibt bis zur Abnahme durch KZW offen. PR #285 (vier Commits, gesquasht zu `8a6626c68`), README separat als `c3fd43b27`.
+
+---
+
+## 2026-07-31 – Die ROADMAP beschrieb den Stand eines Dokuments, nicht den des Projekts
+
+**Summary:** Zwei Einträge in `docs/ROADMAP.md` führten Arbeit als offen, die seit dem 10.07. erledigt ist: die posAll-Anzeige-Migration (#187, Commit `edb16dd3f`, Issue als completed geschlossen) und der WVV-Strophen-Lauf (nachgemessen an `tei/WVV.tei.xml`: 489 fortlaufende `<lg>`). Beide sind aus der Liste „Direkt startbar geworden" genommen und stehen als ein gemeinsamer, datierter Korrekturabsatz darunter.
+
+**Warum das hier steht und nicht nur im Diff:** Es ist an einem Tag dreimal dasselbe Muster aufgetreten. Neben #187 und WVV suggeriert die Spalte „KZW-Antwort liegt vor" bei #250, es sei entschieden; tatsächlich betrifft die Antwort vom 29.07. nur die Punkte 1 und 2, während Punkt 3 am 30.07. ergänzt und als Frage gestellt wurde und unbeantwortet ist. Die ROADMAP altert also nicht zufällig, sondern strukturell: sie wird beim Aufnehmen gepflegt und beim Erledigen nicht. Wer sie als Gegenwartsbeschreibung liest, plant gegen einen Stand, den es nicht mehr gibt.
+
+**Verifikationsweg, weil er den Unterschied gemacht hat:** Nicht die Doku gegen die Doku geprüft, sondern gegen Code und Korpus. Für #187 hieß das, jede der im Issue gelisteten Anzeige-Stellen auf das `posAll[]`-Muster hin anzusehen (dabei fiel `verse-position-search.js` auf, das in der Issue-Liste fehlte); für WVV, die 489 `<lg>` selbst zu zählen. Ein Commit-Betreff ist eine Behauptung, kein Beleg.
+
+**Phase:** Betrieb, reine Doku, kein Rebuild. PR #296.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -47,10 +47,14 @@ Die autonome Merge-Session (08.07., [MASTERPLAN-AUTONOME-MERGE-SESSION](playbook
 
 Direkt startbar geworden:
 - **#92 ARITHMETIC Stage 1** – Escaping-Blocker in #185 gemerged; Metadatenfragen an Carina weiter offen
-- **WVV-Strophen-Lauf** – erledigt, Korrektur 31.07.: der Halbsatz „der Lauf selbst steht noch aus" war stale. Der Lauf ist am 10.07. gefahren (JOURNAL, Vormittag: „#110/WVV komplett"); nachgemessen an `tei/WVV.tei.xml` sind es 489 fortlaufende `<lg>`. Derselbe Fehlertyp wie beim #187-Eintrag darüber
 - **#18 Multi-Lemma + PoS-Suche** – POS-Policy (#27) gemerged; braucht POS-Daten im Corpus-Index
 
-Korrektur 31.07.: **#187 posAll-Anzeige-Migration** stand hier bis heute als startbar, ist aber seit 10.07. erledigt (Commit `edb16dd3f`, Issue als completed geschlossen; JOURNAL-Eintrag 10.07. Vormittag). Alle im Issue gelisteten Anzeige-Stellen lesen inzwischen `posAll[]` mit Erstwert-Fallback für ältere Caches, dazu `verse-position-search.js`, das in der Issue-Liste fehlte.
+**Korrektur 31.07.:** Zwei Einträge standen hier als startbar, sind aber beide seit 10.07. erledigt und deshalb aus der Liste genommen.
+
+- **#187 posAll-Anzeige-Migration** (Commit `edb16dd3f`, Issue als completed geschlossen; JOURNAL 10.07. Vormittag). Alle im Issue gelisteten Anzeige-Stellen lesen inzwischen `posAll[]` mit Erstwert-Fallback für ältere Caches, dazu `verse-position-search.js`, das in der Issue-Liste fehlte.
+- **WVV-Strophen-Lauf**: der Halbsatz „der Lauf selbst steht noch aus" stammte vom 08.07. und wurde am 10.07. überholt (JOURNAL: „#110/WVV komplett"). Nachgemessen an `tei/WVV.tei.xml`: 489 fortlaufende `<lg>`.
+
+Beides derselbe Fehlertyp: die ROADMAP beschreibt den Stand eines Dokuments statt den des Projekts, sobald ein Eintrag nach seiner Erledigung nicht mitgezogen wird.
 
 **#124 (prio-1)** ist technisch fertig: cookieloses Matomo ist seit 17.06. deployed (`includes/_matomo.html`, Opt-out + Datenschutz-Abschnitt im Impressum, Commit `7abbf7672`); offen nur noch DSB-Absegnung der Rechtsgrundlage + Klärung des Dashboard-Zugangs.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -46,10 +46,11 @@ Weiterhin direkt startbar: **#216 minne-Serie** (~7.000 unannotierte Tokens in 2
 Die autonome Merge-Session (08.07., [MASTERPLAN-AUTONOME-MERGE-SESSION](playbooks/MASTERPLAN-AUTONOME-MERGE-SESSION.md)) hat alle 13 PRs der Issue-Session nach main gebracht (#174–#186); 13 Issues wurden automatisch geschlossen (#163 #164 #159 #168 #158 #162 #160 #161 #134 #145 #27 #167 #170), #68/#86/#28/#171 bleiben planmäßig offen (Teilarbeit). Authority-Index v1.6.0 (posAll[]) ist live, Live-Smoke-Checks für beide Stack-Ketten und die Unabhängigen bestanden. Details: JOURNAL-Eintrag 08.07. (Merge-Session) + Abschlussreport in #44.
 
 Direkt startbar geworden:
-- **#187 posAll-Anzeige-Migration** – 11 Konsumenten-Dateien zeigen noch den POS-Erstwert; Muster + Dateiliste im Issue
 - **#92 ARITHMETIC Stage 1** – Escaping-Blocker in #185 gemerged; Metadatenfragen an Carina weiter offen
 - **WVV-Strophen-Lauf** – F35/F36-Fixes gemerged UND KZW-Entscheid da (08.07., Empfehlung b bestätigt, #110 von KZW geschlossen); der Lauf selbst steht noch aus
 - **#18 Multi-Lemma + PoS-Suche** – POS-Policy (#27) gemerged; braucht POS-Daten im Corpus-Index
+
+Korrektur 31.07.: **#187 posAll-Anzeige-Migration** stand hier bis heute als startbar, ist aber seit 10.07. erledigt (Commit `edb16dd3f`, Issue als completed geschlossen; JOURNAL-Eintrag 10.07. Vormittag). Alle im Issue gelisteten Anzeige-Stellen lesen inzwischen `posAll[]` mit Erstwert-Fallback für ältere Caches, dazu `verse-position-search.js`, das in der Issue-Liste fehlte.
 
 **#124 (prio-1)** ist technisch fertig: cookieloses Matomo ist seit 17.06. deployed (`includes/_matomo.html`, Opt-out + Datenschutz-Abschnitt im Impressum, Commit `7abbf7672`); offen nur noch DSB-Absegnung der Rechtsgrundlage + Klärung des Dashboard-Zugangs.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -47,7 +47,7 @@ Die autonome Merge-Session (08.07., [MASTERPLAN-AUTONOME-MERGE-SESSION](playbook
 
 Direkt startbar geworden:
 - **#92 ARITHMETIC Stage 1** – Escaping-Blocker in #185 gemerged; Metadatenfragen an Carina weiter offen
-- **WVV-Strophen-Lauf** – F35/F36-Fixes gemerged UND KZW-Entscheid da (08.07., Empfehlung b bestätigt, #110 von KZW geschlossen); der Lauf selbst steht noch aus
+- **WVV-Strophen-Lauf** – erledigt, Korrektur 31.07.: der Halbsatz „der Lauf selbst steht noch aus" war stale. Der Lauf ist am 10.07. gefahren (JOURNAL, Vormittag: „#110/WVV komplett"); nachgemessen an `tei/WVV.tei.xml` sind es 489 fortlaufende `<lg>`. Derselbe Fehlertyp wie beim #187-Eintrag darüber
 - **#18 Multi-Lemma + PoS-Suche** – POS-Policy (#27) gemerged; braucht POS-Daten im Corpus-Index
 
 Korrektur 31.07.: **#187 posAll-Anzeige-Migration** stand hier bis heute als startbar, ist aber seit 10.07. erledigt (Commit `edb16dd3f`, Issue als completed geschlossen; JOURNAL-Eintrag 10.07. Vormittag). Alle im Issue gelisteten Anzeige-Stellen lesen inzwischen `posAll[]` mit Erstwert-Fallback für ältere Caches, dazu `verse-position-search.js`, das in der Issue-Liste fehlte.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Strategic priorities for the MHDBDB TEI Repository. Updated 2026-07-30.
+Strategic priorities for the MHDBDB TEI Repository. Updated 2026-07-31.
 
 See [Issue #44](https://github.com/DigitalHumanitiesCraft/mhdbdb-tei-only/issues/44) for the full triage matrix with per-issue status.
 


### PR DESCRIPTION
`docs/ROADMAP.md` führte **#187 (posAll-Anzeige-Migration)** unter „Direkt startbar geworden", der JOURNAL-Eintrag vom 10.07. listet sie als erledigt. Geprüft an Issue, Git-History und Code: der JOURNAL-Eintrag stimmt, die Roadmap war stale.

## Beleg

- Issue #187: `CLOSED`, `stateReason: COMPLETED`, closedAt 2026-07-10.
- Commit `edb16dd3f` „posAll[]-Anzeige-Migration: alle restlichen lemma.pos-Konsumenten (#187)" ist auf `main`, 10 Dateien.
- Code auf `origin/main`: alle in #187 gelisteten Stellen lesen `posAll[]` mit Fallback, u. a. `assets/js/app.js:811`, `assets/js/woerterbuch.js:178`, `lemma/lemma-page.js:145`, `playground/js/ui/authority/lemma-explorer.js:88,223,533,760`, `word-frequency.js:185,201`, `rhyme-dictionary.js:229,445,694`, `text-comparison.js:107`, `lemma-distribution.js:182,301`, `concept-distribution.js:165`. Zusätzlich `verse-position-search.js:193,248`, das in der Issue-Liste fehlte.
- Verbleibende `.pos`-Treffer ohne `posAll` sind entweder der dokumentierte Fallback-Zweig, abgeleitete lokale Objekte (deren `pos` bereits aus `posAll` gebaut wurde) oder die Token-Position `o.pos` in `hapax-legomena.js`, die mit Wortarten nichts zu tun hat.

## Changes

- ROADMAP-Bullet entfernt, stattdessen eine datierte Richtigstellung mit Commit-Verweis. JOURNAL bleibt unverändert, es war korrekt.

Nur Doku, kein Code, kein Index-Rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)