### PR TITLE
Playground-IndexedDB: drei Object Stores ohne Schreiber entfernt (#280)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -384,13 +384,11 @@ A–Z-Einstiegsseite zu den Lemma-Seiten. Lädt nur den Authority-Index (via `Co
 
 **Component:** `playground/js/indexed-db-manager.js` (Datenbank `MHDBDB_Playground`)
 
-**Object Stores:** (`indexed-db-manager.js`, `onupgradeneeded`)
-1. **tei_files** - User-uploaded TEI files (Indizes: timestamp, size, source) – der einzige Store mit aktivem Schreibpfad (`saveTEIFile()` über `data/storage/tei-storage.js`)
-2. **corpus_tei_files** - angelegt, aber ohne Schreiber: die vorgeladenen Korpus-Texte kommen aus dem Corpus-Index, nicht aus diesem Store
-3. **authority_files** - angelegt mit `expires`-Index (Default 24h in `saveAuthorityFile()`), ohne Schreiber: der Playground lädt den Authority-Index über den gemeinsamen `CorpusLoader`
-4. **metadata** - Key/Value-Store, ohne Schreiber
+**Object Store:** (`indexed-db-manager.js`, `onupgradeneeded`) genau einer, seit DB-Version 3.
 
-Die Stores 2 bis 4 stammen aus der Zeit vor dem gemeinsamen `CorpusLoader` und sind heute unbenutzt; die 24h aus `saveAuthorityFile()` sind deshalb nirgends wirksam. Aufräumen ist eigener Scope (#280).
+1. **tei_files** - User-uploaded TEI files (Indizes: timestamp, size, source), beschrieben über `saveTEIFile()` in `data/storage/tei-storage.js`
+
+Bis Version 2 legte der Manager zusätzlich `corpus_tei_files`, `authority_files` und `metadata` an. Diese drei stammten aus der Zeit vor dem gemeinsamen `CorpusLoader` und hatten keinen Schreiber mehr; die „24h Expiration" des Authority-Stores war deshalb nirgends wirksam. Version 3 entfernt sie und löscht sie über `deleteObjectStore` auch aus bestehenden Browser-Datenbanken (#280). Der Playground liest Korpus- und Authority-Daten über denselben `CorpusLoader` wie die Hauptseite, also aus `MHDBDBMainSite`.
 
 **Expiration Policy (ADR-004), wirksam im `CorpusLoader`, nicht hier:**
 - Authority- und Corpus-Index: 30-Tage-Cache (`CACHE_DURATION` in `assets/js/lib/corpus-loader.js`, Datenbank `MHDBDBMainSite`) plus Versions-Invalidierung

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -616,6 +616,9 @@ Parse order: ?id > #hash > path segment (first match wins)
 |----------|---------|-------|-----|---------|
 | `MHDBDBMainSite` | Dexie.js | `indices` | `name` (string) | `assets/js/lib/corpus-loader.js` |
 | `MHDBDB_TEI_Cache` | Raw IndexedDB | `parsedTEI` | `filename` (string) | `assets/js/storage/tei-cache-manager.js` |
+| `MHDBDB_Playground` | Raw IndexedDB | `tei_files` | `filename` (string) | `playground/js/indexed-db-manager.js` |
+
+**`MHDBDB_Playground` hält genau einen Store:** `tei_files`, die vom Benutzer selbst hochgeladenen TEI-Dateien, ohne Ablauffrist. Korpus- und Authority-Daten liegen auch im Playground im gemeinsamen `CorpusLoader` (`MHDBDBMainSite`), nicht hier. Ein zweiter Cache-Pfad darf nicht wieder entstehen: DB-Version 3 löscht die drei schreiberlosen Altstores `corpus_tei_files`, `authority_files` und `metadata` aus bestehenden Browser-Datenbanken (#280).
 
 ### Index Cache (MHDBDBMainSite)
 

--- a/playground/js/indexed-db-manager.js
+++ b/playground/js/indexed-db-manager.js
@@ -1,12 +1,27 @@
 /**
  * MHDBDB Playground - IndexedDB Manager
- * Core IndexedDB wrapper with async operations for TEI and Authority files
+ *
+ * Core IndexedDB wrapper for the playground's *only* persistent client data:
+ * TEI files the user uploads themselves (object store `tei_files`).
+ *
+ * Deliberately NOT in here (#280): caches for the corpus and the authority
+ * files. Those live in the shared `CorpusLoader` (Dexie database
+ * `MHDBDBMainSite`, 30-day TTL plus version invalidation, see ADR-004 and
+ * `assets/js/lib/corpus-loader.js`), which the playground uses as well. The
+ * stores `corpus_tei_files`, `authority_files` and `metadata` predate that
+ * loader, had no writer left, and are dropped on upgrade to DB version 3.
+ * Do not reintroduce a second cache path here.
  */
 
 export class IndexedDBManager {
+    // Stores removed in v3; deleted from existing browser databases on upgrade.
+    static OBSOLETE_STORES = ['corpus_tei_files', 'authority_files', 'metadata'];
+
     constructor() {
         this.dbName = 'MHDBDB_Playground';
-        this.dbVersion = 2; // Bumped to 2 for corpus support
+        // v2 added the (never written) corpus store, v3 removes the three
+        // writer-less stores again (#280).
+        this.dbVersion = 3;
         this.db = null;
         this.isInitialized = false;
     }
@@ -43,42 +58,53 @@ export class IndexedDBManager {
                 reject(new Error(`IndexedDB open failed: ${request.error}`));
             };
 
+            // Another tab still holds a connection on the older version, so the
+            // upgrade cannot run. Without this handler the promise would stay
+            // pending forever and every await on ensureInitialized() would hang
+            // silently (#280). Reject instead: the caller reports "storage not
+            // available" and the user can close the other tab and reload.
+            request.onblocked = () => {
+                console.warn('⚠️ IndexedDB upgrade blocked by another open tab: close it and reload the page');
+                reject(new Error('IndexedDB upgrade blocked by another open tab'));
+            };
+
             request.onsuccess = () => {
-                resolve(request.result);
+                const db = request.result;
+
+                // Do not block a future version bump made in another tab.
+                db.onversionchange = () => {
+                    console.warn('⚠️ IndexedDB version change requested elsewhere: closing this connection');
+                    db.close();
+                    this.db = null;
+                    this.isInitialized = false;
+                };
+
+                resolve(db);
             };
 
             request.onupgradeneeded = (event) => {
                 const db = event.target.result;
 
-                // Create object store for TEI files (user uploads)
+                // Create object store for TEI files (user uploads) — the only
+                // store with a write path (saveTEIFile via data/storage/tei-storage.js)
                 if (!db.objectStoreNames.contains('tei_files')) {
                     const teiStore = db.createObjectStore('tei_files', { keyPath: 'filename' });
                     teiStore.createIndex('timestamp', 'timestamp', { unique: false });
                     teiStore.createIndex('size', 'size', { unique: false });
-                    teiStore.createIndex('source', 'source', { unique: false }); // NEW: Track source
+                    teiStore.createIndex('source', 'source', { unique: false }); // Track source
                 }
 
-                // Create object store for Corpus TEI files (pre-loaded 667 files)
-                if (!db.objectStoreNames.contains('corpus_tei_files')) {
-                    const corpusStore = db.createObjectStore('corpus_tei_files', { keyPath: 'filename' });
-                    corpusStore.createIndex('timestamp', 'timestamp', { unique: false });
-                    corpusStore.createIndex('size', 'size', { unique: false });
-                    corpusStore.createIndex('sigle', 'metadata.sigle', { unique: false });
-                    corpusStore.createIndex('author', 'metadata.author', { unique: false });
-                    corpusStore.createIndex('title', 'metadata.title', { unique: false });
-                    console.log('📦 Created corpus_tei_files store for 667 pre-loaded texts');
-                }
-
-                // Create object store for Authority files
-                if (!db.objectStoreNames.contains('authority_files')) {
-                    const authStore = db.createObjectStore('authority_files', { keyPath: 'filename' });
-                    authStore.createIndex('timestamp', 'timestamp', { unique: false });
-                    authStore.createIndex('expires', 'expires', { unique: false });
-                }
-
-                // Create object store for metadata
-                if (!db.objectStoreNames.contains('metadata')) {
-                    db.createObjectStore('metadata', { keyPath: 'key' });
+                // v3: drop the leftovers of the playground-local cache path that
+                // predates the shared CorpusLoader (#280). `authority_files` did
+                // have a writer until 3126c175c (authority-storage-manager.js), so
+                // long-time users may still carry stale authority XML here; the
+                // other two were never written to. Nothing is lost: the indexes
+                // live in MHDBDBMainSite and are re-fetched on demand.
+                for (const obsolete of IndexedDBManager.OBSOLETE_STORES) {
+                    if (db.objectStoreNames.contains(obsolete)) {
+                        db.deleteObjectStore(obsolete);
+                        console.log(`🧹 Removed obsolete object store: ${obsolete}`);
+                    }
                 }
 
                 console.log('📦 IndexedDB stores created/upgraded');
@@ -190,114 +216,6 @@ export class IndexedDBManager {
         }
     }
 
-    // ==================== AUTHORITY FILES OPERATIONS ====================
-
-    async saveAuthorityFile(filename, content, expirationHours = 24) {
-        await this.ensureInitialized();
-
-        try {
-            const transaction = this.db.transaction(['authority_files'], 'readwrite');
-            const store = transaction.objectStore('authority_files');
-
-            const fileData = {
-                filename: filename,
-                content: content,
-                size: content.length,
-                timestamp: Date.now(),
-                expires: Date.now() + (expirationHours * 60 * 60 * 1000),
-                type: 'authority'
-            };
-
-            await this.promisifyRequest(store.put(fileData));
-            console.log(`✅ Authority file cached: ${filename} (${(content.length / 1024).toFixed(1)} KB, expires in ${expirationHours}h)`);
-            return true;
-        } catch (error) {
-            console.error(`❌ Failed to cache authority file ${filename}:`, error);
-            return false;
-        }
-    }
-
-    async loadAuthorityFile(filename) {
-        await this.ensureInitialized();
-
-        try {
-            const transaction = this.db.transaction(['authority_files'], 'readonly');
-            const store = transaction.objectStore('authority_files');
-
-            const result = await this.promisifyRequest(store.get(filename));
-
-            if (result) {
-                // Check if expired
-                if (Date.now() > result.expires) {
-                    console.log(`⏰ Authority file expired: ${filename}, removing from cache`);
-                    await this.removeAuthorityFile(filename);
-                    return null;
-                }
-
-                console.log(`📁 Authority file loaded from cache: ${filename}`);
-                return result.content;
-            }
-            return null;
-        } catch (error) {
-            console.error(`❌ Failed to load authority file ${filename}:`, error);
-            return null;
-        }
-    }
-
-    async removeAuthorityFile(filename) {
-        await this.ensureInitialized();
-
-        try {
-            const transaction = this.db.transaction(['authority_files'], 'readwrite');
-            const store = transaction.objectStore('authority_files');
-
-            await this.promisifyRequest(store.delete(filename));
-            console.log(`🗑️ Authority file removed from cache: ${filename}`);
-            return true;
-        } catch (error) {
-            console.error(`❌ Failed to remove authority file ${filename}:`, error);
-            return false;
-        }
-    }
-
-    async clearExpiredAuthorityFiles() {
-        await this.ensureInitialized();
-
-        try {
-            const transaction = this.db.transaction(['authority_files'], 'readwrite');
-            const store = transaction.objectStore('authority_files');
-            const index = store.index('expires');
-
-            // Get all expired files
-            const range = IDBKeyRange.upperBound(Date.now());
-            const request = index.openCursor(range);
-
-            let removedCount = 0;
-
-            await new Promise((resolve, reject) => {
-                request.onsuccess = (event) => {
-                    const cursor = event.target.result;
-                    if (cursor) {
-                        cursor.delete();
-                        removedCount++;
-                        cursor.continue();
-                    } else {
-                        resolve();
-                    }
-                };
-                request.onerror = () => reject(request.error);
-            });
-
-            if (removedCount > 0) {
-                console.log(`🧹 Removed ${removedCount} expired authority files`);
-            }
-            return removedCount;
-        } catch (error) {
-            console.error('❌ Failed to clear expired authority files:', error);
-            return 0;
-        }
-    }
-
     async clearTEIFiles() {
         await this.ensureInitialized();
 
@@ -317,31 +235,6 @@ export class IndexedDBManager {
         } catch (error) {
             console.error('❌ Failed to clear TEI files:', error);
             return 0;
-        }
-    }
-
-    async clearAllCaches() {
-        await this.ensureInitialized();
-
-        try {
-            const transaction = this.db.transaction(['tei_files', 'authority_files'], 'readwrite');
-
-            // Clear TEI files
-            const teiStore = transaction.objectStore('tei_files');
-            const teiCount = await this.promisifyRequest(teiStore.count());
-            await this.promisifyRequest(teiStore.clear());
-
-            // Clear authority files
-            const authorityStore = transaction.objectStore('authority_files');
-            const authorityCount = await this.promisifyRequest(authorityStore.count());
-            await this.promisifyRequest(authorityStore.clear());
-
-            const totalCount = teiCount + authorityCount;
-            console.log(`🧹 Cleared all caches: ${teiCount} TEI files + ${authorityCount} authority files = ${totalCount} total`);
-            return { tei: teiCount, authority: authorityCount, total: totalCount };
-        } catch (error) {
-            console.error('❌ Failed to clear all caches:', error);
-            return { tei: 0, authority: 0, total: 0 };
         }
     }
 
@@ -384,31 +277,22 @@ export class IndexedDBManager {
             const teiFiles = await this.listTEIFiles();
             const teiSize = teiFiles.reduce((sum, file) => sum + (file.size || 0), 0);
 
-            // Get authority files count and size
-            const transaction = this.db.transaction(['authority_files'], 'readonly');
-            const store = transaction.objectStore('authority_files');
-            const authorityFiles = await this.promisifyRequest(store.getAll());
-            const authoritySize = authorityFiles.reduce((sum, file) => sum + (file.size || 0), 0);
-
+            // tei_files is the only store in this database, so its size is the
+            // whole database size (#280).
             return {
                 teiFiles: {
                     count: teiFiles.length,
                     size: teiSize
                 },
-                authorityFiles: {
-                    count: authorityFiles.length,
-                    size: authoritySize
-                },
                 total: {
-                    count: teiFiles.length + authorityFiles.length,
-                    size: teiSize + authoritySize
+                    count: teiFiles.length,
+                    size: teiSize
                 }
             };
         } catch (error) {
             console.error('❌ Failed to calculate database size:', error);
             return {
                 teiFiles: { count: 0, size: 0 },
-                authorityFiles: { count: 0, size: 0 },
                 total: { count: 0, size: 0 }
             };
         }
@@ -430,8 +314,7 @@ export class IndexedDBManager {
                 estimatedQuota: estimate.quota, // Alias for backward compatibility
                 percentUsed: estimate.percentUsed,
                 dbSize: dbSize.total.size,
-                teiFiles: dbSize.teiFiles,
-                authorityFiles: dbSize.authorityFiles
+                teiFiles: dbSize.teiFiles
             };
         } catch (error) {
             console.error('❌ Failed to get storage quota info:', error);
@@ -444,8 +327,7 @@ export class IndexedDBManager {
                 estimatedQuota: 0,
                 percentUsed: 0,
                 dbSize: 0,
-                teiFiles: { count: 0, size: 0 },
-                authorityFiles: { count: 0, size: 0 }
+                teiFiles: { count: 0, size: 0 }
             };
         }
     }
@@ -475,194 +357,6 @@ export class IndexedDBManager {
         return Math.round(bytes / 1024 / 1024 * 100) / 100 + ' MB';
     }
 
-    // ==================== CORPUS TEI FILES OPERATIONS ====================
-
-    async saveCorpusFile(filename, content, metadata = {}) {
-        await this.ensureInitialized();
-
-        try {
-            const transaction = this.db.transaction(['corpus_tei_files'], 'readwrite');
-            const store = transaction.objectStore('corpus_tei_files');
-
-            const fileData = {
-                filename: filename,
-                content: content,
-                size: content.length,
-                timestamp: Date.now(),
-                metadata: {
-                    sigle: metadata.sigle || '',
-                    title: metadata.title || '',
-                    author: metadata.author || '',
-                    authorRef: metadata.authorRef || '',
-                    workRef: metadata.workRef || ''
-                },
-                source: 'corpus'
-            };
-
-            await this.promisifyRequest(store.put(fileData));
-            console.log(`✅ Corpus file saved: ${filename} (${(content.length / 1024).toFixed(1)} KB)`);
-            return true;
-        } catch (error) {
-            console.error(`❌ Failed to save corpus file ${filename}:`, error);
-            return false;
-        }
-    }
-
-    async loadCorpusFile(filename) {
-        await this.ensureInitialized();
-
-        try {
-            const transaction = this.db.transaction(['corpus_tei_files'], 'readonly');
-            const store = transaction.objectStore('corpus_tei_files');
-
-            const result = await this.promisifyRequest(store.get(filename));
-
-            if (result) {
-                console.log(`📁 Corpus file loaded: ${filename}`);
-                return result.content;
-            }
-            return null;
-        } catch (error) {
-            console.error(`❌ Failed to load corpus file ${filename}:`, error);
-            return null;
-        }
-    }
-
-    async listCorpusFiles() {
-        await this.ensureInitialized();
-
-        try {
-            const transaction = this.db.transaction(['corpus_tei_files'], 'readonly');
-            const store = transaction.objectStore('corpus_tei_files');
-
-            const files = await this.promisifyRequest(store.getAll());
-
-            return files.map(file => ({
-                filename: file.filename,
-                size: file.size || 0,
-                timestamp: file.timestamp || 0,
-                sigle: file.metadata?.sigle || '',
-                title: file.metadata?.title || '',
-                author: file.metadata?.author || '',
-                authorRef: file.metadata?.authorRef || '',
-                workRef: file.metadata?.workRef || ''
-            })).sort((a, b) => (a.sigle || '').localeCompare(b.sigle || ''));
-        } catch (error) {
-            console.error('❌ Failed to list corpus files:', error);
-            return [];
-        }
-    }
-
-    async isCorpusLoaded() {
-        await this.ensureInitialized();
-
-        try {
-            const transaction = this.db.transaction(['corpus_tei_files'], 'readonly');
-            const store = transaction.objectStore('corpus_tei_files');
-            const count = await this.promisifyRequest(store.count());
-
-            console.log(`📊 Corpus status: ${count}/667 files loaded`);
-            return count === 667;
-        } catch (error) {
-            console.error('❌ Failed to check corpus status:', error);
-            return false;
-        }
-    }
-
-    async getCorpusCount() {
-        await this.ensureInitialized();
-
-        try {
-            const transaction = this.db.transaction(['corpus_tei_files'], 'readonly');
-            const store = transaction.objectStore('corpus_tei_files');
-            return await this.promisifyRequest(store.count());
-        } catch (error) {
-            console.error('❌ Failed to get corpus count:', error);
-            return 0;
-        }
-    }
-
-    async copyCorpusToPlayground(filename) {
-        await this.ensureInitialized();
-
-        try {
-            const transaction = this.db.transaction(['corpus_tei_files', 'tei_files'], 'readwrite');
-
-            // Read from corpus
-            const corpusStore = transaction.objectStore('corpus_tei_files');
-            const corpusFile = await this.promisifyRequest(corpusStore.get(filename));
-
-            if (!corpusFile) {
-                throw new Error(`Corpus file not found: ${filename}`);
-            }
-
-            // Write to playground with source marker
-            const teiStore = transaction.objectStore('tei_files');
-            const playgroundFile = {
-                filename: corpusFile.filename,
-                content: corpusFile.content,
-                size: corpusFile.size,
-                timestamp: Date.now(),  // Update timestamp
-                type: 'tei',
-                source: 'corpus-copy',  // Mark as copied from corpus
-                metadata: corpusFile.metadata  // Preserve metadata
-            };
-
-            await this.promisifyRequest(teiStore.put(playgroundFile));
-            console.log(`✅ Copied corpus file to playground: ${filename}`);
-            return true;
-        } catch (error) {
-            console.error(`❌ Failed to copy corpus file ${filename}:`, error);
-            return false;
-        }
-    }
-
-    async copyAllCorpusToPlayground(progressCallback) {
-        await this.ensureInitialized();
-
-        try {
-            const corpusFiles = await this.listCorpusFiles();
-            let copiedCount = 0;
-
-            for (const file of corpusFiles) {
-                const success = await this.copyCorpusToPlayground(file.filename);
-                if (success) {
-                    copiedCount++;
-
-                    if (progressCallback) {
-                        progressCallback(copiedCount, corpusFiles.length);
-                    }
-                }
-            }
-
-            console.log(`✅ Copied ${copiedCount} corpus files to playground`);
-            return copiedCount;
-        } catch (error) {
-            console.error('❌ Failed to copy corpus to playground:', error);
-            return 0;
-        }
-    }
-
-    async clearCorpusFiles() {
-        await this.ensureInitialized();
-
-        try {
-            const transaction = this.db.transaction(['corpus_tei_files'], 'readwrite');
-            const store = transaction.objectStore('corpus_tei_files');
-
-            const countRequest = store.count();
-            const count = await this.promisifyRequest(countRequest);
-
-            await this.promisifyRequest(store.clear());
-
-            console.log(`🧹 Cleared ${count} corpus files from IndexedDB`);
-            return count;
-        } catch (error) {
-            console.error('❌ Failed to clear corpus files:', error);
-            return 0;
-        }
-    }
-
     // ==================== ERROR RECOVERY ====================
 
     async validateDatabase() {
@@ -680,9 +374,6 @@ export class IndexedDBManager {
             if (retrieved !== testData) {
                 throw new Error('Database validation failed - data integrity issue');
             }
-
-            // Clean up expired authority files
-            await this.clearExpiredAuthorityFiles();
 
             console.log('✅ IndexedDB validation successful');
             return true;

--- a/playground/js/indexed-db-manager.js
+++ b/playground/js/indexed-db-manager.js
@@ -54,7 +54,13 @@ export class IndexedDBManager {
         return new Promise((resolve, reject) => {
             const request = indexedDB.open(this.dbName, this.dbVersion);
 
+            // onblocked can be followed by a late onsuccess once the blocking tab
+            // goes away. The resolve is a no-op by then, so remember that we already
+            // settled and close the connection nobody holds a reference to.
+            let settled = false;
+
             request.onerror = () => {
+                settled = true;
                 reject(new Error(`IndexedDB open failed: ${request.error}`));
             };
 
@@ -65,11 +71,17 @@ export class IndexedDBManager {
             // available" and the user can close the other tab and reload.
             request.onblocked = () => {
                 console.warn('⚠️ IndexedDB upgrade blocked by another open tab: close it and reload the page');
+                settled = true;
                 reject(new Error('IndexedDB upgrade blocked by another open tab'));
             };
 
             request.onsuccess = () => {
                 const db = request.result;
+
+                if (settled) {
+                    db.close();
+                    return;
+                }
 
                 // Do not block a future version bump made in another tab.
                 db.onversionchange = () => {
@@ -79,6 +91,7 @@ export class IndexedDBManager {
                     this.isInitialized = false;
                 };
 
+                settled = true;
                 resolve(db);
             };
 

--- a/testing/tests/corpus.spec.js
+++ b/testing/tests/corpus.spec.js
@@ -15,7 +15,10 @@ test.describe('Corpus Loading and Management', () => {
     });
   });
 
-  test('IndexedDB corpus operations - schema version 2', async ({ page }) => {
+  // Seit #280 hat MHDBDB_Playground genau einen Store. Die frueheren Stores
+  // corpus_tei_files, authority_files und metadata hatten keinen Schreiber mehr
+  // und werden in DB-Version 3 auch aus bestehenden Browser-Datenbanken geloescht.
+  test('IndexedDB schema - version 3 keeps only tei_files', async ({ page }) => {
     await page.goto('/testing/test.html');
 
     const result = await page.evaluate(async () => {
@@ -24,28 +27,71 @@ test.describe('Corpus Loading and Management', () => {
 
       await dbManager.initialize();
 
-      // Verify database version
-      if (dbManager.dbVersion !== 2) {
-        throw new Error(`Expected DB version 2, got ${dbManager.dbVersion}`);
+      if (dbManager.dbVersion !== 3) {
+        throw new Error(`Expected DB version 3, got ${dbManager.dbVersion}`);
       }
 
-      // Verify corpus_tei_files store exists
       const storeNames = Array.from(dbManager.db.objectStoreNames);
-      if (!storeNames.includes('corpus_tei_files')) {
-        throw new Error('corpus_tei_files store not found');
+      if (!storeNames.includes('tei_files')) {
+        throw new Error('tei_files store not found');
       }
 
       return { success: true, version: dbManager.dbVersion, stores: storeNames };
     });
 
     expect(result.success).toBe(true);
-    expect(result.version).toBe(2);
-    expect(result.stores).toContain('corpus_tei_files');
-    expect(result.stores).toContain('tei_files');
-    expect(result.stores).toContain('authority_files');
+    expect(result.version).toBe(3);
+    expect(result.stores).toEqual(['tei_files']);
   });
 
-  test('IndexedDB corpus operations - save and load corpus file', async ({ page }) => {
+  // Migrationspfad: eine Datenbank auf dem alten Stand (Version 2, vier Stores,
+  // Daten im authority_files-Store) muss beim naechsten Oeffnen auf Version 3
+  // hochgezogen werden, die Altstores verlieren und tei_files behalten.
+  test('IndexedDB schema - v2 database is migrated to v3', async ({ page }) => {
+    await page.goto('/testing/test.html');
+
+    const result = await page.evaluate(async () => {
+      // Alte v2-Datenbank von Hand nachbauen
+      await new Promise((resolve, reject) => {
+        const request = indexedDB.open('MHDBDB_Playground', 2);
+        request.onupgradeneeded = (event) => {
+          const db = event.target.result;
+          const teiStore = db.createObjectStore('tei_files', { keyPath: 'filename' });
+          teiStore.createIndex('timestamp', 'timestamp', { unique: false });
+          db.createObjectStore('corpus_tei_files', { keyPath: 'filename' });
+          const authStore = db.createObjectStore('authority_files', { keyPath: 'filename' });
+          authStore.createIndex('expires', 'expires', { unique: false });
+          db.createObjectStore('metadata', { keyPath: 'key' });
+        };
+        request.onsuccess = () => {
+          const db = request.result;
+          const tx = db.transaction(['tei_files', 'authority_files'], 'readwrite');
+          tx.objectStore('tei_files').put({ filename: 'keep-me.xml', content: '<TEI/>', timestamp: Date.now() });
+          tx.objectStore('authority_files').put({ filename: 'lexicon.xml', content: 'stale', expires: Date.now() });
+          tx.oncomplete = () => { db.close(); resolve(); };
+          tx.onerror = () => reject(tx.error);
+        };
+        request.onerror = () => reject(request.error);
+      });
+
+      const { IndexedDBManager } = await import('../playground/js/indexed-db-manager.js');
+      const dbManager = new IndexedDBManager();
+      await dbManager.initialize();
+
+      const stores = Array.from(dbManager.db.objectStoreNames);
+      const survived = await dbManager.loadTEIFile('keep-me.xml');
+
+      return { success: true, version: dbManager.db.version, stores, survived };
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.version).toBe(3);
+    expect(result.stores).toEqual(['tei_files']);
+    // User-Uploads ueberleben die Migration
+    expect(result.survived).toBe('<TEI/>');
+  });
+
+  test('IndexedDB user uploads - save, load and list', async ({ page }) => {
     await page.goto('/testing/test.html');
 
     const result = await page.evaluate(async () => {
@@ -54,7 +100,6 @@ test.describe('Corpus Loading and Management', () => {
 
       await dbManager.initialize();
 
-      // Create test TEI content
       const testFilename = 'TEST.tei.xml';
       const testContent = `<?xml version="1.0" encoding="UTF-8"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="TEST">
@@ -67,136 +112,26 @@ test.describe('Corpus Loading and Management', () => {
   <text><body><p>Test content</p></body></text>
 </TEI>`;
 
-      const testMetadata = {
-        sigle: 'TEST',
-        title: 'Test Document',
-        author: 'Test Author',
-        authorRef: '#person_1',
-        workRef: 'works.xml#work_1'
-      };
+      const saved = await dbManager.saveTEIFile(testFilename, testContent);
+      if (!saved) throw new Error('Failed to save TEI file');
 
-      // Save corpus file
-      const saved = await dbManager.saveCorpusFile(testFilename, testContent, testMetadata);
-      if (!saved) throw new Error('Failed to save corpus file');
+      const loaded = await dbManager.loadTEIFile(testFilename);
+      if (loaded !== testContent) throw new Error('Content mismatch');
 
-      // Load corpus file
-      const loaded = await dbManager.loadCorpusFile(testFilename);
-      if (!loaded) throw new Error('Failed to load corpus file');
-
-      // Verify content matches
-      if (loaded !== testContent) {
-        throw new Error('Content mismatch');
-      }
-
-      // List corpus files
-      const files = await dbManager.listCorpusFiles();
+      const files = await dbManager.listTEIFiles();
       const testFile = files.find(f => f.filename === testFilename);
-
       if (!testFile) throw new Error('Test file not in list');
-      if (testFile.sigle !== 'TEST') throw new Error('Metadata not preserved');
 
       return {
         success: true,
         fileCount: files.length,
-        metadata: testFile
+        size: testFile.size
       };
     });
 
     expect(result.success).toBe(true);
     expect(result.fileCount).toBe(1);
-    expect(result.metadata.sigle).toBe('TEST');
-    expect(result.metadata.title).toBe('Test Document');
-    expect(result.metadata.author).toBe('Test Author');
-  });
-
-  test('IndexedDB corpus operations - isCorpusLoaded check', async ({ page }) => {
-    await page.goto('/testing/test.html');
-
-    const result = await page.evaluate(async () => {
-      const { IndexedDBManager } = await import('../playground/js/indexed-db-manager.js');
-      const dbManager = new IndexedDBManager();
-
-      await dbManager.initialize();
-
-      // Initially corpus should not be loaded (0/667)
-      let isLoaded = await dbManager.isCorpusLoaded();
-      if (isLoaded) throw new Error('Corpus should not be loaded initially');
-
-      let count = await dbManager.getCorpusCount();
-      if (count !== 0) throw new Error(`Expected 0 files, got ${count}`);
-
-      // Add test files (not all 667, just a few for testing)
-      for (let i = 1; i <= 5; i++) {
-        await dbManager.saveCorpusFile(
-          `TEST${i}.tei.xml`,
-          `<TEI>Content ${i}</TEI>`,
-          { sigle: `TEST${i}`, title: `Test ${i}`, author: 'Test' }
-        );
-      }
-
-      // Should still not be loaded (5/667)
-      isLoaded = await dbManager.isCorpusLoaded();
-      if (isLoaded) throw new Error('Corpus should not be fully loaded yet');
-
-      count = await dbManager.getCorpusCount();
-      if (count !== 5) throw new Error(`Expected 5 files, got ${count}`);
-
-      return { success: true, partialCount: count };
-    });
-
-    expect(result.success).toBe(true);
-    expect(result.partialCount).toBe(5);
-  });
-
-  test('IndexedDB corpus operations - copy to playground', async ({ page }) => {
-    await page.goto('/testing/test.html');
-
-    const result = await page.evaluate(async () => {
-      const { IndexedDBManager } = await import('../playground/js/indexed-db-manager.js');
-      const dbManager = new IndexedDBManager();
-
-      await dbManager.initialize();
-
-      // Create and save corpus file
-      const filename = 'COPY_TEST.tei.xml';
-      const content = '<TEI>Copy test content</TEI>';
-      const metadata = {
-        sigle: 'COPY',
-        title: 'Copy Test',
-        author: 'Test Author',
-        authorRef: '#person_1',
-        workRef: 'works.xml#work_1'
-      };
-
-      await dbManager.saveCorpusFile(filename, content, metadata);
-
-      // Copy to playground
-      const copied = await dbManager.copyCorpusToPlayground(filename);
-      if (!copied) throw new Error('Failed to copy corpus file');
-
-      // Load from playground store
-      const loadedFromPlayground = await dbManager.loadTEIFile(filename);
-      if (!loadedFromPlayground) throw new Error('File not in playground store');
-
-      if (loadedFromPlayground !== content) {
-        throw new Error('Content mismatch after copy');
-      }
-
-      // Verify both stores have the file
-      const corpusFiles = await dbManager.listCorpusFiles();
-      const teiFiles = await dbManager.listTEIFiles();
-
-      const inCorpus = corpusFiles.some(f => f.filename === filename);
-      const inPlayground = teiFiles.some(f => f.filename === filename);
-
-      if (!inCorpus) throw new Error('File missing from corpus store');
-      if (!inPlayground) throw new Error('File missing from playground store');
-
-      return { success: true, inBothStores: true };
-    });
-
-    expect(result.success).toBe(true);
-    expect(result.inBothStores).toBe(true);
+    expect(result.size).toBeGreaterThan(0);
   });
 
   test('Corpus index structure after auto-load', async ({ page }) => {
@@ -290,7 +225,7 @@ test.describe('Corpus Loading and Management', () => {
     expect(result.lemmaCount).toBeGreaterThan(0);
   });
 
-  test('Clear corpus files operation', async ({ page }) => {
+  test('Clear TEI files operation', async ({ page }) => {
     await page.goto('/testing/test.html');
 
     const result = await page.evaluate(async () => {
@@ -299,25 +234,18 @@ test.describe('Corpus Loading and Management', () => {
 
       await dbManager.initialize();
 
-      // Add test files
       for (let i = 1; i <= 5; i++) {
-        await dbManager.saveCorpusFile(
-          `CLEAR${i}.tei.xml`,
-          `<TEI>Clear test ${i}</TEI>`,
-          { sigle: `CLR${i}`, title: `Clear ${i}`, author: 'Test' }
-        );
+        await dbManager.saveTEIFile(`CLEAR${i}.tei.xml`, `<TEI>Clear test ${i}</TEI>`);
       }
 
-      let count = await dbManager.getCorpusCount();
-      if (count !== 5) throw new Error(`Expected 5 files before clear, got ${count}`);
+      let files = await dbManager.listTEIFiles();
+      if (files.length !== 5) throw new Error(`Expected 5 files before clear, got ${files.length}`);
 
-      // Clear corpus
-      const cleared = await dbManager.clearCorpusFiles();
+      const cleared = await dbManager.clearTEIFiles();
       if (cleared !== 5) throw new Error(`Expected to clear 5 files, cleared ${cleared}`);
 
-      // Verify empty
-      count = await dbManager.getCorpusCount();
-      if (count !== 0) throw new Error(`Expected 0 files after clear, got ${count}`);
+      files = await dbManager.listTEIFiles();
+      if (files.length !== 0) throw new Error(`Expected 0 files after clear, got ${files.length}`);
 
       return { success: true, cleared };
     });


### PR DESCRIPTION
Refs #280.

`MHDBDB_Playground` legte vier Object Stores an, drei davon ohne Schreibpfad. Sie stammen aus der Zeit vor dem gemeinsamen `CorpusLoader`, der Korpus- und Authority-Index heute auch im Playground aus `MHDBDBMainSite` liefert (30-Tage-TTL, ADR-004). Übrig bleibt genau `tei_files`: die vom Benutzer selbst hochgeladenen TEI-Dateien.

## Totsein-Beweis

Vor dem Löschen geprüft, mit auf Wortgrenzen verankerten Mustern über `playground/`, `assets/`, `lemma/`, `testing/` und alle `*.html`:

| Store | Belege |
|---|---|
| `corpus_tei_files` | kein Produktions-Schreiber und kein Leser, auch historisch nie einer. Einzige Verwender waren fünf Tests in `testing/tests/corpus.spec.js`, die die Store-API gegen sich selbst prüften |
| `authority_files` | kein Schreiber mehr. Bis Commit `3126c175c` gab es einen (`playground/js/authority-storage-manager.js`, gelöscht). Der setzte 24h Expiry, alles darin ist also seit Langem abgelaufen |
| `metadata` | nie beschrieben, nie gelesen, keine einzige Referenz im Repo |

Zusätzlich geprüft, weil ein fehlender Grep-Treffer bei dynamisch gebildeten Namen nichts beweist: Store-Namen werden in `indexed-db-manager.js` ausschließlich als String-Literale verwendet, nie zusammengesetzt. Kein `eval`, kein Service Worker, keine `onclick=`-Verdrahtung und kein dynamischer Member-Access auf den Manager. Der einzige externe Treffer auf `MHDBDB_Playground` ist `assets/js/site-chrome.js`, das die ganze Datenbank per Namen löscht und store-unabhängig ist.

**Ein Fund, den das Issue nicht hatte:** `getDatabaseSize()` las `authority_files` auf einem *lebenden* Pfad (`tei-manager.getStorageInfo` → `tei-storage.getStorageQuotaInfo` → hier). Das Entfernen war also nicht rein subtraktiv. Die Methode rechnet jetzt nur noch über `tei_files`; das Feld `authorityFiles` fällt aus dem Rückgabeobjekt, kein Konsument las es (geprüft in `test-utils.js`, `test.html`, `tei-manager.js`).

## Umgang mit der DB-Version

`dbVersion` 2 → 3, und `onupgradeneeded` löscht die drei Altstores per `deleteObjectStore`, jeweils hinter einem `objectStoreNames.contains`-Guard.

Die Entscheidung bewusst so und nicht anders: Ohne Bump feuert `onupgradeneeded` bei Bestandsnutzern nie, die drei Stores blieben in deren Browsern für immer liegen, und der Store-Bestand liefe zwischen neuen und alten Nutzern auseinander. Mit Bump konvergieren alle auf denselben Stand. Datenverlust gibt es nicht: `tei_files` wird nicht angefasst, `corpus_tei_files` und `metadata` waren immer leer, und der Inhalt von `authority_files` war schon nach der alten 24h-Regel wertlos. Bei Nutzern, die den Store noch gefüllt haben, gibt die Migration sogar Plattenplatz zurück. Der `contains`-Guard macht den Pfad versionsagnostisch, auch eine v1-Datenbank landet korrekt auf v3.

Weil das der erste echte Version-Bump für bestehende Nutzer ist, kommen zwei Handler dazu, die vorher gefehlt haben: `request.onblocked` und `db.onversionchange`. Ohne sie hätte ein zweiter offener Tab mit altem Code die Upgrade-Anfrage blockiert, das Open-Promise wäre für immer pending geblieben, und jedes `await ensureInitialized()` hätte still gehangen. Jetzt rejectet der blockierte Fall sichtbar, der Playground meldet "storage not available", und weil `isInitialized` false bleibt, heilt sich der nächste Versuch selbst, sobald der andere Tab weg ist. `onversionchange` gibt umgekehrt die eigene Verbindung frei; das repariert nebenbei, dass der Site-Chrome-Reset bisher von einer offenen Playground-Verbindung blockiert werden konnte.

## Änderungen

- `playground/js/indexed-db-manager.js`: drei Stores und 13 tote Methoden entfernt, Version-Bump plus Migration, `onblocked`/`onversionchange`, `getDatabaseSize`/`getStorageQuotaInfo` bereinigt. Ein Klassen-Kommentar hält fest, dass Korpus- und Authority-Caching bewusst im gemeinsamen `CorpusLoader` liegt, damit hier kein zweiter Cache-Pfad nachwächst.
- `docs/ARCHITECTURE.md` § Storage, `docs/CONTRACTS.md` §E: nachgezogen. `MHDBDB_Playground` fehlte in der CONTRACTS-Tabelle bisher ganz.
- `testing/tests/corpus.spec.js`: siehe Scope-Hinweis unten.

Jeder Punkt ist ein eigener Commit, damit die Doku- und Test-Commits einzeln droppbar sind.

## Scope-Hinweis

Der Auftrag lautete "nur `playground/`". Zwei begründete Erweiterungen:

1. **`testing/tests/corpus.spec.js`.** Fünf Tests waren die einzigen Verwender der gelöschten Methoden und pinnten „DB-Version 2" samt der drei Store-Namen. Ohne Anpassung wäre `npm test` nach diesem PR garantiert rot. Umgestellt auf den lebenden `tei_files`-Pfad, plus ein neuer Migrationstest, der eine v2-Datenbank mit allen vier Stores und Daten in `authority_files` von Hand nachbaut, sie mit dem Manager öffnet und prüft, dass die Altstores verschwinden und ein User-Upload überlebt.
2. **`docs/ARCHITECTURE.md`.** Der Abschnitt zählte die vier Stores namentlich auf und verwies für das Aufräumen auf dieses Issue. Nach dem Merge wäre er sofort wieder falsch gewesen, also genau der Drift, den der Health-Check am 31.07. gerade behoben hat.

## Verifikation

Statisch verifiziert:

- `node --check` auf beiden geänderten JS-Dateien
- Wortgrenzen-Greps über alle 13 gelöschten Methodennamen und alle Store-Namen, siehe oben
- `python scripts/audit/check-no-em-dash.py` grün
- Zweitmeinung durch `fable-advisor` eingeholt: hat den Totsein-Beweis unabhängig nachgeprüft (inklusive Service Worker, `eval`, dynamischer Member-Access) und keine Lücke gefunden, den Migrationspfad bestätigt und einen Nit gemeldet, der übernommen ist (verwaiste Verbindung nach `onblocked` schließen).

**Nicht verifiziert, weil in diesem Lauf ausdrücklich untersagt:** kein Dev-Server, kein `npm test`, keine Chrome-Verifikation. Vor dem Merge fehlen also (a) der tatsächliche Playwright-Lauf, insbesondere für den neuen Migrationstest mit dem handgebauten v2-Aufbau, und (b) die im Issue gewünschte Chrome-Verifikation des Upload-Pfads: TEI-Datei im Playground hochladen, Seite neu laden, Datei ist noch da, und in den DevTools unter Application → IndexedDB steht `MHDBDB_Playground` auf Version 3 mit nur `tei_files`. Am aussagekräftigsten mit einem Profil, das die alte v2-Datenbank noch hat.

Kein HTML angefasst, also kein `npm run build:css` nötig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzWk9ShinfAHZoUMkwCX4M
