### PR TITLE
Korpus-Dateiauswahl in ein gemeinsames Modul (#287)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,6 +14,7 @@ scripts/
 ├── validate-indices.py          # Generierte Indexes validieren
 ├── mhg_normalizer.py            # MHG-Textnormalisierung (shared lib)
 ├── tei_namespaces.py            # TEI-Namespace-Erkennung für lxml-Bäume (shared lib)
+├── corpus_files.py              # welche Dateien der Korpus sind, in welcher Reihenfolge, plus Worker-Cap (shared lib, #287)
 ├── insert-pb-from-linecode.py   # <pb> aus Legacy-Linecode einfügen (#26)
 ├── insert-stanzas-from-linecode.py # Stanza-Anchors aus Legacy-Linecode (#23)
 ├── insert-div-wrappers-138.py   # Editorische <div>-Hüllen für HUG und MBS (#138)

--- a/scripts/audit/audit-tei-corpus.py
+++ b/scripts/audit/audit-tei-corpus.py
@@ -21,6 +21,10 @@ from datetime import date
 from pathlib import Path
 from lxml import etree
 
+# Gemeinsame Korpusauswahl (#287).
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from corpus_files import DISAMB_MARKER, corpus_files  # noqa: E402
+
 TEI_NS = '{http://www.tei-c.org/ns/1.0}'
 XML_NS = '{http://www.w3.org/XML/1998/namespace}'
 
@@ -72,7 +76,7 @@ def audit_corpus(tei_dir):
     """Run the full audit on all base TEI files."""
     # Collect files
     all_files = sorted(Path(tei_dir).glob('*.tei.xml'))
-    base_files = [f for f in all_files if '.disamb.' not in f.name]
+    base_files = corpus_files(tei_dir)
 
     print(f'Found {len(base_files)} base TEI files (excluded {len(all_files) - len(base_files)} .disamb files)')
 
@@ -165,7 +169,7 @@ def build_json(elements, file_stats, base_files):
     result = {
         'meta': {
             'files_analyzed': len(base_files),
-            'files_excluded_pattern': '*.disamb.tei.xml',
+            'files_excluded_pattern': f'*{DISAMB_MARKER}tei.xml',
             'date': str(date.today()),
             'script': 'scripts/audit/audit-tei-corpus.py',
         },

--- a/scripts/audit/check-authority-cross-refs.py
+++ b/scripts/audit/check-authority-cross-refs.py
@@ -42,6 +42,10 @@ from pathlib import Path
 
 from lxml import etree
 
+# Gemeinsame Korpusauswahl (#287).
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from corpus_files import TEI_DIR, corpus_files  # noqa: E402
+
 XML_NS = '{http://www.w3.org/XML/1998/namespace}'
 
 # Reference-bearing attributes to scan, in priority order.
@@ -49,7 +53,6 @@ REF_ATTRS = ('lemmaRef', 'ana', 'corresp', 'ref', 'target')
 
 # Authority files live here; we resolve fragments against their xml:id sets.
 AUTHORITY_DIR = Path('authority-files')
-TEI_DIR = Path('tei')
 SCRIPT_DIR = Path(__file__).resolve().parent
 JSON_OUT = SCRIPT_DIR / 'authority-cross-refs-audit.json'
 
@@ -151,7 +154,7 @@ def main():
     print('Building authority id-sets...')
     auth_ids = build_authority_ids()
 
-    base_files = sorted(f for f in TEI_DIR.glob('*.tei.xml') if '.disamb.' not in f.name)
+    base_files = corpus_files()
     print(f'\nScanning {len(base_files)} base corpus files...')
 
     total_scanned = 0

--- a/scripts/audit/classify-lexicon-backfill.py
+++ b/scripts/audit/classify-lexicon-backfill.py
@@ -48,9 +48,11 @@ try:
 except ImportError:
     sys.exit("ERROR: lxml not installed — run: pip install lxml")
 
-# Reuse the canonical MHG normalizer (parity with text-normalizer.js).
+# Reuse the canonical MHG normalizer (parity with text-normalizer.js)
+# und die gemeinsame Korpusauswahl (#287).
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from mhg_normalizer import normalize_mhg
+from corpus_files import PROJECT_ROOT, TEI_DIR, corpus_files
 
 if hasattr(sys.stdout, 'reconfigure'):
     sys.stdout.reconfigure(encoding='utf-8', errors='replace')
@@ -58,9 +60,7 @@ if hasattr(sys.stdout, 'reconfigure'):
 XML_NS = '{http://www.w3.org/XML/1998/namespace}'
 TEI_NS = '{http://www.tei-c.org/ns/1.0}'
 
-PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 LEXICON = PROJECT_ROOT / 'authority-files' / 'lexicon.xml'
-TEI_DIR = PROJECT_ROOT / 'tei'
 SCRIPT_DIR = Path(__file__).resolve().parent
 JSON_OUT = SCRIPT_DIR / 'lexicon-backfill.json'
 MD_OUT = SCRIPT_DIR / 'lexicon-backfill-curatorial.md'
@@ -155,8 +155,7 @@ def scan_corpus(lemma_ids, sense_ids):
       dangling_senses (Counter of sense_id -> ref count, only unresolved),
       resolved_sense_refs (int, refs whose sense DID resolve — context only).
     """
-    base_files = sorted(f for f in TEI_DIR.glob('*.tei.xml')
-                        if '.disamb.' not in f.name)
+    base_files = corpus_files()
     records = defaultdict(lambda: {
         'forms': Counter(), 'pos': Counter(), 'sigles': set(),
         'examples': [], 'lemma_ref_count': 0,

--- a/scripts/audit/count-verse-numbering-resets.py
+++ b/scripts/audit/count-verse-numbering-resets.py
@@ -36,15 +36,17 @@ Usage:
     python scripts/audit/count-verse-numbering-resets.py --text PZ # ein Text im Detail
 """
 import argparse
-import glob
 import re
+import sys
 from collections import Counter
 from pathlib import Path
 
 from lxml import etree
 
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
-TEI_DIR = PROJECT_ROOT / 'tei'
+# Gemeinsame Korpusauswahl (#287).
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from corpus_files import corpus_files  # noqa: E402
+
 TEI_NS = 'http://www.tei-c.org/ns/1.0'
 
 NUMERIC = re.compile(r'^\d+$')
@@ -154,15 +156,15 @@ def main():
     ap.add_argument('--text', help='nur diese Sigle, mit Detailausgabe')
     args = ap.parse_args()
 
-    files = sorted(glob.glob(str(TEI_DIR / '*.tei.xml')))
+    files = corpus_files()
     if args.text:
-        files = [f for f in files if Path(f).name.startswith(args.text + '.')]
+        files = [f for f in files if f.name.startswith(args.text + '.')]
         if not files:
             raise SystemExit(f'Keine TEI-Datei fuer Sigle {args.text}')
 
     results = []
     for f in files:
-        r = analyse(Path(f))
+        r = analyse(f)
         if r:
             results.append(r)
 

--- a/scripts/audit/doc-count-audit.py
+++ b/scripts/audit/doc-count-audit.py
@@ -24,9 +24,11 @@ import sys
 from pathlib import Path
 from lxml import etree
 
-# scripts/ auf den Pfad, damit der Parity-Normalizer importierbar ist
+# scripts/ auf den Pfad, damit der Parity-Normalizer und die gemeinsame
+# Korpusauswahl (#287) importierbar sind
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from mhg_normalizer import normalize_mhg
+from corpus_files import corpus_files
 
 if sys.stdout.encoding and sys.stdout.encoding.lower() not in ('utf-8', 'utf8'):
     sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8', line_buffering=True)
@@ -57,7 +59,7 @@ def count_variants_normalized(path: str) -> int:
 
 def collect_counts() -> dict:
     counts = {}
-    counts['corpus_files'] = len(glob.glob('tei/*.tei.xml'))
+    counts['corpus_files'] = len(corpus_files())
     counts['authority_files'] = len(glob.glob('authority-files/*.xml'))
     counts['lexicon_entries'] = count_xml_elements('authority-files/lexicon.xml', '//tei:entry[@xml:id]')
     counts['variants_entries'] = count_xml_elements('authority-files/variants.xml', '//tei:entry[@corresp]')

--- a/scripts/audit/drop-negative-variant-corresp.py
+++ b/scripts/audit/drop-negative-variant-corresp.py
@@ -31,7 +31,9 @@ import sys
 from collections import Counter
 from pathlib import Path
 
-TEI_DIR = Path('tei')
+# Gemeinsame Korpusauswahl (#287).
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from corpus_files import TEI_DIR, corpus_files  # noqa: E402
 
 # ' corresp="variants.xml#type_-<digits>"' — leading space + whole-value match.
 PATTERN = re.compile(rb' corresp="variants\.xml#type_-\d+"')
@@ -45,7 +47,7 @@ def main():
         print('Error: run from repo root (tei/ required)')
         return 1
 
-    files = sorted(f for f in TEI_DIR.glob('*.tei.xml') if '.disamb.' not in f.name)
+    files = corpus_files()
     total = 0
     touched = []
     skipped_multi = Counter()

--- a/scripts/audit/drop-negative-variant-corresp.py
+++ b/scripts/audit/drop-negative-variant-corresp.py
@@ -43,8 +43,10 @@ MULTI_GUARD = re.compile(rb'corresp="[^"]*variants\.xml#type_-\d+[^"]*"')
 
 def main():
     apply = '--apply' in sys.argv
+    # Kein "run from repo root"-Guard mehr (#287): TEI_DIR haengt jetzt am
+    # PROJECT_ROOT, das Skript ist damit CWD-unabhaengig.
     if not TEI_DIR.exists():
-        print('Error: run from repo root (tei/ required)')
+        print(f'Error: {TEI_DIR} not found')
         return 1
 
     files = corpus_files()

--- a/scripts/audit/quantify-unannotated-tokens.py
+++ b/scripts/audit/quantify-unannotated-tokens.py
@@ -28,9 +28,9 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 PROJECT_ROOT = SCRIPT_DIR.parent.parent
 sys.path.insert(0, str(PROJECT_ROOT / 'scripts'))
 from mhg_normalizer import normalize_mhg  # noqa: E402
+from corpus_files import corpus_files  # noqa: E402
 
 TEI = '{http://www.tei-c.org/ns/1.0}'
-TEI_DIR = PROJECT_ROOT / 'tei'
 
 
 def main() -> int:
@@ -45,7 +45,7 @@ def main() -> int:
     unannot_examples = {}              # normalized form -> ein Original-Beispiel
     annotated_forms = set()            # normalisierte Formen MIT lemmaRef
 
-    files = sorted(TEI_DIR.glob('*.tei.xml'))
+    files = corpus_files()
     for i, fp in enumerate(files):
         if (i + 1) % 100 == 0:
             print(f'  {i + 1}/{len(files)}...', flush=True)

--- a/scripts/audit/validate-corpus.py
+++ b/scripts/audit/validate-corpus.py
@@ -148,6 +148,11 @@ def main():
                 print(f'  MISSING: {s}')
     else:
         if not args.authority_only:
+            # Bewusst NICHT corpus_files() aus scripts/corpus_files.py (#287):
+            # dieses Skript fragt nicht "was ist der Korpus", sondern "ist jede
+            # XML-Datei in diesen beiden Verzeichnissen schema-valide". Ein
+            # versehentlich in tei/ liegender .disamb.-Zwischenstand soll hier
+            # geprueft und nicht stillschweigend uebersprungen werden.
             for f in sorted(glob.glob('tei/*.tei.xml')):
                 files.append((Path(f), mhdbdb, 'mhdbdb'))
         if not args.corpus_only:

--- a/scripts/build-corpus-index.py
+++ b/scripts/build-corpus-index.py
@@ -51,7 +51,6 @@ import json
 import gzip
 import subprocess
 import sys
-import os
 import time
 from pathlib import Path
 from collections import defaultdict
@@ -68,33 +67,16 @@ except ImportError:
 sys.path.insert(0, str(Path(__file__).parent))
 from mhg_normalizer import normalize_mhg
 from tei_namespaces import get_namespaces
+# PROJECT_ROOT/TEI_DIR kommen mit, damit TEI_DIR.relative_to(PROJECT_ROOT) in
+# check_working_tree() nicht davon abhaengt, ob beide gleich aufgeloest sind.
+from corpus_files import PROJECT_ROOT, TEI_DIR, corpus_files, default_jobs
 
 # Paths
-PROJECT_ROOT = Path(__file__).parent.parent
-TEI_DIR = PROJECT_ROOT / 'tei'
 DATA_DIR = PROJECT_ROOT / 'data'
 OUTPUT_FILE = DATA_DIR / 'corpus-index.json.gz'
 
 # TEI namespace
 TEI_NS = {'tei': 'http://www.tei-c.org/ns/1.0'}
-
-# Worker-Obergrenze (#284). Nicht cpu_count(): jeder Worker haelt einen
-# kompletten lxml-Baum im Speicher, und der Elternprozess muss jedes Ergebnis
-# entpicken und behalten (der fertige Index sind rund 200 MB JSON).
-#
-# Gemessen am 2026-07-31, 667 Dateien, 16 Kerne, Hash jedes Mal identisch:
-#   jobs= 1  183,5 s     jobs= 4   56,1 s     jobs=12   39,9 s
-#   jobs= 2   97,9 s     jobs= 8   45,8 s     jobs=16   42,4 s
-# Ab 8 ist die Kurve flach, ab 12 kippt sie (Ueberbuchung). Der Rest sind
-# rund 16 s Serialisieren und Gzippen, die niemand parallelisiert.
-#
-# Speicher-Peak ueber alle Python-Prozesse, gleiche Messung:
-#   jobs=1  1.344 MB       jobs=8  3.893 MB
-# Also rund 320 MB je zusaetzlichem Worker, linear. Bei 16 waeren es ueber
-# 6 GB fuer 6 gesparte Sekunden. Deshalb 8: der Grossteil des Gewinns zum
-# halben Aufschlag. Wer mehr Kerne als Sorgen hat, nimmt --jobs. Auf
-# kleineren Maschinen greift min(cap, cpu_count).
-DEFAULT_JOBS_CAP = 8
 
 
 def extract_metadata(filepath):
@@ -310,11 +292,9 @@ def build_corpus_index(jobs=1):
     print("\n🔨 Building corpus index...")
     print(f"TEI directory: {TEI_DIR}")
 
-    # Get all TEI files
-    # glob-Reihenfolge ist OS-abhängig — sortiert für deterministische Index-Bytes, #125.
-    # key=p.name: Path-Objekte vergleichen auf Windows casefolded, auf Linux byte-weise —
-    # erst der String-Key macht die Ordnung plattformgleich (Review #146).
-    tei_files = sorted(TEI_DIR.glob('*.tei.xml'), key=lambda p: p.name)
+    # Auswahl und Sortierung liegen in scripts/corpus_files.py (#287), damit
+    # extract-variants.py und die audit/-Skripte dieselbe Liste sehen.
+    tei_files = corpus_files()
     total_files = len(tei_files)
 
     print(f"Found {total_files} TEI files")
@@ -447,7 +427,7 @@ def main():
         help="Build even if tei/ has untracked or modified files (use for local tests)."
     )
     parser.add_argument(
-        '--jobs', type=int, default=min(DEFAULT_JOBS_CAP, os.cpu_count() or 1),
+        '--jobs', type=int, default=default_jobs(),
         help="Worker-Prozesse fuer das Parsen (1 = sequentiell). Das Ergebnis ist "
              "von diesem Wert unabhaengig und byte-identisch (#284)."
     )

--- a/scripts/corpus_files.py
+++ b/scripts/corpus_files.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Shared corpus file selection for everything that reads tei/ (#287).
+
+Beantwortet an einer Stelle die Frage "welche Dateien sind der Korpus, und in
+welcher Reihenfolge". Vorher beantworteten build-corpus-index.py und
+sync/extract-variants.py sie unterschiedlich (alle *.tei.xml gegen alle ausser
+*.disamb.*), womit ein versehentlich in tei/ liegender Disambiguierungs-
+Zwischenstand im Korpus-Index gelandet waere, aber nicht in variants.xml.
+
+Enthaelt ausserdem die Worker-Obergrenze fuer das parallele Parsen: auch das
+ist eine Frage der Art "wie liest man den Korpus", und sie stand seit #284
+doppelt (Nachtrag zu #287 aus PR #288).
+
+Import-Muster wie tei_namespaces und mhg_normalizer: scripts/ liegt auf
+sys.path, wenn die Konsumenten laufen.
+"""
+
+import os
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+TEI_DIR = PROJECT_ROOT / 'tei'
+
+# Disambiguierungs-Zwischenstaende (SIG.disamb.tei.xml) sind keine Korpustexte.
+# Sie tragen dieselbe idno[@type="sigle"] wie ihre Basisdatei, wuerden also
+# jeden nach Sigle geschluesselten Konsumenten doppelt beliefern, ohne dass es
+# auffaellt: das Freshness-Gate prueft nur, ob das committete Artefakt zum
+# Quellstand passt, und das taete es dann ja. Ihr Platz ist ingest/; in tei/
+# liegen sie hoechstens versehentlich (Stand 2026-07-31: keine).
+DISAMB_MARKER = '.disamb.'
+
+
+def corpus_files(tei_dir=None):
+    """Die Korpusdateien als sortierte Liste von Path-Objekten.
+
+    Die Reihenfolge ist Teil der Determinismus-Zusicherung aus #125: identischer
+    Quellstand muss byte-identische Artefakte erzeugen, und in corpus-index.json
+    ist die Schluesselreihenfolge von lemmaIndex die Reihenfolge des
+    Erstauftretens ueber genau diese Liste.
+
+    Deshalb zwei Dinge explizit:
+    - sortiert, denn die glob-Reihenfolge ist OS-abhaengig;
+    - key=p.name statt der Path-Objekte selbst, denn Path vergleicht auf Windows
+      casefolded und auf Linux byte-weise. Erst der String-Key macht die Ordnung
+      plattformgleich (Review #146).
+    """
+    base = TEI_DIR if tei_dir is None else Path(tei_dir)
+    return sorted((f for f in base.glob('*.tei.xml') if DISAMB_MARKER not in f.name),
+                  key=lambda p: p.name)
+
+
+# Worker-Obergrenze (#284). Nicht cpu_count(): jeder Worker haelt einen
+# kompletten lxml-Baum im Speicher, und der Elternprozess muss jedes Ergebnis
+# entpicken und behalten (der fertige Korpus-Index sind rund 200 MB JSON).
+#
+# Gemessen am 2026-07-31 mit build-corpus-index.py, 667 Dateien, 16 Kerne,
+# Hash jedes Mal identisch:
+#   jobs= 1  183,5 s     jobs= 4   56,1 s     jobs=12   39,9 s
+#   jobs= 2   97,9 s     jobs= 8   45,8 s     jobs=16   42,4 s
+# Ab 8 ist die Kurve flach, ab 12 kippt sie (Ueberbuchung). Der Rest sind
+# rund 16 s Serialisieren und Gzippen, die niemand parallelisiert.
+#
+# Speicher-Peak ueber alle Python-Prozesse, gleiche Messung:
+#   jobs=1  1.344 MB       jobs=8  3.893 MB
+# Also rund 320 MB je zusaetzlichem Worker, linear. Bei 16 waeren es ueber
+# 6 GB fuer 6 gesparte Sekunden. Deshalb 8: der Grossteil des Gewinns zum
+# halben Aufschlag. Wer mehr Kerne als Sorgen hat, nimmt --jobs.
+DEFAULT_JOBS_CAP = 8
+
+
+def default_jobs():
+    """Vorgabe fuer --jobs: die Obergrenze, auf kleinen Maschinen die Kernzahl."""
+    return min(DEFAULT_JOBS_CAP, os.cpu_count() or 1)

--- a/scripts/sync/extract-variants.py
+++ b/scripts/sync/extract-variants.py
@@ -29,7 +29,6 @@ Usage:
 """
 
 import concurrent.futures
-import os
 import re
 import sys
 from collections import Counter, defaultdict
@@ -38,22 +37,21 @@ from pathlib import Path
 
 from lxml import etree
 
+# Korpusauswahl, -reihenfolge und Worker-Obergrenze teilen sich alle
+# Korpus-Leser (#287). scripts/ auf den Pfad, wie in classify-lexicon-backfill.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from corpus_files import corpus_files, default_jobs  # noqa: E402
+
 TEI_NS = 'http://www.tei-c.org/ns/1.0'
 TEI = f'{{{TEI_NS}}}'
 XML = '{http://www.w3.org/XML/1998/namespace}'
 
-TEI_DIR = Path('tei')
 VARIANTS = Path('authority-files/variants.xml')
 DRY_OUT = Path('authority-files/variants.regen.xml')
 
 TYPE_POS_RE = re.compile(r'^type_\d+$')        # positive type id only
 TYPE_NUM_RE = re.compile(r'^type_(\d+)$')
 LEMMA_NUM_RE = re.compile(r'^lemma_(\d+)$')
-
-# Worker-Obergrenze (#284): jeder Worker haelt einen lxml-Baum im Speicher,
-# und der Elternprozess summiert alle Teilergebnisse allein. Siehe die
-# gleichlautende Konstante in scripts/build-corpus-index.py.
-DEFAULT_JOBS_CAP = 8
 
 PI_MODEL = [
     ('xml-model', 'href="../schema/mhdbdb-authority.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"'),
@@ -248,7 +246,7 @@ def read_existing():
 
 
 def parse_jobs(argv):
-    """--jobs N aus argv lesen. Default: bis DEFAULT_JOBS_CAP Prozesse.
+    """--jobs N aus argv lesen. Default: bis corpus_files.DEFAULT_JOBS_CAP Prozesse.
 
     Bewusst kein argparse: das Skript liest seine Flags seit jeher direkt aus
     sys.argv, und ein halber Umstieg waere die schlechtere Variante.
@@ -264,7 +262,7 @@ def parse_jobs(argv):
             sys.exit('--jobs braucht eine Zahl')
         raw = argv[i + 1]
     else:
-        return min(DEFAULT_JOBS_CAP, os.cpu_count() or 1)
+        return default_jobs()
     try:
         jobs = int(raw)
     except ValueError:
@@ -277,7 +275,7 @@ def parse_jobs(argv):
 def main():
     apply = '--apply' in sys.argv
     jobs = parse_jobs(sys.argv)
-    base_files = sorted(f for f in TEI_DIR.glob('*.tei.xml') if '.disamb.' not in f.name)
+    base_files = corpus_files()
     print(f'Scanning {len(base_files)} corpus files for <w @lemmaRef @corresp>... ({jobs} Prozesse)')
     type_form, type_lemma = collect(base_files, jobs=jobs)
     lemma_to_types, type_to_form, type_to_lemma, multi_form, multi_lemma = resolve(type_form, type_lemma)

--- a/scripts/sync/extract-variants.py
+++ b/scripts/sync/extract-variants.py
@@ -40,14 +40,20 @@ from lxml import etree
 # Korpusauswahl, -reihenfolge und Worker-Obergrenze teilen sich alle
 # Korpus-Leser (#287). scripts/ auf den Pfad, wie in classify-lexicon-backfill.
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-from corpus_files import corpus_files, default_jobs  # noqa: E402
+from corpus_files import PROJECT_ROOT, corpus_files, default_jobs  # noqa: E402
 
 TEI_NS = 'http://www.tei-c.org/ns/1.0'
 TEI = f'{{{TEI_NS}}}'
 XML = '{http://www.w3.org/XML/1998/namespace}'
 
-VARIANTS = Path('authority-files/variants.xml')
-DRY_OUT = Path('authority-files/variants.regen.xml')
+# Ein- und Ausgabe an derselben Wurzel (#287). Vorher war die Eingabe
+# CWD-relativ und ein Lauf aus dem falschen Verzeichnis scheiterte sichtbar
+# (0 Dateien gefunden). Jetzt findet die Eingabe den Korpus immer, also muss
+# auch die Ausgabe dorthin zeigen: sonst laese read_existing() stillschweigend
+# keine Bestandsdatei (der Diff faellt auf "alles neu") und der Schreibvorgang
+# landete woanders.
+VARIANTS = PROJECT_ROOT / 'authority-files' / 'variants.xml'
+DRY_OUT = PROJECT_ROOT / 'authority-files' / 'variants.regen.xml'
 
 TYPE_POS_RE = re.compile(r'^type_\d+$')        # positive type id only
 TYPE_NUM_RE = re.compile(r'^type_(\d+)$')

--- a/scripts/sync/sync_tei_headers.py
+++ b/scripts/sync/sync_tei_headers.py
@@ -42,6 +42,10 @@ from lxml import etree
 from typing import Dict, List, Set
 from abc import ABC, abstractmethod
 
+# Gemeinsame Korpusauswahl (#287).
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from corpus_files import TEI_DIR, corpus_files  # noqa: E402
+
 # Set up logging
 logging.basicConfig(
     level=logging.INFO,
@@ -51,7 +55,6 @@ logger = logging.getLogger(__name__)
 
 # File paths
 AUTHORITY_DIR = Path("authority-files")
-TEI_DIR = Path("tei")
 
 # TEI namespace
 TEI_NS = {"tei": "http://www.tei-c.org/ns/1.0"}
@@ -90,7 +93,7 @@ class AuthoritySyncer(ABC):
         logger.info(f"Loaded data for {len(authority_data)} sigles from {self.authority_file.name}")
         
         # Process TEI files
-        tei_files = sorted(self.tei_dir.glob("*.tei.xml"))
+        tei_files = corpus_files(self.tei_dir)
         logger.info(f"Processing {len(tei_files)} TEI files for {self.name}...")
         
         updated_count = 0


### PR DESCRIPTION
Behebt #287 (bewusst ohne `Closes`, das Issue schliesst ihr).

## Befund

`scripts/build-corpus-index.py` und `scripts/sync/extract-variants.py` bestimmten ihre Dateiliste aus `tei/` unterschiedlich: nur extract-variants schloss `*.disamb.tei.xml` aus. Eine solche Datei in `tei/` waere im Korpus-Index gelandet, aber nicht in `variants.xml`, und zwar unbemerkt: das Freshness-Gate prueft nur, ob das committete Artefakt zum Quellstand passt, und das taete es dann ja.

## Bestandsaufnahme vor der Entscheidung

13 Stellen im Repo iterieren ueber `tei/`. Vier Merkmale gingen auseinander:

| | `.disamb.` ausgeschlossen | Sortierschluessel | Wurzel |
|---|---|---|---|
| `build-corpus-index.py` | nein | `key=p.name` | PROJECT_ROOT |
| `sync/extract-variants.py` | ja | Path-Objekte | CWD |
| `sync/sync_tei_headers.py` | nein | Path-Objekte | CWD |
| `audit/audit-tei-corpus.py` | ja | Path-Objekte | Argument |
| `audit/check-authority-cross-refs.py` | ja | Path-Objekte | CWD |
| `audit/classify-lexicon-backfill.py` | ja | Path-Objekte | PROJECT_ROOT |
| `audit/drop-negative-variant-corresp.py` | ja | Path-Objekte | CWD |
| `audit/quantify-unannotated-tokens.py` | nein | Path-Objekte | PROJECT_ROOT |
| `audit/count-verse-numbering-resets.py` | nein | glob-Strings | PROJECT_ROOT |
| `audit/doc-count-audit.py` | nein | nur `len()` | CWD |
| `audit/validate-corpus.py` | nein | glob-Strings | CWD |
| `audit/count-editorial-notes-and-div-heads.py` | nein | glob-Strings | `--corpus` |
| `ingest/legacy-sources/03-build-sources.py` | nein | Set von Siglen | Argument |

## Entscheidung: der Ausschluss ist die richtige Auswahl

Also die strengere der beiden, und der Filter kommt zu `build-corpus-index.py` dazu statt aus `extract-variants.py` heraus. Begruendung:

1. `SIG.disamb.tei.xml` traegt dieselbe `idno[@type="sigle"]` wie seine Basisdatei. Jeder nach Sigle geschluesselte Konsument bekaeme den Text doppelt, der Korpus-Index zwei Eintraege unter derselben id.
2. Der Platz dieser Zwischenstaende ist `ingest/`; in `tei/` liegen sie hoechstens versehentlich. Genau dann soll die Ableitungsschicht sie ignorieren, nicht verdoppeln.
3. Die Gegenrichtung waere semantisch falsch: sie wuerde die Falle vergroessern statt sie zu schliessen.
4. Die Mehrheit der absichtlich korpus-lesenden Skripte (5 von 8, darunter die beiden `#115`-Skripte und der CI-Gate `check-authority-cross-refs.py`) filterte ohnehin schon; `audit-tei-corpus.py` hat den Begriff "base TEI files" bereits im Docstring.

## Aenderungen

Neu: `scripts/corpus_files.py` mit `corpus_files()` als einziger Antwort auf "welche Dateien sind der Korpus, in welcher Reihenfolge", dazu `TEI_DIR`, `PROJECT_ROOT`, `DISAMB_MARKER`, und `DEFAULT_JOBS_CAP` / `default_jobs()`, die seit #284 doppelt standen (Nachtrag aus PR #288). Import-Muster wie `tei_namespaces.py` und `mhg_normalizer.py`.

Umgestellt: `build-corpus-index.py`, `sync/extract-variants.py`, `sync/sync_tei_headers.py`, `audit/audit-tei-corpus.py`, `audit/check-authority-cross-refs.py`, `audit/classify-lexicon-backfill.py`, `audit/count-verse-numbering-resets.py`, `audit/doc-count-audit.py`, `audit/drop-negative-variant-corresp.py`, `audit/quantify-unannotated-tokens.py`.

Bewusst nicht umgestellt, mit Begruendung im Code: `audit/validate-corpus.py`. Es fragt nicht "was ist der Korpus", sondern "ist jede XML-Datei in diesen beiden Verzeichnissen schema-valide". Ein versehentlich in `tei/` liegender `.disamb.`-Zwischenstand soll dort geprueft und nicht stillschweigend uebersprungen werden. Ebenfalls aussen vor: `audit/count-editorial-notes-and-div-heads.py` (nimmt ein beliebiges `--corpus`-Verzeichnis) und `ingest/**` (Einmal-Skripte; `03-build-sources.py` baut ein Sigle-Set, in dem eine disamb-Datei auf die Basissigle kollabiert).

## Verhaltensaenderungen, ausdruecklich deklariert

Alle drei sind fuer den heutigen Bestand wirkungslos, aber sie sind da:

1. **`.disamb.`-Filter neu** in `build-corpus-index.py`, `sync_tei_headers.py`, `count-verse-numbering-resets.py`, `doc-count-audit.py`, `quantify-unannotated-tokens.py`. In `tei/` liegen aktuell 0 solche Dateien, also 0 Treffer.
2. **Sortierung `Path`-Objekt auf `key=p.name`** in sieben Skripten. `Path` vergleicht auf Windows casefolded, auf Linux byte-weise. Fuer die heutigen 667 Namen ist die Ordnung identisch (alle `[A-Z0-9]+.tei.xml`, keine Unterstriche, keine Kleinbuchstaben); geprueft, byte-weise sortiert gleich casefolded sortiert. Damit ist die letzte plattformabhaengige Sortierstelle im Sinne von #146 geschlossen: ein kuenftiges `ARI_MUE279.tei.xml` neben einem `ARIS*.tei.xml` haette den alten Path-Sort auseinanderlaufen lassen.
3. **Eingabe-Wurzel CWD auf PROJECT_ROOT** in fuenf Skripten. Bei `extract-variants.py` sind darum auch `VARIANTS` und `DRY_OUT` mitgewandert (zweiter Commit, aus der Zweitmeinung): sonst haette ein Lauf aus dem falschen Verzeichnis erstmals den vollen Korpus gelesen, in `read_existing()` stillschweigend keine Bestandsdatei gefunden und woanders geschrieben. Vorher scheiterte er sichtbar an 0 gefundenen Dateien.

## Determinismus, per Hash belegt

Die Anforderung aus #125 ist byte-identischer Rebuild bei identischem Quellstand, und die sortierte Dateiliste ist Teil davon (in `corpus-index.json` ist die Schluesselreihenfolge von `lemmaIndex` die Reihenfolge des Erstauftretens ueber genau diese Liste).

Vorher-Nachher-Vergleich mit dem Code dieses PRs, `python scripts/build-corpus-index.py` und `python scripts/sync/extract-variants.py --apply`:

```
data/corpus-index.json.gz     34eaf88592e4bd01b3a2874bcedd5bdef4960807c5c53f25534a76e49a593d50   vorher == nachher
authority-files/variants.xml  39caca2e8dcea67c9f70356aba2d11dfe729baddac5352a1a682914d374eeb6d   vorher == nachher
```

`git status` fuer `data/` und `authority-files/` blieb nach beiden Laeufen leer. Zusaetzlich direkt auf den Listen geprueft: `corpus_files()` liefert dieselben 667 Namen in derselben Reihenfolge wie beide alten Implementierungen (`ABG.tei.xml` bis `ZWR.tei.xml`).

**Die neu gebauten Artefakte sind nicht Teil dieses PRs.** Sie waren Beweismittel; der Diff beruehrt ausschliesslich `scripts/`.

## Weitere Pruefungen

- `python scripts/audit/check-no-em-dash.py` gruen, Selbsttest 42/42.
- Alle zwoelf beruehrten Skripte kompilieren; `audit-tei-corpus.py`, `classify-lexicon-backfill.py`, `quantify-unannotated-tokens.py`, `check-authority-cross-refs.py` zusaetzlich importgeprueft.
- Smoke-Laeufe: `build-corpus-index.py --help`, `sync_tei_headers.py --help`, `count-verse-numbering-resets.py --text PZ`, `drop-negative-variant-corresp.py` (dry-run, 0 Treffer wie erwartet), `doc-count-audit.py --check` (exit 0, kein Drift, Korpus-Dateien weiterhin 667).
- Keine Tests und kein Fixture-Korpus angelegt: haengt an #172 und ist hier ausdruecklich nicht in Scope.

## Zweitmeinung

Fable hat den Diff skript-fuer-skript gegen die Frage geprueft, ob die Vereinheitlichung irgendwo Auswahl oder Reihenfolge veraendert. Ergebnis: fortfahren, fuer den heutigen Bestand ueberall auswahl- und reihenfolgenneutral. Zwei konkrete Anpassungen kamen von dort und sind eingearbeitet (Wurzel-Verankerung der extract-variants-Ausgabe, toter `run from repo root`-Guard in `drop-negative-variant-corresp.py`). Die Deklarationsliste oben geht ebenfalls auf diese Durchsicht zurueck.

Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzWk9ShinfAHZoUMkwCX4M
