### PR TITLE
#327/#325/#329: drei Aufräumbefunde, eine Fehlerklasse

### DIFF
--- a/.github/workflows/no-cdn-check.yml
+++ b/.github/workflows/no-cdn-check.yml
@@ -6,10 +6,24 @@
 # Lokales Gegenstück (inkl. Laufzeit-Check window.pako/Dexie):
 # testing/tests/vendor.spec.js
 #
-# Seit 28.07. laeuft hier ein zweites Gate: user-sichtbare Strings duerfen
+# Seit 28.07. läuft hier ein zweites Gate: user-sichtbare Strings dürfen
 # keine Em-Dashes tragen (#140). KZW meldet sie wiederholt aus dem Betrieb,
 # zuletzt im Hapax-Werkzeug. Kommentare bleiben ausgenommen. Der Workflow-
 # Name bleibt no-cdn-check, damit vorhandene Check-Referenzen halten.
+#
+# Seit 01.08. ein drittes: jede Spec in testing/tests/ steht in der Inventar-
+# Tabelle in docs/DEVELOPMENT.md (#329, dort fehlten zehn von dreißig). Auch
+# das ist ein reiner stdlib-Check ohne Rebuild und gehört deshalb hierher.
+# data-integrity.yml wäre der falsche Ort, aber nicht wegen seiner Trigger
+# (es horcht ohnehin auf scripts/audit/**, siehe unten), sondern wegen seiner
+# Kosten: dort hinge das Gate hinter Index-Rebuild und RelaxNG über 667
+# Dateien, und es liefe bei jedem tei/-Commit mit, während eine Änderung an
+# testing/tests/ es gar nicht auslöste.
+#
+# Nebenwirkung, bewusst in Kauf genommen: weil data-integrity.yml auf
+# 'scripts/audit/**' horcht, startet eine Änderung an check-test-inventory.py
+# selbst auch dort einen Lauf, ohne dass das Skript darin ausgeführt wird.
+# check-no-cdn.py und check-no-em-dash.py haben dieselbe Eigenschaft seit je.
 
 name: no-cdn-check
 
@@ -23,6 +37,9 @@ on:
       - 'assets/css/**'
       - 'scripts/audit/check-no-cdn.py'
       - 'scripts/audit/check-no-em-dash.py'
+      - 'testing/tests/**'
+      - 'docs/DEVELOPMENT.md'
+      - 'scripts/audit/check-test-inventory.py'
       - '.github/workflows/no-cdn-check.yml'
   push:
     branches:
@@ -35,6 +52,9 @@ on:
       - 'assets/css/**'
       - 'scripts/audit/check-no-cdn.py'
       - 'scripts/audit/check-no-em-dash.py'
+      - 'testing/tests/**'
+      - 'docs/DEVELOPMENT.md'
+      - 'scripts/audit/check-test-inventory.py'
       - '.github/workflows/no-cdn-check.yml'
   workflow_dispatch:
 
@@ -58,3 +78,9 @@ jobs:
 
       - name: Keine Em-Dashes in user-sichtbarem Text (#140)
         run: python3 scripts/audit/check-no-em-dash.py
+
+      - name: Spec-Inventar-Gate Selbsttest (#329)
+        run: python3 scripts/audit/check-test-inventory.py --selftest
+
+      - name: Jede Spec steht im Test File Inventory (#329)
+        run: python3 scripts/audit/check-test-inventory.py

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -227,7 +227,11 @@ function lemmaRefMatchesId(lemmaRef, lemmaId):
 | `lexicon.xml#lemma_308 lexicon.xml#lemma_5` | `lemma_5` | yes |
 | `lexicon.xml#lemma_30800` | `lemma_308` | **no** |
 
-**Applies to all highlight/match paths**, all routed through the single `lemmaRefMatchesId` since #130 (was 6 inline copies across 4 files, the duplication that made #126 possible): `tei-text-reader.js` (single + multi-lemma) and the playground (`tei-manager.js` proximity + enrichment, `ui-helpers.js` context highlight). (`text-renderer.js` was a fourth call site until its dead render path, then the whole shim, were removed: audit #42 plus Carearbeit 2026-07.) Validated on real corpus data: PL1 689 → 57, OVG 369 → 26 (matches the result-card count).
+**Applies to all highlight/match paths**, all routed through the single `lemmaRefMatchesId` since #130 (was 6 inline copies across 4 files, the duplication that made #126 possible). Call sites today, measured 2026-08-01: `tei-text-reader.js:770/:784` (single + multi-lemma), `kwic-service.js:93` (KWIC lines) and `ui-helpers.js:444` in the playground (context highlight).
+
+Two former call sites are gone, and both are worth naming because the rule is easy to think of as universal: `text-renderer.js` lost its dead render path and then the whole shim (audit #42 plus Carearbeit 2026-07), and `tei-manager.js` stopped calling it with #314. The latter is not a gap: the proximity search reads `words[]` from the corpus index, and that array holds exactly one lemma ID per position (`build-corpus-index.py`: `words.append(lemma_ids[0])`, #170). There is no whitespace-separated list to tokenize, so a normalized `===` is the same predicate there. The unused import stayed behind until #325.
+
+Validated on real corpus data: PL1 689 → 57, OVG 369 → 26 (matches the result-card count).
 
 ### Test Coverage
 

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -460,16 +460,22 @@ Source: `playground/js/data/tei-manager.js` (document search function)
 
 ```
 function searchDocumentLevel(lemmaIds, corpusData):
+    // corpusData is window.playground.corpusData, filled by the playground's
+    // own file browser. Not the main site's identically named selection.
     results = []
     includedTexts = corpusData.includedTexts or empty set
 
     for each text in corpusData.texts:
-        // Honours the main-site checkbox selection, unlike the analysis tools
+        // Honours the playground's text selection, unlike the analysis tools
         // in section H (see the scope note there)
         if text.id not in includedTexts: continue
 
-        // Require ALL lemmata present (intersection, not union)
-        containsAll = lemmaIds.every(id => text.lemmata[id] exists)
+        // Require ALL lemmata present (intersection, not union). Each id is
+        // normalized and then tried under both spellings, because the caller
+        // hands over bare ids while the index keys carry the prefix.
+        containsAll = lemmaIds.every(id =>
+            cleanId = id without leading "lemma_"
+            text.lemmata["lemma_" + cleanId] or text.lemmata[cleanId] exists)
 
         if containsAll:
             results.push({filename, title, author, context: 'document', totalWords})
@@ -477,6 +483,8 @@ function searchDocumentLevel(lemmaIds, corpusData):
     return results
     // No dedup needed — each text can only appear once (checked via containsAll)
 ```
+
+**Why both spellings:** `resolveLemmaIds` strips the prefix (`tei-ui.js`, `matches[0].id.replace('lemma_', '')`), the index writes it (`build-corpus-index.py`, keys like `"lemma_879"`). A lookup on the bare id alone would find nothing, silently, for every query. The other two modes reach the same place differently and do **not** use this double lookup: the verse path normalizes upward to one prefixed key, the proximity path compares stripped ids against `words[]`. Three spellings of one rule, which is why this one is written out here.
 
 **Note:** No dedup needed here because the intersection check (`every`) guarantees each text appears at most once.
 

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -461,23 +461,26 @@ Source: `playground/js/data/tei-manager.js` (document search function)
 ```
 function searchDocumentLevel(lemmaIds, corpusData):
     results = []
+    includedTexts = corpusData.includedTexts or empty set
 
     for each text in corpusData.texts:
+        // Honours the main-site checkbox selection, unlike the analysis tools
+        // in section H (see the scope note there)
+        if text.id not in includedTexts: continue
+
         // Require ALL lemmata present (intersection, not union)
         containsAll = lemmaIds.every(id => text.lemmata[id] exists)
 
         if containsAll:
-            matchingWords = {}
-            for each lemmaId in lemmaIds:
-                matchingWords[lemmaId] = text.lemmata[lemmaId].length  // count per lemma
-
-            results.push({filename, title, author, matchingWords, totalWords})
+            results.push({filename, title, author, context: 'document', totalWords})
 
     return results
     // No dedup needed — each text can only appear once (checked via containsAll)
 ```
 
 **Note:** No dedup needed here because the intersection check (`every`) guarantees each text appears at most once.
+
+**Removed field (#327):** the pushed object used to carry a `matchingWords` map, the hit count per lemma, built in a loop over `lemmaIds` with two index lookups per matching text. Its last reader was `formatMatchingWordsOrCounts` in `tei-ui.js`, which had lost its own callers long before; when that method went, the field became write-only. What the result card shows is `totalWords`.
 
 ---
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -188,6 +188,8 @@ Für dieses Repo besonders relevant sind `tei/` und `data/`: das sind bei laufen
 
 ### Test File Inventory
 
+Vollständigkeit gegen `testing/tests/` gatet `scripts/audit/check-test-inventory.py` (läuft in `no-cdn-check.yml`, lokal ohne Abhängigkeiten aufrufbar). Eine neue Spec ohne Zeile hier macht die CI rot: die Tabelle ist der einzige Ort, an dem steht, wofür eine Spec da ist. Bis #329 fehlten zehn von dreißig.
+
 | File | Category | What it tests |
 |------|----------|--------------|
 | `main-site.spec.js` | Main site | Landing page, search page loading, search results, reading view |
@@ -198,15 +200,25 @@ Für dieses Repo besonders relevant sind `tei/` und `data/`: das sind bei laufen
 | `results-table.spec.js` | Main site | Corpus search results table view (#114): columns, sorting |
 | `tei-caching.spec.js` | Main site | IndexedDB TEI cache behavior |
 | `error-handling.spec.js` | Main site | Graceful error handling |
+| `woerterbuch.spec.js` | Main site | A–Z-Register über den Authority-Index, Pagination, Deep-Links (#117) |
 | `lemma-page.spec.js` | Lemma pages | URL parsing, data rendering, external links |
 | `playground.spec.js` | Playground | Authority explorers, TEI analysis, UI navigation |
 | `playground-authority-index.spec.js` | Playground | Authority index loading, data structure integrity |
 | `playground-corpus.spec.js` | Playground | Corpus index loading, search functions |
 | `concept-distribution.spec.js` | Playground | Concept distribution analysis (concept → senses → lemmata → texts) |
+| `cooccurrence-ranking.spec.js` | Playground | Kookkurrenz-Ranking und Homographen-Auflösung der Multi-Lemma-Suche (#163/#164) |
+| `proximity-and-resolution.spec.js` | Playground | Nähesuche-Fenster bei drei und mehr Lemmata, Überlappungs-Dedup, Lemma-Auflösung (#169) |
+| `multi-lemma-verse.spec.js` | Playground | Suchmodus „Im selben Vers" über `lineStarts[]`/`lineEnds[]` (#106) |
+| `rhyme-dictionary.spec.js` | Playground | Reim-Wörterbuch: Versende-Scan plus Suffix-Heuristik (#106) |
+| `verse-ending-profile.spec.js` | Playground | Versendings-Profil: Top-N Lemmata an Versenden, Scope-Selector (#106) |
+| `hapax-legomena.spec.js` | Playground | Korpusweite Hapax/Dis/Tris-Aggregation, Filter-Toolbar, Detail-Panel (#196) |
+| `word-component-search.spec.js` | Playground | Wortbestandteil-Modus im Lemmata-Explorer für Komposita-Recherche (#239) |
+| `naming-explorer.spec.js` | Playground | Figurenbezeichnungen: Route, Werk-/Figur-Auswahl, Kategorie-Tabs, Pflicht-Attribution (#59) |
 | `normalization-parity.spec.js` | Cross-cutting | Python/JS normalizer agreement (see [CONTRACTS.md](CONTRACTS.md#a-mhg-normalization-parity)) |
 | `lemma-matching.spec.js` | Cross-cutting | Lemma highlight matching exactness, #130 (see [CONTRACTS.md](CONTRACTS.md#b1-lemma-highlight-matching-contract)) |
 | `position-parity.spec.js` | Cross-cutting | Python/JS word-position agreement, #131 (see [CONTRACTS.md](CONTRACTS.md#b-position-counting-contract)) |
 | `site-chrome.spec.js` | Cross-cutting | Build-injected nav/footer + mobile-menu (`build-pages.py`) |
+| `vendor.spec.js` | Cross-cutting | Runtime-Bibliotheken kommen aus `assets/vendor/`, keine CDN-Abhängigkeit (Laufzeit-Gegenstück zu `no-cdn-check.yml`) |
 | `cross-reference-test.spec.js` | Data integrity | Authority/corpus cross-reference validity |
 | `corpus.spec.js` | Data integrity | Corpus index structure validation |
 | `visual-mobile-test.spec.js` | Visual | Responsive Screenshots + Touch-Target-Größe über mehrere Viewports (iPhone-SE 375px … Desktop 1440px) |
@@ -269,7 +281,8 @@ Diagnose- und Validierungs-Skripte in `scripts/audit/`:
 | `check-naming-index.py` | Naming-Index-Konsistenz (#152): `source.commit` vorhanden + alle `works[].sigle` existieren in `tei/`; `--print-source-commit` liefert den Pin für die Workflows (siehe oben) |
 | `audit-tei-corpus.py` | Korpus-weite Stichproben (z.B. fehlende `<l>`/`<lg>`, ungewöhnliche xml:id-Pattern, Encoding-Anomalien) |
 | `check-lexicon-senses.py` | `lexicon.xml`-Sanity: Lemmata ohne `<sense>`, Senses ohne `conceptIds` |
-| `doc-count-audit.py` | Drift-Detektor zwischen tatsächlichen Korpus-/Authority-Zahlen und den in der Doku verankerten Werten. Heuristik: Window ±2 absolut oder ±2 % relativ, strikter Keyword-Anchor unmittelbar nach der Zahl |
+| `doc-count-audit.py` | Drift-Detektor zwischen tatsächlichen Korpus-/Authority-Zahlen und den in der Doku verankerten Werten. Heuristik: Window ±2 absolut oder ±2 % relativ, strikter Keyword-Anchor unmittelbar nach der Zahl. Läuft als Health-Check-Werkzeug von Hand, kein Workflow ruft es |
+| `check-test-inventory.py` | Spec-Inventar-Gate (#329): jede Datei in `testing/tests/` steht in der Tabelle „Test File Inventory" und umgekehrt. Nur stdlib, gerufen von `no-cdn-check.yml`; `--selftest` prüft den Scanner an künstlichen Eingaben |
 
 ### Skipped Tests (Issue #43 – resolved)
 

--- a/playground/js/data/tei-manager.js
+++ b/playground/js/data/tei-manager.js
@@ -4,17 +4,23 @@
  *
  * Der früher hier liegende Upload-Pfad (Datei einlesen, XML-DOM parsen,
  * darin suchen) ist mit #314 entfernt: die Upload-UI war beim Redesign
- * weggefallen, damit war der ganze Zweig unerreichbar. Die Suche laeuft
+ * weggefallen, damit war der ganze Zweig unerreichbar. Die Suche läuft
  * ausschließlich über data/corpus-index.json.gz, und Positionen sind
  * damit durchgängig die aus CONTRACTS Paragraph B.
  */
 
-import { lemmaRefMatchesId } from '../../../assets/js/lib/lemma-match.js';
+// Kein Import mehr aus lemma-match.js: der einzige Nutzer von
+// lemmaRefMatchesId war hier der XML-Pfad, den #314 entfernt hat, und der
+// Import blieb danach ungenutzt stehen. Die Nähesuche unten braucht ihn nicht:
+// sie liest words[] aus dem Korpus-Index, und dort steht genau eine Lemma-ID
+// je Position (build-corpus-index.py, #170), also gibt es keine
+// whitespace-getrennte Liste zu tokenisieren. Siehe CONTRACTS §B.1.
 
 export class TEIFilesManager {
-    constructor(teiData) {
-        this.teiData = teiData;
-    }
+    // Kein Konstruktor mehr: bis #325 nahm er ein teiData-Objekt entgegen und
+    // legte es auf this.teiData, gelesen hat es hier nie jemand. Der Zustand
+    // dieser Klasse ist corpusIndex, und den setzt playground-main.js von
+    // außen, nachdem der Index geladen ist.
 
     // ==================== INDEX-BASED SEARCH (FAST) ====================
 
@@ -188,20 +194,17 @@ export class TEIFilesManager {
             });
 
             if (containsAll) {
-                // Count total matches for each lemma
-                const matchingWords = {};
-                lemmaIds.forEach(lemmaId => {
-                    const cleanId = lemmaId.toString().replace('lemma_', '');
-                    const positions = text.lemmata[`lemma_${cleanId}`] || text.lemmata[cleanId] || [];
-                    matchingWords[lemmaId] = positions.length;
-                });
-
+                // Hier stand bis #327 ein matchingWords-Objekt (Trefferzahl je
+                // Lemma, eine Schleife über lemmaIds mit zwei Lookups pro
+                // Treffertext). Sein letzter Leser war formatMatchingWordsOrCounts
+                // in tei-ui.js, und der hatte selbst keinen Aufrufer mehr; mit
+                // dessen Löschung wurde das Feld rein schreibend. Angezeigt wird
+                // totalWords.
                 results.push({
                     filename: text.filename,
                     title: text.title,
                     author: text.author || 'Unbekannt',
                     context: 'document',
-                    matchingWords: matchingWords,
                     totalWords: text.wordCount
                 });
             }

--- a/playground/js/playground-main.js
+++ b/playground/js/playground-main.js
@@ -43,22 +43,21 @@ class MHDBDBPlayground {
             variants: []
         };
         
-        this.teiData = {
-            files: [],
-            parsedXML: [],
-            words: [],
-            lines: [],
-            annotations: []
-        };
+        // Hier stand bis #325 ein this.teiData mit fünf Feldern (files,
+        // parsedXML, words, lines, annotations). Befüllt hat es der
+        // Datei-Upload, den #314 zurückgebaut hat; danach hatte kein Feld mehr
+        // einen Schreiber. Der Container wurde trotzdem noch durch drei
+        // Konstruktoren gereicht und hat damit einen Datenfluss suggeriert,
+        // den es nicht mehr gab.
 
         // Data managers (UNCHANGED)
         this.authorityManager = new AuthorityFilesManager(this.authorityData);
-        this.teiManager = new TEIFilesManager(this.teiData);
+        this.teiManager = new TEIFilesManager();
 
         // NEW: Modular UI instead of single UIHelpers
         this.ui = {
             authorityExplorers: new AuthorityUI(this.authorityData),
-            teiExplorer: new TEIExplorer(this.teiData, this.authorityData)
+            teiExplorer: new TEIExplorer()
         };
 
         // Initialize after teiExplorer is created
@@ -500,7 +499,7 @@ class MHDBDBPlayground {
 
     updateUI() {
         // NEW: Use centralized UI update function
-        updateAllUI(this.authorityData, this.teiData);
+        updateAllUI(this.authorityData);
     }
 }
 

--- a/playground/js/ui/core/ui-helpers.js
+++ b/playground/js/ui/core/ui-helpers.js
@@ -512,7 +512,7 @@ export function showWelcomeMessage() {
 
 // ==================== UI STATE COORDINATION ====================
 
-export function updateAllUI(authorityData, teiData) {
+export function updateAllUI(authorityData) {
   const totalAuthorityFiles = 7; // persons, works, lexicon, concepts, genres, names, variants
   const loadedLabel = `${authorityData.files.length}/${totalAuthorityFiles} Authority Files geladen`;
   const indicator = authorityData.files.length === totalAuthorityFiles ? '✅' : '📥';
@@ -522,7 +522,11 @@ export function updateAllUI(authorityData, teiData) {
 
   enableAuthorityQueries();
 
-  if (authorityData.files.length > 0 && teiData.files.length === 0) {
+  // Zweiter Teil der Bedingung war bis #325 `teiData.files.length === 0` und
+  // damit dauerhaft wahr: das Feld hatte seit dem Upload-Rückbau (#314) keinen
+  // Schreiber mehr. Die Bedingung prüft also nur noch, was sie ohnehin
+  // geprüft hat.
+  if (authorityData.files.length > 0) {
     showWelcomeMessage();
   }
 }

--- a/playground/js/ui/tei/multi-lemma-search.js
+++ b/playground/js/ui/tei/multi-lemma-search.js
@@ -293,7 +293,7 @@ export class MultiLemmaSearchUI {
                 // Dokumentweite Suche über den Index
                 results = await teiManager.searchMultipleLemmasUsingIndex(lemmaIds, searchMode);
                 if (getNavigationEpoch() !== myEpoch) return;
-                this.teiExplorer.displayMultiLemmaResults(results, searchTerms, searchMode);
+                this.teiExplorer.displayMultiLemmaResults(results, searchTerms);
             }
 
         } catch (error) {

--- a/playground/js/ui/tei/tei-ui.js
+++ b/playground/js/ui/tei/tei-ui.js
@@ -6,10 +6,10 @@
 import { displayResults, displaySummaryResults } from '../core/ui-helpers.js';
 
 export class TEIExplorer {
-    constructor(teiData, authorityData) {
-        this.teiData = teiData;
-        this.authorityData = authorityData;
-    }
+    // Kein Konstruktor: bis #325/#327 nahm er teiData und authorityData
+    // entgegen und legte beide auf this.*, gelesen hat sie hier nie jemand.
+    // Den Authority-Manager holt sich resolveLemmaIds unten über
+    // window.playground, nicht über ein Konstruktorargument.
 
     resolveLemmaIds(searchTerms) {
         const lemmaIds = [];
@@ -63,25 +63,48 @@ export class TEIExplorer {
 
     // Context selection is now handled by the MultiLemmaSearchUI modal
 
-    displayMultiLemmaResults(results, searchTerms, contextType) {
+    // Zeigt ausschließlich Ergebnisse der Dokumentsuche an. Bis #327 nahm die
+    // Methode einen contextType entgegen und verzweigte darauf; erreichbar war
+    // davon nur 'document'. Der einzige Aufrufer ist der else-Zweig in
+    // multi-lemma-search.js, der greift, nachdem 'proximity' und 'verse'
+    // abgefangen sind, und alles außerhalb dieser drei Modi hat zwei Zeilen
+    // vorher schon `searchMultipleLemmasUsingIndex` abgewiesen (tei-manager.js,
+    // „Unbekannter Suchmodus"). Ein eigener Guard hier wäre deshalb wieder
+    // Code, der nie läuft: die Prüfung sitzt eine Schicht tiefer, wo
+    // contextType echte Dispatch-Variable mit drei lebenden Zweigen ist.
+    //
+    // Was mit den Zweigen verschwunden ist: getResultCount, createPreviewText
+    // und createDetailItems hatten je einen 'proximity'-Zweig plus einen
+    // Fallthrough dahinter, der im Fehlerfall eine plausibel aussehende Zahl
+    // geliefert hätte statt aufzufallen. createDetailItems schrieb dabei
+    // undefined-Einträge in die Detailliste, weil der map-Callback ohne return
+    // durchfiel.
+    displayMultiLemmaResults(results, searchTerms) {
         if (results.length === 0) {
             displayResults(
                 `Multi-Lemma-Suche: ${searchTerms.join(' + ')} (0 Treffer)`,
-                [{ 
-                    meta: `Keine Treffer in ${contextType}`, 
-                    snippet: 'Versuchen Sie andere Suchbegriffe oder einen anderen Kontext' 
+                [{
+                    meta: 'Keine Treffer im gesamten Dokument',
+                    snippet: 'Versuchen Sie andere Suchbegriffe oder einen anderen Kontext'
                 }]
             );
             return;
         }
 
         // Create summary data for the new display format
-        const summaryData = this.createMultiLemmaSummary(results, searchTerms, contextType);
+        const summaryData = this.createMultiLemmaSummary(results);
 
-        // Pass raw results and lemma IDs for lazy TEI loading
-        const lemmaIds = results.length > 0 && results[0].matchingPositions
-            ? [...new Set(results.flatMap(r => r.matchingPositions || []).map(p => p.lemmaRef.replace('lemma_', '')))]
-            : [];
+        // Die Dokumentsuche liefert keine matchingPositions (tei-manager.js
+        // pusht filename/title/author/context/totalWords), hier stand bis #327
+        // ein Ternär, dessen erster Zweig nie griff.
+        //
+        // Die leere Liste wird trotzdem übergeben, aber nicht aus Not: das
+        // Argument hat in displaySummaryResults den Default null, und beide
+        // Lesestellen vertragen null (die eine normalisiert mit `|| []`, die
+        // andere kehrt per Guard früh zurück). Sie steht hier, damit der Aufruf
+        // dieselbe Gestalt hat wie der der Nähe-Suche darunter, die echte IDs
+        // übergibt.
+        const lemmaIds = [];
 
         displaySummaryResults(
             `Multi-Lemma-Suche: ${searchTerms.join(' + ')}`,
@@ -91,10 +114,10 @@ export class TEIExplorer {
         );
     }
 
-    createMultiLemmaSummary(results, searchTerms, contextType) {
+    createMultiLemmaSummary(results) {
         // Group results by filename for better organization
         const fileGroups = {};
-        
+
         results.forEach(result => {
             if (!fileGroups[result.filename]) {
                 fileGroups[result.filename] = [];
@@ -103,151 +126,26 @@ export class TEIExplorer {
         });
 
         return Object.entries(fileGroups).map(([filename, fileResults]) => {
-            const count = this.getResultCount(fileResults, contextType);
-            const preview = this.createPreviewText(fileResults, contextType);
-            const details = this.createDetailItems(fileResults, contextType);
+            const count = this.getResultCount(fileResults);
 
             return {
                 title: `${filename}`,
                 count: count,
-                preview: preview,
-                details: details
+                preview: this.createPreviewText(fileResults),
+                // Die Dokumentsuche hat keine Detailzeilen. createSummaryCard in
+                // ui-helpers.js rendert bei leerer Liste die statische Karte
+                // ohne Aufklapp-Symbol, genau das ist hier gewollt.
+                details: []
             };
         });
     }
 
-    getResultCount(fileResults, contextType) {
-        // v4.0.0: Paragraph mode removed
-        if (contextType === 'document') {
-            return fileResults.reduce((sum, result) => sum + (result.totalWords || 1), 0);
-        } else if (contextType === 'proximity') {
-            return fileResults.reduce((sum, result) =>
-                sum + (result.cooccurrences ? result.cooccurrences.length : 0), 0);
-        }
-        return fileResults.length;
+    getResultCount(fileResults) {
+        return fileResults.reduce((sum, result) => sum + (result.totalWords || 1), 0);
     }
 
-    createPreviewText(fileResults, contextType) {
-        const count = this.getResultCount(fileResults, contextType);
-
-        // v4.0.0: Paragraph mode removed
-        if (contextType === 'document') {
-            // Document search: show just word count as metadata
-            return `${count} Wörter`;
-        } else if (contextType === 'proximity') {
-            return `${count} Nähe-Beziehungen gefunden`;
-        }
-        return `${count} Treffer`;
-    }
-
-    createDetailItems(fileResults, contextType) {
-        // v4.0.0: Paragraph mode removed - only document and proximity modes remain
-        if (contextType === 'document') {
-            return []; // Document search: no detail items - just show file list
-        }
-
-        return fileResults.map((result, index) => {
-            if (contextType === 'proximity') {
-                // v3.0.0: proximity results are flat, not nested in cooccurrences
-                if (result.contextText) {
-                    // Has actual text (enriched)
-                    return {
-                        meta: `Abstand: ${result.distance} Wörter`,
-                        snippet: `"${result.contextText}"`
-                    };
-                } else {
-                    // Fallback: show lemma IDs
-                    const preview = result.contextLemmas ? result.contextLemmas.slice(0, 20).join(' ') : '';
-                    return {
-                        meta: `Abstand: ${result.distance} Wörter`,
-                        snippet: `<code style="font-size: 0.85em;">${preview}...</code>`
-                    };
-                }
-            }
-        }).flat().slice(0, 50); // Limit to 50 detail items for performance
-    }
-
-    // v3.0.0 compact format helpers
-    formatMatchingPositions(matchingPositions) {
-        if (!matchingPositions || matchingPositions.length === 0) {
-            return 'Keine Positionen';
-        }
-        const lemmaRefs = matchingPositions.map(p => p.lemmaRef).filter(Boolean);
-        const uniqueLemmas = [...new Set(lemmaRefs)];
-        return `${uniqueLemmas.length} Lemmata (${matchingPositions.length} Vorkommen)`;
-    }
-
-    formatParagraphLemmas(paragraphLemmas) {
-        if (!paragraphLemmas || paragraphLemmas.length === 0) {
-            return 'Kein Text verfügbar';
-        }
-        // Show first 100 lemma IDs as placeholder
-        const preview = paragraphLemmas.slice(0, 100).join(' ');
-        const more = paragraphLemmas.length > 100 ? ` ... (+${paragraphLemmas.length - 100} weitere)` : '';
-        return `<code style="font-size: 0.85em; color: #475569;">${preview}${more}</code>`;
-    }
-
-    formatMatchingWordsOrCounts(matchingWords) {
-        // Handle both formats: array of words (paragraph) or counts (document)
-        const summaries = [];
-        for (const [lemmaId, data] of Object.entries(matchingWords)) {
-            if (typeof data === 'number') {
-                // Document search: data is a count
-                summaries.push(`lemma_${lemmaId} (${data}x)`);
-            } else if (Array.isArray(data)) {
-                // Paragraph search: data is array of word objects
-                const uniqueTexts = [...new Set(data.map(w => w.text))];
-                summaries.push(`${uniqueTexts.join(', ')} (${data.length}x)`);
-            }
-        }
-        return summaries.join(' • ');
-    }
-
-    formatMatchingWords(matchingWords) {
-        const summaries = [];
-        for (const [lemmaId, words] of Object.entries(matchingWords)) {
-            const uniqueTexts = [...new Set(words.map(w => w.text))];
-            summaries.push(`${uniqueTexts.join(', ')} (${words.length}x)`);
-        }
-        return summaries.join(' • ');
-    }
-
-    highlightLemmasInText(text, matchingWords) {
-        let highlightedText = text;
-
-        for (const [lemmaId, words] of Object.entries(matchingWords)) {
-            words.forEach(word => {
-                // Escape special regex characters in word.text
-                const escapedWord = word.text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-                // Use negative lookahead to avoid double-wrapping already highlighted text
-                const regex = new RegExp(`(?<!<[^>]*)\\b${escapedWord}\\b(?![^<]*<\\/span>)`, 'gi');
-                highlightedText = highlightedText.replace(regex,
-                    `<span class="highlight multi-lemma-${lemmaId}">${word.text}</span>`
-                );
-            });
-        }
-
-        return highlightedText;
-    }
-
-    highlightCooccurrenceContext(context, lemma1, lemma2) {
-        let highlightedContext = context;
-
-        // Highlight lemma1
-        const escapedText1 = lemma1.text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-        const regex1 = new RegExp(`\\b${escapedText1}\\b`, 'gi');
-        highlightedContext = highlightedContext.replace(regex1,
-            `<span class="highlight multi-lemma-${lemma1.id}">${lemma1.text}</span>`
-        );
-
-        // Highlight lemma2 (avoid double-wrapping)
-        const escapedText2 = lemma2.text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-        const regex2 = new RegExp(`(?<!<[^>]*)\\b${escapedText2}\\b(?![^<]*<\\/span>)`, 'gi');
-        highlightedContext = highlightedContext.replace(regex2,
-            `<span class="highlight multi-lemma-${lemma2.id}">${lemma2.text}</span>`
-        );
-
-        return highlightedContext;
+    createPreviewText(fileResults) {
+        return `${this.getResultCount(fileResults)} Wörter`;
     }
 
     // findCooccurringLemmas() method removed - now handled by MultiLemmaSearchUI modal
@@ -301,8 +199,9 @@ export class TEIExplorer {
                         snippet: `"${match.contextText}"`
                     };
                 } else {
-                    // No text yet - show lemma IDs preview
-                    const preview = match.contextLemmas ? match.contextLemmas.slice(0, 20).join(' ') : '';
+                    // Noch kein Text geladen. Hier stand bis #327 eine
+                    // Lemma-ID-Vorschau, die berechnet und dann verworfen wurde:
+                    // das snippet daneben ist ein fester Hinweistext.
                     return {
                         meta: meta,
                         snippet: `<em style="color: #475569;">Klicken Sie auf "KLICKEN ZUM ERWEITERN" um den vollständigen Text anzuzeigen</em>`

--- a/playground/js/ui/tei/tei-ui.js
+++ b/playground/js/ui/tei/tei-ui.js
@@ -131,7 +131,7 @@ export class TEIExplorer {
             return {
                 title: `${filename}`,
                 count: count,
-                preview: this.createPreviewText(fileResults),
+                preview: this.createPreviewText(count),
                 // Die Dokumentsuche hat keine Detailzeilen. createSummaryCard in
                 // ui-helpers.js rendert bei leerer Liste die statische Karte
                 // ohne Aufklapp-Symbol, genau das ist hier gewollt.
@@ -144,8 +144,10 @@ export class TEIExplorer {
         return fileResults.reduce((sum, result) => sum + (result.totalWords || 1), 0);
     }
 
-    createPreviewText(fileResults) {
-        return `${this.getResultCount(fileResults)} Wörter`;
+    // Nimmt die fertige Zahl, nicht die Liste: der Aufrufer hat getResultCount
+    // zwei Zeilen vorher schon gerufen.
+    createPreviewText(count) {
+        return `${count} Wörter`;
     }
 
     // findCooccurringLemmas() method removed - now handled by MultiLemmaSearchUI modal

--- a/playground/js/ui/tei/tei-ui.js
+++ b/playground/js/ui/tei/tei-ui.js
@@ -73,12 +73,13 @@ export class TEIExplorer {
     // Code, der nie läuft: die Prüfung sitzt eine Schicht tiefer, wo
     // contextType echte Dispatch-Variable mit drei lebenden Zweigen ist.
     //
-    // Was mit den Zweigen verschwunden ist: getResultCount, createPreviewText
-    // und createDetailItems hatten je einen 'proximity'-Zweig plus einen
-    // Fallthrough dahinter, der im Fehlerfall eine plausibel aussehende Zahl
-    // geliefert hätte statt aufzufallen. createDetailItems schrieb dabei
-    // undefined-Einträge in die Detailliste, weil der map-Callback ohne return
-    // durchfiel.
+    // Was dabei wegfiel: in getResultCount und createPreviewText je ein
+    // 'proximity'-Zweig plus ein Fallthrough dahinter, der im Fehlerfall eine
+    // plausibel aussehende Zahl geliefert hätte statt aufzufallen. Beide
+    // Methoden gibt es weiter, nur ohne diese Zweige. createDetailItems ist
+    // ganz weg: dort schrieb der map-Callback undefined-Einträge in die
+    // Detailliste, weil er ohne return durchfiel, und übrig geblieben wäre
+    // ein return [].
     displayMultiLemmaResults(results, searchTerms) {
         if (results.length === 0) {
             displayResults(

--- a/scripts/audit/check-test-inventory.py
+++ b/scripts/audit/check-test-inventory.py
@@ -80,10 +80,18 @@ def tabellen_abschnitt(text: str) -> str:
     meldete das Gate nach einer Umbenennung der Überschrift jede einzelne Spec
     als fehlend, statt zu sagen, dass es die Tabelle nicht mehr findet.
 
-    Code-Blöcke werden übersprungen, weil eine Zeile wie `# python scripts/...`
-    darin sonst als Überschrift zählte und die Tabelle vorzeitig abschnitte.
-    Das Muster ist in dieser Datei üblich, und der Abschnitt trägt bereits
-    Prosa, wird also wachsen.
+    Code-Blöcke werden ganz verworfen, aus zwei Gründen in dieser Reihenfolge.
+    Der erste: eine Zeile wie `# python scripts/…` darin zählte sonst als
+    Überschrift und schnitte die Tabelle vorzeitig ab; das Muster ist in diesen
+    Docstrings üblich, und der Abschnitt trägt bereits Prosa, wird also wachsen.
+    Der zweite folgt aus dem ersten: sobald ein Code-Block im Abschnitt möglich
+    ist, kann darin eine Beispiel-Tabellenzeile stehen, und die zählte als
+    Eintrag. Eine Spec wäre dann gelistet, weil jemand sie als Beispiel
+    hingeschrieben hat. Die Zeilen nur für die Überschriftenerkennung zu
+    ignorieren und sie trotzdem zurückzugeben, wäre also ein Fail-open.
+
+    Eine nicht geschlossene Fence verwirft den Rest des Dokuments. Das ist
+    fail-closed: die Specs darunter fehlen dann im Ergebnis und werden gemeldet.
     """
     zeilen = text.splitlines()
     try:
@@ -93,16 +101,18 @@ def tabellen_abschnitt(text: str) -> str:
             f'FEHLER: Überschrift "{TABELLEN_TITEL}" steht nicht in {DOC.name}. '
             'Wurde sie umbenannt? Dann TABELLEN_TITEL hier mitziehen.'
         )
-    ende = len(zeilen)
+    behalten = []
     im_codeblock = False
-    for i in range(start + 1, len(zeilen)):
-        if zeilen[i].lstrip().startswith(('```', '~~~')):
+    for zeile in zeilen[start + 1:]:
+        if zeile.lstrip().startswith(('```', '~~~')):
             im_codeblock = not im_codeblock
             continue
-        if not im_codeblock and zeilen[i].startswith(('# ', '## ', '### ')):
-            ende = i
+        if im_codeblock:
+            continue
+        if zeile.startswith(('# ', '## ', '### ')):
             break
-    return '\n'.join(zeilen[start:ende])
+        behalten.append(zeile)
+    return '\n'.join(behalten)
 
 
 def specs_im_dateisystem() -> set:
@@ -143,6 +153,7 @@ def selbsttest() -> int:
         '\n'
         '```bash\n'
         '# python scripts/audit/check-test-inventory.py\n'
+        '| `beispiel.spec.js` | X | so sieht eine Zeile aus |\n'
         '```\n'
         '\n'
         '| `a.spec.js` | Main site | Erste |\n'
@@ -182,10 +193,18 @@ def selbsttest() -> int:
              == {'wörterbuch prüfung.spec.js'}),
         ('Nicht-Spec zählt nicht',
          not ENDUNG.search('util.js') and not ENDUNG.search('fixture.spec.xml')),
-        # Ohne Codeblock-Erkennung schnitte die Kommentarzeile darin die
-        # Tabelle ab, und a.spec.js fehlte plötzlich.
-        ('Ein Codeblock im Abschnitt beendet die Tabelle nicht',
+        # Zwei Wirkungen in einer Eingabe: ohne Codeblock-Erkennung schnitte
+        # die Kommentarzeile darin die Tabelle ab und a.spec.js fehlte; würden
+        # die Blockzeilen nur für die Überschriftensuche ignoriert und trotzdem
+        # zurückgegeben, zählte die Beispielzeile als Eintrag.
+        ('Ein Codeblock beendet die Tabelle nicht und zählt selbst nicht mit',
          specs_in_tabelle(tabellen_abschnitt(mit_codeblock)) == {'a.spec.js'}),
+        # Die gelockerte ZEILE nimmt auch Prosa in Spalte 1 an. Das ist die
+        # Kehrseite davon, Leerzeichen zuzulassen, und fail-closed: das Phantom
+        # taucht als "genannt, aber nicht vorhanden" auf und macht Exit 1.
+        ('Prosa in Spalte 1 wird als verwaister Eintrag gemeldet',
+         pruefe(set(), specs_in_tabelle('| Ersatz für a.spec.js | X | Y |'))[1]
+         == ['Ersatz für a.spec.js']),
     ]
 
     for name, ok in faelle:

--- a/scripts/audit/check-test-inventory.py
+++ b/scripts/audit/check-test-inventory.py
@@ -64,9 +64,12 @@ TABELLEN_TITEL = '### Test File Inventory'
 ENDUNG = re.compile(r'\.(?:spec|test)\.(?:[cm]?[jt]sx?)$')
 
 # Erste Spalte einer Tabellenzeile: | `name.spec.js` | Kategorie | Text |
-# Der Name darf alles außer Pipe, Backtick und Leerraum sein, aus demselben
-# Grund; die Endung entscheidet.
-ZEILE = re.compile(r'^\|\s*`?([^|`\s]+\.(?:spec|test)\.(?:[cm]?[jt]sx?))`?\s*\|')
+# Der Name darf alles außer Pipe und Backtick sein, Leerzeichen eingeschlossen.
+# Enger wäre hier zwar fail-closed und nicht fail-open, aber genauso kaputt:
+# eine Datei, die ENDUNG oben akzeptiert, muss sich auch eintragen lassen,
+# sonst bliebe das Gate rot ohne einen Weg, es grün zu bekommen. Der Match ist
+# nicht-gierig, damit er in Spalte 1 bleibt; umgebender Leerraum wird getrimmt.
+ZEILE = re.compile(r'^\|\s*`?([^|`]+?\.(?:spec|test)\.(?:[cm]?[jt]sx?))`?\s*\|')
 
 
 def tabellen_abschnitt(text: str) -> str:
@@ -76,6 +79,11 @@ def tabellen_abschnitt(text: str) -> str:
     Fehlt die Überschrift, ist das ein Fehler und kein leeres Ergebnis: sonst
     meldete das Gate nach einer Umbenennung der Überschrift jede einzelne Spec
     als fehlend, statt zu sagen, dass es die Tabelle nicht mehr findet.
+
+    Code-Blöcke werden übersprungen, weil eine Zeile wie `# python scripts/...`
+    darin sonst als Überschrift zählte und die Tabelle vorzeitig abschnitte.
+    Das Muster ist in dieser Datei üblich, und der Abschnitt trägt bereits
+    Prosa, wird also wachsen.
     """
     zeilen = text.splitlines()
     try:
@@ -86,8 +94,12 @@ def tabellen_abschnitt(text: str) -> str:
             'Wurde sie umbenannt? Dann TABELLEN_TITEL hier mitziehen.'
         )
     ende = len(zeilen)
+    im_codeblock = False
     for i in range(start + 1, len(zeilen)):
-        if zeilen[i].startswith(('# ', '## ', '### ')):
+        if zeilen[i].lstrip().startswith(('```', '~~~')):
+            im_codeblock = not im_codeblock
+            continue
+        if not im_codeblock and zeilen[i].startswith(('# ', '## ', '### ')):
             ende = i
             break
     return '\n'.join(zeilen[start:ende])
@@ -126,6 +138,20 @@ def selbsttest() -> int:
     )
     gelistet = specs_in_tabelle(tabellen_abschnitt(tabelle))
 
+    mit_codeblock = (
+        f'{TABELLEN_TITEL}\n'
+        '\n'
+        '```bash\n'
+        '# python scripts/audit/check-test-inventory.py\n'
+        '```\n'
+        '\n'
+        '| `a.spec.js` | Main site | Erste |\n'
+        '\n'
+        '### Naechster Abschnitt\n'
+        '\n'
+        '| `d.spec.js` | X | darf nicht mitzaehlen |\n'
+    )
+
     faelle = [
         ('Tabelle endet an der nächsten Überschrift',
          'c.spec.js' not in gelistet),
@@ -147,10 +173,19 @@ def selbsttest() -> int:
          bool(ENDUNG.search('x.test.js')) and specs_in_tabelle('| `x.test.js` | X | Y |') == {'x.test.js'}),
         ('TypeScript- und Modul-Varianten zählen mit',
          all(ENDUNG.search(n) for n in ('a.spec.ts', 'b.test.mjs', 'c.spec.cjs', 'd.test.tsx'))),
-        ('Name mit Umlaut oder Leerzeichen zählt mit',
-         ENDUNG.search('wörterbuch prüfung.spec.js') is not None),
+        # Beide Regexe müssen dieselben Namen durchlassen. Ließe der Dateiscan
+        # einen Namen zu, den die Tabellenzeile nicht aufnehmen kann, bliebe
+        # das Gate rot ohne einen Weg, es grün zu bekommen.
+        ('Name mit Umlaut oder Leerzeichen zählt beidseitig mit',
+         ENDUNG.search('wörterbuch prüfung.spec.js') is not None
+         and specs_in_tabelle('| `wörterbuch prüfung.spec.js` | X | Y |')
+             == {'wörterbuch prüfung.spec.js'}),
         ('Nicht-Spec zählt nicht',
          not ENDUNG.search('util.js') and not ENDUNG.search('fixture.spec.xml')),
+        # Ohne Codeblock-Erkennung schnitte die Kommentarzeile darin die
+        # Tabelle ab, und a.spec.js fehlte plötzlich.
+        ('Ein Codeblock im Abschnitt beendet die Tabelle nicht',
+         specs_in_tabelle(tabellen_abschnitt(mit_codeblock)) == {'a.spec.js'}),
     ]
 
     for name, ok in faelle:

--- a/scripts/audit/check-test-inventory.py
+++ b/scripts/audit/check-test-inventory.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""
+Spec-Inventar-Gate: jede Playwright-Spec steht in der Tabelle
+"Test File Inventory" in docs/DEVELOPMENT.md, und die Tabelle nennt keine
+Spec, die es nicht gibt.
+
+Anlass ist #329: die Tabelle listete 20 von 30 Specs. Die zehn fehlenden
+gehörten alle zu Features aus Mai bis Juli 2026, zusammen 86 der 276 Tests.
+Das ist der Drift-Typ, den niemand bemerkt, weil sein Veralten nichts kaputt
+macht: die Tabelle ist der einzige Ort, an dem steht, WOFÜR eine Spec da ist
+(Kategorie plus ein Satz), und genau deshalb lohnt sie sich nur gepflegt.
+
+## Warum die Prüfung nur die eine Tabelle liest
+
+Ein `grep <name> docs/DEVELOPMENT.md` über das ganze Dokument wäre die
+naheliegende Fassung und wäre falsch. `vendor.spec.js` etwa stand seit #328 in
+der Blindstellen-Tabelle weiter oben und hätte den Test bestanden, ohne je im
+Inventar aufzutauchen: gemessen am 01.08.2026 meldet der Ganzdokument-Vergleich
+neun Fehlende, der Tabellen-Vergleich zehn. Die Zahl, die zählt, ist zehn.
+
+Dieselbe Datei enthält außerdem eine zweite Spec-Tabelle (die Blindstellen von
+`test:changed`), die absichtlich unvollständig ist: sie listet nur die
+Nicht-JS-Abhängigkeiten. Sie darf nicht mitgezählt werden. Die Tabelle wird
+deshalb über ihre Überschrift abgegrenzt, von `### Test File Inventory` bis zur
+nächsten Überschrift derselben oder einer höheren Ebene.
+
+## Selbsttest
+
+Beide Richtungen werden an künstlichen Eingaben belegt, nicht zugesichert. Der
+Grund steht im JOURNAL zum 31.07.: ein Gate, das jahrelang grün läuft, sagt
+nichts, solange niemand den Fehler einbaut, den es fangen soll. Zwei der Fälle
+unten spiegeln genau die beiden Fehlermodi, die dieses Skript rechtfertigen:
+eine neue Spec, die niemand einträgt, und ein Spec-Name, der außerhalb der
+Tabelle vorkommt.
+
+Usage:
+    python scripts/audit/check-test-inventory.py             # Bericht + Exit-Code
+    python scripts/audit/check-test-inventory.py --selftest  # Scanner prüfen
+"""
+import argparse
+import io
+import re
+import sys
+from pathlib import Path
+
+if sys.stdout.encoding and sys.stdout.encoding.lower() not in ('utf-8', 'utf8'):
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8', line_buffering=True)
+
+REPO = Path(__file__).resolve().parents[2]
+SPEC_DIR = REPO / 'testing' / 'tests'
+DOC = REPO / 'docs' / 'DEVELOPMENT.md'
+TABELLEN_TITEL = '### Test File Inventory'
+
+# Was Playwright tatsächlich einsammelt, nicht was heute zufällig dort liegt.
+# testing/playwright.config.js setzt nur testDir und kein testMatch, es gilt
+# also der Default `**/*.@(spec|test).?(c|m)[jt]s?(x)`: rekursiv und auch
+# *.test.js. Heute ist das Verzeichnis flach und enthält nur *.spec.js, ein
+# engerer Glob wäre aber ein Fail-open: eine Spec in einem künftigen
+# Unterordner liefe in der Suite mit und wäre hier grün.
+#
+# Geprüft wird nur die Endung, nicht der ganze Name. Eine Zeichenklasse für den
+# Namensteil wäre die zweite Sorte Fail-open: eine Datei mit Umlaut oder
+# Leerzeichen im Namen fiele still aus dem Scan, liefe in der Suite aber mit.
+ENDUNG = re.compile(r'\.(?:spec|test)\.(?:[cm]?[jt]sx?)$')
+
+# Erste Spalte einer Tabellenzeile: | `name.spec.js` | Kategorie | Text |
+# Der Name darf alles außer Pipe, Backtick und Leerraum sein, aus demselben
+# Grund; die Endung entscheidet.
+ZEILE = re.compile(r'^\|\s*`?([^|`\s]+\.(?:spec|test)\.(?:[cm]?[jt]sx?))`?\s*\|')
+
+
+def tabellen_abschnitt(text: str) -> str:
+    """Der Bereich unter der Inventar-Überschrift bis zur nächsten Überschrift
+    gleicher oder höherer Ebene.
+
+    Fehlt die Überschrift, ist das ein Fehler und kein leeres Ergebnis: sonst
+    meldete das Gate nach einer Umbenennung der Überschrift jede einzelne Spec
+    als fehlend, statt zu sagen, dass es die Tabelle nicht mehr findet.
+    """
+    zeilen = text.splitlines()
+    try:
+        start = zeilen.index(TABELLEN_TITEL)
+    except ValueError:
+        raise SystemExit(
+            f'FEHLER: Überschrift "{TABELLEN_TITEL}" steht nicht in {DOC.name}. '
+            'Wurde sie umbenannt? Dann TABELLEN_TITEL hier mitziehen.'
+        )
+    ende = len(zeilen)
+    for i in range(start + 1, len(zeilen)):
+        if zeilen[i].startswith(('# ', '## ', '### ')):
+            ende = i
+            break
+    return '\n'.join(zeilen[start:ende])
+
+
+def specs_im_dateisystem() -> set:
+    """Bezeichner ist der Pfad relativ zu testing/tests/. Solange das
+    Verzeichnis flach ist, ist das der Dateiname; liegt eine Spec je in einem
+    Unterordner, steht der Pfad in der Tabelle und bleibt eindeutig."""
+    return {p.relative_to(SPEC_DIR).as_posix()
+            for p in SPEC_DIR.rglob('*')
+            if p.is_file() and ENDUNG.search(p.name)}
+
+
+def specs_in_tabelle(abschnitt: str) -> set:
+    return {m.group(1) for m in (ZEILE.match(z) for z in abschnitt.splitlines()) if m}
+
+
+def pruefe(vorhanden: set, gelistet: set) -> tuple:
+    """(fehlt in der Tabelle, in der Tabelle ohne Datei)"""
+    return sorted(vorhanden - gelistet), sorted(gelistet - vorhanden)
+
+
+def selbsttest() -> int:
+    tabelle = (
+        f'{TABELLEN_TITEL}\n'
+        '\n'
+        '| File | Category | What it tests |\n'
+        '|------|----------|--------------|\n'
+        '| `a.spec.js` | Main site | Erste |\n'
+        '| `b.spec.js` | Playground | Zweite |\n'
+        '\n'
+        '### CI: Data Integrity\n'
+        '\n'
+        'Hier steht c.spec.js außerhalb der Tabelle.\n'
+    )
+    gelistet = specs_in_tabelle(tabellen_abschnitt(tabelle))
+
+    faelle = [
+        ('Tabelle endet an der nächsten Überschrift',
+         'c.spec.js' not in gelistet),
+        ('Nennung außerhalb der Tabelle zählt nicht als gelistet',
+         pruefe({'a.spec.js', 'b.spec.js', 'c.spec.js'}, gelistet)[0] == ['c.spec.js']),
+        ('Fehlende Spec wird gemeldet',
+         pruefe({'a.spec.js', 'b.spec.js', 'neu.spec.js'}, gelistet)[0] == ['neu.spec.js']),
+        ('Gelöschte Spec wird gemeldet',
+         pruefe({'a.spec.js'}, gelistet)[1] == ['b.spec.js']),
+        ('Deckungsgleich ist grün',
+         pruefe({'a.spec.js', 'b.spec.js'}, gelistet) == ([], [])),
+        ('Backticks sind optional',
+         specs_in_tabelle('| x.spec.js | Main site | ohne Backticks |') == {'x.spec.js'}),
+        ('Namensnennung in der Beschreibungsspalte zählt nicht',
+         specs_in_tabelle('| `a.spec.js` | X | Gegenstück zu b.spec.js |') == {'a.spec.js'}),
+        # Die folgenden decken ab, was Playwright per Default noch einsammelt
+        # und ein Glob auf *.spec.js im Wurzelverzeichnis nicht:
+        ('*.test.js zählt mit',
+         bool(ENDUNG.search('x.test.js')) and specs_in_tabelle('| `x.test.js` | X | Y |') == {'x.test.js'}),
+        ('TypeScript- und Modul-Varianten zählen mit',
+         all(ENDUNG.search(n) for n in ('a.spec.ts', 'b.test.mjs', 'c.spec.cjs', 'd.test.tsx'))),
+        ('Name mit Umlaut oder Leerzeichen zählt mit',
+         ENDUNG.search('wörterbuch prüfung.spec.js') is not None),
+        ('Nicht-Spec zählt nicht',
+         not ENDUNG.search('util.js') and not ENDUNG.search('fixture.spec.xml')),
+    ]
+
+    for name, ok in faelle:
+        print(f'  {"OK  " if ok else "FAIL"} {name}')
+    gescheitert = [name for name, ok in faelle if not ok]
+    if gescheitert:
+        print(f'\nSelbsttest fehlgeschlagen: {len(gescheitert)} von {len(faelle)}')
+        return 1
+    print(f'\nSelbsttest bestanden: {len(faelle)} von {len(faelle)}')
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--selftest', action='store_true',
+                    help='Scanner an künstlichen Eingaben prüfen, Repo nicht anfassen')
+    args = ap.parse_args()
+
+    if args.selftest:
+        return selbsttest()
+
+    vorhanden = specs_im_dateisystem()
+    gelistet = specs_in_tabelle(tabellen_abschnitt(DOC.read_text(encoding='utf-8')))
+    fehlen, verwaist = pruefe(vorhanden, gelistet)
+
+    print(f'{len(vorhanden)} Specs in testing/tests/, {len(gelistet)} in der Inventar-Tabelle')
+
+    if fehlen:
+        print(f'\nFehlt in der Tabelle "{TABELLEN_TITEL[4:]}" ({len(fehlen)}):')
+        for name in fehlen:
+            print(f'  {name}')
+    if verwaist:
+        print(f'\nIn der Tabelle genannt, aber nicht in testing/tests/ ({len(verwaist)}):')
+        for name in verwaist:
+            print(f'  {name}')
+
+    if fehlen or verwaist:
+        print(f'\nBitte {DOC.relative_to(REPO).as_posix()} nachziehen: '
+              'Kategorie plus einen Satz, wofür die Spec da ist.')
+        return 1
+
+    print('Keine Drift.')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/testing/tests/proximity-and-resolution.spec.js
+++ b/testing/tests/proximity-and-resolution.spec.js
@@ -231,6 +231,45 @@ test.describe('#169 Befund #51: Fast-Path-Wörterbuch ist gestrichen', () => {
     });
 });
 
+// Dieselbe Bauart wie der Test darüber, aus demselben Grund: eine Löschung
+// festhalten statt eine Existenz. Ein `typeof x === 'function'`-Test auf eine
+// Methode ohne Aufrufer hat in corpus.spec.js zuletzt toten Code am Leben
+// gehalten; die Umkehrung kostet nichts und schlägt an, falls jemand eine der
+// sieben Methoden versehentlich wieder einführt.
+test.describe('#327: der unerreichbare proximity-Pfad im TEIExplorer ist weg', () => {
+    test('sieben Methoden ohne Aufrufer existieren nicht mehr', async ({ page }) => {
+        await page.goto('http://localhost:8080/playground/');
+        await page.waitForFunction(() => window.playground?.ui?.multiLemmaSearch !== undefined,
+            { timeout: 60000 });
+
+        const typen = await page.evaluate(() => {
+            const explorer = window.playground.ui.multiLemmaSearch.teiExplorer;
+            const namen = ['createDetailItems', 'formatMatchingPositions', 'formatParagraphLemmas',
+                           'formatMatchingWordsOrCounts', 'formatMatchingWords',
+                           'highlightLemmasInText', 'highlightCooccurrenceContext'];
+            return Object.fromEntries(namen.map(n => [n, typeof explorer[n]]));
+        });
+
+        for (const [name, typ] of Object.entries(typen)) {
+            expect(typ, `${name} sollte entfernt sein`).toBe('undefined');
+        }
+    });
+
+    test('displayMultiLemmaResults nimmt keinen contextType mehr entgegen', async ({ page }) => {
+        await page.goto('http://localhost:8080/playground/');
+        await page.waitForFunction(() => window.playground?.ui?.multiLemmaSearch !== undefined,
+            { timeout: 60000 });
+
+        // Function.length zählt die deklarierten Parameter. Zwei statt drei ist
+        // die Zusicherung, dass der Modus nicht wieder zur Verzweigungsvariable
+        // wird: entschieden wird er in tei-manager.js, eine Schicht tiefer.
+        const stelligkeit = await page.evaluate(() =>
+            window.playground.ui.multiLemmaSearch.teiExplorer.displayMultiLemmaResults.length);
+
+        expect(stelligkeit).toBe(2);
+    });
+});
+
 test.describe('Aufräumrunde: doppelte Lemma-IDs degenerieren die Kookkurrenz-Suche', () => {
     test.beforeEach(async ({ page }) => {
         await page.goto('http://localhost:8080/playground/');


### PR DESCRIPTION
Closes #327
Closes #325
Closes #329

Drei Befunde aus den Reviews zu #324 und #328, alle dieselbe Fehlerklasse: etwas, das nicht mehr erreicht wird, sieht weiter aus, als würde es gebraucht.

## #327: der unerreichbare proximity-Pfad im TEIExplorer

`displayMultiLemmaResults` hat genau einen Aufrufer, den `else`-Zweig in `multi-lemma-search.js`, der erst greift, nachdem `proximity` und `verse` abgefangen sind. `contextType` war dort konstant `'document'`. Unerreichbar waren damit drei Zweige samt ihrer Fallthroughs, darunter einer, der `[undefined, …]` in die Detailliste schrieb, weil der `map`-Callback ohne `return` durchfiel.

**Der Parameter fällt, statt bewacht zu werden.** Erste Fassung dieses PRs setzte einen `throw` an den Methodenkopf, analog zu `tei-manager.js` seit #314. Der Review hat das zerlegt: alles außerhalb der drei Modi weist `searchMultipleLemmasUsingIndex` bereits zwei Zeilen vorher ab („Unbekannter Suchmodus"). Ein Guard hier wäre wieder Code gewesen, der nie läuft, in einem PR, der genau das entfernt. #314 hat dort geworfen, wo `contextType` echte Dispatch-Variable mit drei lebenden Zweigen ist.

Entfernt: sieben Methoden ohne jeden Aufrufer. Das Issue nennt vier, es sind sieben. `highlightLemmasInText` und `highlightCooccurrenceContext` standen nicht drin, `createDetailItems` wäre nach dem Schnitt zu `return []` geschrumpft. Keine Regression, alle waren schon vor #314 aufruferlos.

Drei Funde, die nicht im Issue standen:
- Das Ternär auf `results[0].matchingPositions` konnte nie greifen: die Dokumentsuche liefert kein solches Feld.
- In `displayCooccurrenceResults` wurde eine Lemma-ID-Vorschau berechnet und verworfen.
- **Ein Fund, den dieser PR selbst erzeugt hat:** `matchingWords` in `tei-manager.js` (Trefferzahl je Lemma, eine Schleife mit zwei Lookups pro Treffertext) hatte als letzten Leser `formatMatchingWordsOrCounts`. Mit dessen Löschung wurde das Feld rein schreibend. Gleich mitgenommen, statt es dem nächsten Audit zu überlassen; `CONTRACTS.md` §C.2.3 führte es im Pseudocode ebenfalls noch. Beim Nachziehen kam heraus, dass die Passage drei weitere Dinge falsch oder gar nicht sagte: `context` fehlte, der `includedTexts`-Filter fehlte ganz, und die `containsAll`-Zeile war so nicht lauffähig (real wird jede ID normalisiert und unter beiden Schreibweisen probiert, sonst fände eine Rekonstruktion still null Treffer).

## #325: `teiData` als leerer Container

Fünf Felder, seit dem Upload-Rückbau kein Schreiber, ein einziger Leser (`teiData.files.length === 0`, dauerhaft wahr). Gereicht wurde das Objekt durch drei Konstruktoren.

Der stille Fehler saß in der Argument-Reihenfolge: bei `TEIExplorer(teiData, authorityData)` stand `teiData` **vorne**. Wer nur den Container löscht, übergibt `undefined` als erstes Argument, und weil die Klasse beide Felder nie liest, gäbe es weder Exception noch rote Tests. Signatur und Aufruf sind deshalb in einem Schritt geändert; inzwischen ist der Konstruktor ganz weg, weil auch `authorityData` keinen Leser hatte (`resolveLemmaIds` holt den Manager über `window.playground`).

**Gegenrichtung, der eigentliche Fund:** `tei-manager.js` importierte `lemmaRefMatchesId`, ohne es zu benutzen. Der einzige Nutzer war der XML-Pfad aus #314. `docs/CONTRACTS.md` §B.1 führte `tei-manager.js` deshalb bis heute als Call-Site und ließ `kwic-service.js` aus. Beides korrigiert, mit der Begründung, warum die Nähesuche die Funktion nicht braucht: sie liest `words[]` aus dem Index, und dort steht eine Lemma-ID je Position, es gibt keine whitespace-getrennte Liste zu tokenisieren.

## #329: Test File Inventory, plus Gate

Zehn von dreißig Specs fehlten, zusammen 86 der 276 Tests. Alle zehn gehören zu Features aus Mai bis Juli 2026.

Nachgetragen mit Kategorie und Beschreibung, gelesen aus den `describe`-Blöcken und `goto`-Zielen, nicht aus den Dateinamen. Gegenrichtung geprüft: die Tabelle nennt keine Spec, die es nicht gibt.

**`scripts/audit/check-test-inventory.py`**, stdlib only, gerufen aus `no-cdn-check.yml`. Vier Entscheidungen, die nicht offensichtlich sind:

1. **Nur die eine Tabelle wird gelesen, nicht das Dokument.** Ein Ganzdokument-`grep` hätte `vendor.spec.js` durchgewinkt, weil der Name seit #328 in der Blindstellen-Tabelle steht: neun Fehlende statt zehn. Die Tabelle wird an ihrer Überschrift abgegrenzt.
2. **Der Dateiscan spiegelt, was Playwright einsammelt**, nicht was heute dort liegt. Die Config setzt nur `testDir`, es gilt also der Default `**/*.@(spec|test).?(c|m)[jt]s?(x)`: rekursiv und auch `*.test.js`. Ein Glob auf `testing/tests/*.spec.js` wäre ein Fail-open gewesen. An einer echten Datei belegt: eine Spec in `testing/tests/probe/` macht das Gate rot. Geprüft wird nur die Endung, nicht der ganze Name: eine Zeichenklasse für den Namensteil wäre dieselbe Falle noch einmal, ein Dateiname mit Umlaut fiele still aus dem Scan und liefe trotzdem mit. **Beide Regexe müssen dabei dasselbe durchlassen.** In der ersten Fassung tat das nur einer: der Dateiscan akzeptierte Leerzeichen, die Tabellenzeile nicht. Eine solche Datei hätte sich nie eintragen lassen, das Gate wäre rot geblieben ohne einen Weg zurück. Fail-closed statt fail-open, aber genauso kaputt.
3. **Codeblöcke beenden den Abschnitt nicht.** Er endet an der nächsten Überschrift, und ein Fenced Block mit einer Zeile wie `# python scripts/audit/…` hätte die Tabelle vorzeitig abgeschnitten. Genau dieses Muster ist in den Skript-Docstrings üblich, und der Abschnitt trägt seit diesem PR einen Prosa-Absatz, wird also wachsen.
4. **`no-cdn-check.yml`, nicht `data-integrity.yml`.** Nicht wegen der Trigger (data-integrity horcht ohnehin auf `scripts/audit/**`), sondern wegen der Kosten: dort hinge das Gate hinter Index-Rebuild und RelaxNG über 667 Dateien und liefe bei jedem `tei/`-Commit mit, während eine Änderung an `testing/tests/` es gar nicht auslöste.

Der Selbsttest belegt beide Richtungen an künstlichen Eingaben, dreizehn Fälle. Zusätzlich mit einer echten Mutation geprüft: eine entfernte Tabellenzeile ergibt Exit 1, der zurückgesetzte Stand Exit 0. Der Grund für diesen Aufwand steht im JOURNAL zum 31.07.: ein Gate, das jahrelang grün läuft, sagt nichts, solange niemand den Fehler einbaut, den es fangen soll.

## Tests

Zwei Negativtests in `proximity-and-resolution.spec.js`, in der Bauart des dortigen Präzedenzfalls (`findLemmaIdByOrthography existiert nicht mehr`): sie halten eine Löschung fest statt eine Existenz. Ein `typeof x === 'function'`-Test auf eine aufruferlose Methode hat in `corpus.spec.js` zuletzt toten Code am Leben gehalten, die Umkehrung kostet nichts.

## Verifikation

- Volle Suite: **278 passed (5,2 min)**, Exit 0. 276 vorher plus die zwei neuen Negativtests.
- `check-test-inventory.py --selftest`: 13 von 13.
- Gate an drei echten Mutationen der Datei belegt: entfernte Tabellenzeile, Spec in `testing/tests/probe/`, und eine Zeile, die nur noch als Beispiel in einem Codeblock steht, je Exit 1; zurückgesetzt je Exit 0.
- Em-Dash-Gate grün, `node --check` auf allen berührten JS-Dateien.

## Zum Vorgehen

Kartierung und Gegenprüfung liefen als Workflow mit Fan-out, ein Planer und ein Skeptiker je Issue, danach eine Zweitmeinung über den fertigen Diff. Ertrag: der widerlegte `throw`, die drei zusätzlichen toten Symbole, der ungenutzte Import samt CONTRACTS-Drift, der rekursive Dateiscan, die falsche Workflow-Begründung, das schreibend-tote `matchingWords`, das zweite Fail-open im Namens-Regex und zwei Kommentare, die etwas Zählbares falsch behaupteten.

Handwerklicher Fehler dabei, der Nachahmern erspart bleiben soll: die Agenten lasen denselben Worktree, in dem ich parallel editierte. Zwei der drei Skeptiker meldeten deshalb „parallele Session überschreibt fremde Arbeit" als Blocker, was sie nicht war. Kartieren und Umsetzen gehören in getrennte Bäume oder in getrennte Zeitfenster.
