### PR TITLE
JOURNAL: fehlenden Trenner nachtragen

### DIFF
--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -645,6 +645,8 @@ Last gemessen und unkritisch: fünf parallele Requests kosten 31 bis 81 ms kalt,
 
 **Phase:** Betrieb, reine Doku, kein Rebuild. PR #296.
 
+---
+
 ## 2026-07-31 – Die gefährlichsten Doku-Sätze sind die über Abwesenheit
 
 **Summary:** `docs/CONTRACTS.md` hat mit §H Zählregeln für die Analyse-Werkzeuge bekommen, die zitierfähige Zahlen ausgeben (#281, PR #304). Der Abschnitt ging durch fünf Review-Runden, und in jeder einzelnen wurde ein Fehler im Text gefunden. Bemerkenswert ist nicht, dass es Fehler gab, sondern dass sie fast alle denselben Typ hatten: **Aussagen darüber, dass etwas nicht existiert.**


### PR DESCRIPTION
Nachtrag zu #310. Zwischen dem Ende des Vorgänger-Eintrags und dem ersten neuen Header fehlte das `---`, das alle anderen Einträge trennt; die drei neuen untereinander hatten es bereits.

Gegenprobe: jeder `## 2026-07-3…`-Header hat jetzt einen Trenner davor.

Gefunden in der Zweitmeinung, die erst nach dem Merge von #310 zurückkam.