### PR TITLE
#315/#318: erledigte Ausnahmen, ein Changelog zu viel, eine Messvorschrift

### DIFF
--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -293,7 +293,7 @@ The project uses pre-built JSON indexes to avoid runtime XML parsing.
 ### Corpus Index
 
 **File:** `data/corpus-index.json.gz`
-**Size:** ~40 MB compressed (v4.1.x; war ~34 MB in v4.0.1)
+**Size:** ~40 MB compressed (war ~34 MB, bevor `lineStarts`/`lineEnds` dazukamen)
 **Version:** Aktueller Stand in [TEI-MODEL.md §11](TEI-MODEL.md#11-versionierung). Quelle im Code: `INDEX_VERSION` in `assets/js/lib/corpus-loader.js` und `'version'` in `scripts/build-corpus-index.py` (dort steht auch der Versions-Historien-Kommentar). MAJOR/MINOR/PATCH-Semantik siehe unten.
 
 **Schema (illustrativ – konkrete Version siehe Tabelle in TEI-MODEL.md §11):**
@@ -328,31 +328,22 @@ The project uses pre-built JSON indexes to avoid runtime XML parsing.
 }
 ```
 
-**Key features (v4.1.x):**
+**Key features:**
 - Document-level word indexing (removed paragraph-based indexing in 4.0.0)
 - `words[i]` = lemma ID at position `i` (sequential, 0-indexed)
 - Only words with `@lemmaRef` are indexed
 - `lemmata` is the per-text reverse index (lemma → positions), enables O(1) lookup of "where does lemma X appear in text Y"
 - `lemmaIndex` is the global reverse index (lemma → list of text sigles), enables fast "which texts contain lemma X" queries
 - `lineStarts[]` / `lineEnds[]` (seit 4.1.0): pro Text die Word-Indizes der `<l>`-Boundaries. Gleiche Länge wie die Anzahl `<l>` mit mindestens einem indizierten Wort. Empty arrays für Prosa-Texte ohne `<l>` (67/667 ≈ 10 % des Korpus, Stand 2026-07-31; es waren 64, bis #143 drei Texte auf Prosa umstellte). Enables „Lemma am Versanfang/Versende"-Lookups in O(L) statt O(W).
+  **Messvorschrift für die Verszahl:** 1.356.748 Boundaries über 600 Texte, gezählt als Summe der `lineStarts`-Längen im gebauten Index. Das Korpus selbst trägt 1.358.973 `<l>`; die Differenz sind Verse ohne ein einziges lemmatisiertes Wort, die keine Boundary erzeugen. Beide Zahlen sind richtig, sie messen Verschiedenes.
 - 100% word coverage from TEI `<body>` elements (Wörter außerhalb von `<l>` wie `<head>`, `<note>`, `<fw>` zählen in `words[]`, aber matchen keine Vers-Boundary)
 - Supports accurate proximity search + Versposition-Filter
 
 **Why v4.0.0?** Removed paragraph-based indexing due to position misalignment between Python extraction and JavaScript parsing. Document-level indexing is simpler and more accurate.
 
-**Why v4.0.1?** WZB (Wenzelsbibel) ingested into the corpus after Phase-2 POS coverage reached 95.5% (Issue #34).
+**Why v4.1.0?** Per-Text `lineStarts[]` / `lineEnds[]` für #47.3 Lemmasuche nach Versposition. Bumped `Schema-feature-add` (MINOR), nicht nur `data-add` (PATCH).
 
-**Why v4.1.0?** Per-Text `lineStarts[]` / `lineEnds[]` für #47.3 Lemmasuche nach Versposition. 1.359.789 `<l>`-Elemente über 603 Versdichtungs-Texte (Stand v4.1.0; heute 1.356.748 über 600, siehe die Anmerkung zu 67/667 oben). Bumped `Schema-feature-add` (MINOR), nicht nur `data-add` (PATCH). Index-Größe +6 MB gz (34 → 40 MB).
-
-**Why v4.1.1?** Korpus-Rebuild nach Stanza-Insertion-Sweep (#23) – etwa 90 Texte bekamen `<lg type="stanza">`-Wrapper, was die `lineStarts`/`lineEnds`-Werte für diese Texte ändert; keine Schema-Änderung, daher PATCH.
-
-**Why v4.1.2?** #104 Sigle-Titel-Differenzierung (PL1-3, FLG/FLG1, FR1-3); reiner Daten-Add, PATCH.
-
-**Why v4.1.3?** #110 WVV-Rebuild – 478 zusätzliche `<lg type="stanza">`-Wraps; PATCH.
-
-**Why v4.1.4?** #125 Deterministischer Build – `generatedAt` entfernt, sortiertes glob, gzip `mtime=0`; gleicher Quellstand erzeugt byte-identische Indexe. PATCH.
-
-**Why v4.1.5?** #143 Prosa-Konversion APO/HMT/HH (`<l>` → `<lb/>`) – `lineStarts[]`/`lineEnds[]` entfallen für die drei Texte. PATCH.
+**Alles Weitere ist Changelog und steht nicht hier.** Die Begründung jedes einzelnen Bumps ab v4.1.5 hängt als Kommentar an der `'version'`-Konstante in `scripts/build-corpus-index.py`, die aktuelle Version in [TEI-MODEL.md §11](TEI-MODEL.md#11-versionierung), die älteren in der Git-Historie dieser Datei. Ein Schema-Dokument, das jeden PATCH nacherzählt, veraltet an einer Stelle, die niemand pflegt (#318).
 
 **Field name note:** the primary identifier is `id` (sigle), not `textId`. Older docs and some code paths may use `textId` – the canonical field in the index JSON is `id`.
 

--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -335,7 +335,7 @@ The project uses pre-built JSON indexes to avoid runtime XML parsing.
 - `lemmata` is the per-text reverse index (lemma → positions), enables O(1) lookup of "where does lemma X appear in text Y"
 - `lemmaIndex` is the global reverse index (lemma → list of text sigles), enables fast "which texts contain lemma X" queries
 - `lineStarts[]` / `lineEnds[]` (seit 4.1.0): pro Text die Word-Indizes der `<l>`-Boundaries. Gleiche Länge wie die Anzahl `<l>` mit mindestens einem indizierten Wort. Empty arrays für Prosa-Texte ohne `<l>` (67/667 ≈ 10 % des Korpus, Stand 2026-07-31; es waren 64, bis #143 drei Texte auf Prosa umstellte). Enables „Lemma am Versanfang/Versende"-Lookups in O(L) statt O(W).
-  **Messvorschrift für die Verszahl:** 1.356.748 Boundaries über 600 Texte, gezählt als Summe der `lineStarts`-Längen im gebauten Index. Das Korpus selbst trägt 1.358.973 `<l>`; die Differenz sind Verse ohne ein einziges lemmatisiertes Wort, die keine Boundary erzeugen. Beide Zahlen sind richtig, sie messen Verschiedenes.
+  **Messvorschrift für die Verszahl** (Stand 2026-08-02)**:** 1.356.748 Boundaries über 600 Texte, gezählt als Summe der `lineStarts`-Längen im gebauten Index. Das Korpus selbst trägt 1.358.973 `<l>`; die Differenz sind Verse ohne ein einziges lemmatisiertes Wort, die keine Boundary erzeugen. Beide Zahlen sind richtig, sie messen Verschiedenes.
 - 100% word coverage from TEI `<body>` elements (Wörter außerhalb von `<l>` wie `<head>`, `<note>`, `<fw>` zählen in `words[]`, aber matchen keine Vers-Boundary)
 - Supports accurate proximity search + Versposition-Filter
 

--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -335,7 +335,7 @@ The project uses pre-built JSON indexes to avoid runtime XML parsing.
 - `lemmata` is the per-text reverse index (lemma → positions), enables O(1) lookup of "where does lemma X appear in text Y"
 - `lemmaIndex` is the global reverse index (lemma → list of text sigles), enables fast "which texts contain lemma X" queries
 - `lineStarts[]` / `lineEnds[]` (seit 4.1.0): pro Text die Word-Indizes der `<l>`-Boundaries. Gleiche Länge wie die Anzahl `<l>` mit mindestens einem indizierten Wort. Empty arrays für Prosa-Texte ohne `<l>` (67/667 ≈ 10 % des Korpus, Stand 2026-07-31; es waren 64, bis #143 drei Texte auf Prosa umstellte). Enables „Lemma am Versanfang/Versende"-Lookups in O(L) statt O(W).
-  **Messvorschrift für die Verszahl** (Stand 2026-08-02)**:** 1.356.748 Boundaries über 600 Texte, gezählt als Summe der `lineStarts`-Längen im gebauten Index. Das Korpus selbst trägt 1.358.973 `<l>`; die Differenz sind Verse ohne ein einziges lemmatisiertes Wort, die keine Boundary erzeugen. Beide Zahlen sind richtig, sie messen Verschiedenes.
+  **Messvorschrift für die Verszahl (Stand 2026-08-02):** 1.356.748 Boundaries über 600 Texte, gezählt als Summe der `lineStarts`-Längen im gebauten Index. Das Korpus selbst trägt 1.358.973 `<l>`; die Differenz sind Verse ohne ein einziges lemmatisiertes Wort, die keine Boundary erzeugen. Beide Zahlen sind richtig, sie messen Verschiedenes.
 - 100% word coverage from TEI `<body>` elements (Wörter außerhalb von `<l>` wie `<head>`, `<note>`, `<fw>` zählen in `words[]`, aber matchen keine Vers-Boundary)
 - Supports accurate proximity search + Versposition-Filter
 

--- a/docs/TEI-MODEL-AUTH-FILES.md
+++ b/docs/TEI-MODEL-AUTH-FILES.md
@@ -470,7 +470,7 @@ In den Korpus-Headern werden dieselben drei Fest-Slot-Personen (Schmidt, Pütz, 
 </persName>
 ```
 
-Das ist bewusst so: `contributors.xml` ist die kanonische semantische Quelle (mit `@xml:id` als Identität), der Header-Eintrag ist eine serialisierte Darstellung, die der `scripts/_archived/migrate-header-credits.py`-Migration 2026-04-15 aus einer hardcodierten `CANONICAL_AUTHORITY`-Konstante erzeugt hat. Die Konstante steht in der Script-Datei und war das einfachste Ausdrucksmittel, da die Spaltung "Vorname | Nachname" für drei Personen bekannt und stabil war. Die restlichen 48+ Editor:innen haben keinen Header-Eintrag – nur den kollektiven `mhdbdb-team`-Verweis.
+Das ist bewusst so: `contributors.xml` ist die kanonische semantische Quelle (mit `@xml:id` als Identität), der Header-Eintrag ist eine serialisierte Darstellung, die der `scripts/_archived/migrate-header-credits.py`-Migration 2026-04-15 aus einer hardcodierten `CANONICAL_AUTHORITY`-Konstante erzeugt hat. Die Konstante steht in der Script-Datei und war das einfachste Ausdrucksmittel, da die Spaltung "Vorname | Nachname" für drei Personen bekannt und stabil war. Die übrigen Editor:innen haben keinen Header-Eintrag – nur den kollektiven `mhdbdb-team`-Verweis.
 
 **Für zukünftige Tools**, die contributors.xml lesen und strukturierte Namen brauchen (z.B. eine Reader-View-Integration für Lead-Editor-Anzeige): die Plaintext-Form muss am Whitespace gesplittet werden (letztes Token = Nachname), mit Sonder-Behandlung für Präfixe wie "van", "von", etc. Die Fest-Slot-Einträge in der Script-Konstante sind keine verlässliche Quelle für nicht-feste contrib_NNN-IDs.
 

--- a/docs/TEI-MODEL.md
+++ b/docs/TEI-MODEL.md
@@ -868,7 +868,7 @@ Frühere Fehler (alle behoben durch Migration):
 | concepts.xml | 567 Kategorien | tei_all ✓ · mhdbdb-authority ✓ |
 | genres.xml | 615 Kategorien | tei_all ✓ · mhdbdb-authority ✓ |
 | names.xml | 90 Kategorien | tei_all ✓ · mhdbdb-authority ✓ |
-| contributors.xml | 51 Personen + 2 Orgs (project-internal MHDBDB-Team-Register seit #83) | tei_all ✓ · mhdbdb-authority ✓ |
+| contributors.xml | 52 Personen + 2 Orgs (project-internal MHDBDB-Team-Register seit #83) | tei_all ✓ · mhdbdb-authority ✓ |
 
 Migrationsscripts: einmalig in den Phasen F–K ausgeführt, inzwischen in `scripts/_archived/` bzw. Git-Historie nach Abschluss von #32.
 Schema: `schema/mhdbdb-authority.rnc` (Source) → `schema/mhdbdb-authority.rng` (generiert)
@@ -890,9 +890,9 @@ Konsolidierte Liste aller bewusst nicht-normalisierten Daten-Inseln und bekannte
 | Schema-GAPs 1–11 (`schema/mhdbdb.rnc`) | 30 Korpus-Dateien (Kategorien-Tabelle oben) | Bestandsdaten; Migration unverhältnismäßig teuer oder semantisch riskant – dokumentierte Ausnahmen der Daten-vor-Schema-Regel | dauerhaft; jede GAP im Schema kommentiert |
 | ARI/PD-001 Domain-Elemente | 6 ARITHMETIC-Handschriften (noch nicht im Korpus) | 12 Nicht-Schema-Element-Klassen + 24 `div/@type`- + 7 `hi/@rend`-Werte aus Carinas Rechenbüchern; blockieren Stage-2-Validierung | entschieden 2026-05-08: Domain-Tags ins Schema (DECISIONS.md § PD-001); Schema-Erweiterung + Ingest ausstehend → #92 |
 | lexicon.xml-Backfill | Rest 396 dangling Refs / 109 IDs (Kategorie B: Sense-Kuratorik, Kategorie C: Tippfehler/Homographen) | WZB-Forward-Ingest prägte Lemma-IDs nur ins Korpus; Kategorie A (125 Entries) 2026-07-02 per `backfill-lexicon.py` gestubbt | offen → #115 (B/C kuratorisch, KZW/Julia) |
-| WVV Stanza-Anchors | WVV, 23 Stanzen | ungewöhnliches Linecode-Template, Anchors fehlen (#23-Followup) | offen → #110 (depends-on-human) |
+| WVV Stanza-Anchors | WVV, 23 Stanzen | ungewöhnliches Linecode-Template, Anchors fehlen (#23-Followup) | **gelöst** 2026-07-08 (#110) – die 4 offenen Stellen enthielten 11 header-getrennte Versblöcke, jeder ist jetzt eine eigene `<lg type="stanza">`; WVV hat 489 Strophen, Token-Strom byte-identisch |
 | Editorische `<div>`-Hülle | HUG, KLA, PL1–PL3, MBS-Serie | Follow-up aus dem manuellen TEI-Review (#30) | offen → #138 (needs-clarification) |
-| Prosa-Policy `<l>` vs. `<lb/>` | 17 l-kodierte Prosatexte | Phase C2 wandelte 18 Texte; Policy für die verbleibenden ungeklärt | offen → #143 (depends-on-human) |
+| Prosa-Policy `<l>` vs. `<lb/>` | 3 Texte (APO, HMT, HH) | Phase C2 wandelte 18 Texte, für die Restkandidaten war die Policy ungeklärt | **gelöst** 2026-07-03 (#143) – die 3 sind konvertiert, die 17 übrigen Kandidaten sind geprüfte Versdichtung und bleiben `<l>` (§8.1) |
 | WZB `@meaningRef` (historisch) | WZB | Alt-Annotation der Erstlieferung | **gelöst** – zu `@ana` migriert; es verbleibt nur ein `revisionDesc`-Logeintrag |
 
 ---

--- a/docs/TEI-MODEL.md
+++ b/docs/TEI-MODEL.md
@@ -708,7 +708,7 @@ TEI P5 definiert `<l>` als "a single line of **verse**" und nutzt in Kapitel 24 
 | APO | Apollonius (Heinrich Steinhöwel, 1461) | Prosa-Übersetzung (Terrahe-Edition); Verwechslungskandidat war Heinrichs von Neustadt "Apollonius von Tyrland" (Reimquote 4,5%) |
 | HH | Himmel und Hölle | frühmhd. rhythmische Prosa in kurzen Kola, keine Versdichtung (Reimquote 1,1%) |
 
-Die 17 übrigen `<l>`-basierten Kandidaten aus der #143-Heuristik (ALX, DIO, FB, FP, GWTK, MR1, MR2, PSG, PTS, RUD, TKA, TKR, WH, WLE, WRB) wurden inhaltlich geprüft (Reimprobe 18-36%, Wortdichte) und sind Versdichtung – `<l>` bleibt dort korrekt.
+Die #143-Heuristik nannte 17 Kandidaten. Zwei davon (APO, HMT) stehen in der Tabelle darüber und sind konvertiert; die 15 übrigen (ALX, DIO, FB, FP, GWTK, MR1, MR2, PSG, PTS, RUD, TKA, TKR, WH, WLE, WRB) wurden inhaltlich geprüft (Reimprobe 18-36%, Wortdichte) und sind Versdichtung – `<l>` bleibt dort korrekt. (Die Zahl stand hier bis 2026-08-02 auf 17, also auf der Größe der Kandidatenliste statt auf der des Rests; die Siglenliste war immer 15 lang. HH kam nicht aus dieser Heuristik.)
 
 **Zu migrieren (`<l>` → `<lb/>`):** 18 Dateien
 
@@ -892,7 +892,7 @@ Konsolidierte Liste aller bewusst nicht-normalisierten Daten-Inseln und bekannte
 | lexicon.xml-Backfill | Rest 396 dangling Refs / 109 IDs (Kategorie B: Sense-Kuratorik, Kategorie C: Tippfehler/Homographen) | WZB-Forward-Ingest prägte Lemma-IDs nur ins Korpus; Kategorie A (125 Entries) 2026-07-02 per `backfill-lexicon.py` gestubbt | offen → #115 (B/C kuratorisch, KZW/Julia) |
 | WVV Stanza-Anchors | WVV, 23 Stanzen | ungewöhnliches Linecode-Template, Anchors fehlen (#23-Followup) | **gelöst** 2026-07-08 (#110) – die 4 offenen Stellen enthielten 11 header-getrennte Versblöcke, jeder ist jetzt eine eigene `<lg type="stanza">`; WVV hat 489 Strophen, Token-Strom byte-identisch |
 | Editorische `<div>`-Hülle | HUG, KLA, PL1–PL3, MBS-Serie | Follow-up aus dem manuellen TEI-Review (#30) | offen → #138 (needs-clarification) |
-| Prosa-Policy `<l>` vs. `<lb/>` | 3 Texte (APO, HMT, HH) | Phase C2 wandelte 18 Texte, für die Restkandidaten war die Policy ungeklärt | **gelöst** 2026-07-03 (#143) – die 3 sind konvertiert, die 17 übrigen Kandidaten sind geprüfte Versdichtung und bleiben `<l>` (§8.1) |
+| Prosa-Policy `<l>` vs. `<lb/>` | 3 Texte (APO, HMT, HH) | Phase C2 wandelte 18 Texte, für die Restkandidaten war die Policy ungeklärt | **gelöst** 2026-07-03 (#143) – die 3 sind konvertiert, die übrigen Kandidaten sind geprüfte Versdichtung und bleiben `<l>` (§8.1) |
 | WZB `@meaningRef` (historisch) | WZB | Alt-Annotation der Erstlieferung | **gelöst** – zu `@ana` migriert; es verbleibt nur ein `revisionDesc`-Logeintrag |
 
 ---

--- a/hilfe-daten.html
+++ b/hilfe-daten.html
@@ -246,7 +246,7 @@
                 </li>
                 <li>
                     <strong>contributors.xml</strong> <span class="text-slate-500">(intern)</span> –
-                    Register der MHDBDB-Mitwirkenden (51 Personen + 2 Organisationen). Dient
+                    Register der MHDBDB-Mitwirkenden (52 Personen + 2 Organisationen). Dient
                     der Editor-Attribution in den TEI-Headern und wird nicht über die Suche
                     zugänglich gemacht.
                 </li>

--- a/scripts/audit/doc-count-audit.py
+++ b/scripts/audit/doc-count-audit.py
@@ -93,7 +93,7 @@ NUMERIC_SCAN_MIN = 100
 # Die Absenkung gilt KEY-GLOBAL, nicht pro (Datei, Key): kommt der Key spaeter
 # in einem zahlenreichen Target dazu (INDEX.md, ROADMAP.md), waechst die
 # Fehlalarmflaeche still mit. Dann pro Target entscheiden statt hier absenken.
-SCAN_MIN_OVERRIDE = {'names': 50}
+SCAN_MIN_OVERRIDE = {'names': 50, 'contributors_persons': 50}
 
 # min_digits (find_stale_numbers) koppelt die Stellenzahl an diese Schwelle
 # und kennt nur zwei- oder dreistellig. Ein Override unter 10 waere still
@@ -190,14 +190,16 @@ LABELS = [
 # actual current value — when found, that means the doc is stale.
 DOC_TARGETS = [
     ('docs/TEI-MODEL.md', ['corpus_files', 'lexicon_entries', 'works', 'persons',
-                            'concepts', 'genres', 'names', 'variants_entries', 'variants_forms']),
+                            'concepts', 'genres', 'names', 'variants_entries', 'variants_forms',
+                            'contributors_persons']),
     ('docs/INDEX.md', ['corpus_files']),
     ('docs/ROADMAP.md', ['corpus_files']),
     # Beide tragen undatierte Ist-Angaben zu variants.xml und standen bis
     # 2026-07-28 nicht im Audit; sie blieben deshalb bei 256.761 stehen.
     ('docs/DATA-MODEL.md', ['variants_forms', 'variants_entries', 'variants_normalized',
                             'works']),  # works: #293 hat die 584 in Prosa gebracht
-    ('docs/TEI-MODEL-AUTH-FILES.md', ['variants_forms', 'variants_entries']),
+    ('docs/TEI-MODEL-AUTH-FILES.md', ['variants_forms', 'variants_entries',
+                                       'contributors_persons']),
     # CONTRACTS.md:315 beschreibt den Ist-Aufbau des Variants-Dictionary; der
     # Datumsstempel dort macht die Zeile nicht historisch.
     ('docs/CONTRACTS.md', ['variants_forms', 'variants_normalized']),
@@ -364,6 +366,12 @@ NEAR_KEYWORDS = {
     'concepts': r'(?:Konzepte|Begriffe|Kategorien)',
     'genres': r'(?:Gattungen|Kategorien)',
     'names': r'(?:Namen|Kategorien)',
+    # Der Wert wurde schon berechnet, war aber in keinem DOC_TARGETS-Eintrag
+    # eingetragen: docs/TEI-MODEL.md stand deshalb still auf 51, waehrend
+    # TEI-MODEL-AUTH-FILES.md 52 fuehrte (#315 Punkt 4). Kollision mit dem
+    # gleichnamigen Anker von 'persons' (211) gibt es nicht: das Drift-Fenster
+    # ist +-2 um 52.
+    'contributors_persons': r'Personen',
 }
 
 

--- a/scripts/audit/doc-count-audit.py
+++ b/scripts/audit/doc-count-audit.py
@@ -83,9 +83,10 @@ NUMERIC_SCAN_MIN = 100
 
 # Ausnahmen von NUMERIC_SCAN_MIN (#297 Punkt 1). Die 100er-Schwelle schuetzt
 # gegen Tabellenindizes, Prozente und Abschnittsnummern; sie macht das Audit
-# aber blind fuer jede Datenzahl darunter. names.xml ist die einzige
+# aber blind fuer jede Datenzahl darunter. names.xml war die erste
 # doc-gepruefte Authority-Datei unter der Schwelle (90 Kategorien) und stand
-# damit still in docs/TEI-MODEL.md. Zulaessig ist die Absenkung nur bei einem
+# damit still in docs/TEI-MODEL.md; contributors.xml (52) kam 2026-08-02 aus
+# demselben Grund dazu. Zulaessig ist die Absenkung nur bei einem
 # Key, dessen Anker die Zahl eng bindet und dessen Drift-Fenster klein bleibt:
 # bei 90 sind das +-2, es werden also nur 88 bis 92 mit direkt folgendem
 # "Kategorien" oder "Namen" gemeldet.
@@ -246,7 +247,8 @@ DOC_TARGETS = [
     # dort 256.761 stehen, waehrend #138 alle anderen Seiten auf 256.760 zog.
     ('index.html', ['corpus_files', 'lexicon_entries', 'variants_forms']),
     ('hilfe-daten.html', ['corpus_files', 'lexicon_entries',
-                          'variants_forms', 'variants_normalized']),
+                          'variants_forms', 'variants_normalized',
+                          'contributors_persons']),
     ('hilfe-korpussuche.html', ['variants_normalized']),
     ('hilfe-playground.html', ['variants_normalized']),
     ('hilfe-daten-beitragen.html', ['variants_forms']),


### PR DESCRIPTION
Arbeitet die mechanischen Restposten aus #315 und #318 ab. Beide Issues bleiben offen, weil je ein Punkt eine fachliche Antwort braucht.

## #315: zwei erledigte Ausnahmen und eine falsche Zahl

**§10 führte zwei geschlossene Issues als offen.** `#110` (WVV-Stanza-Anchors, geschlossen 2026-07-08) und `#143` (Prosa-Policy, geschlossen 2026-07-03). Die `#143`-Zeile widersprach dabei §8.1 derselben Datei: dort stehen die 17 Restkandidaten seit der Prüfung als bestätigte Versdichtung, in §10 standen sie als „Policy ungeklärt".

**contributors.xml: 51 gegen 52.** Gemessen mit `doc-count-audit.py`: 52 Personen + 2 Orgs. `TEI-MODEL-AUTH-FILES.md` führte den richtigen Wert, `TEI-MODEL.md` nicht.

**Warum das unsichtbar bleiben konnte, und was dagegen getan ist.** Der Wert wird von `doc-count-audit.py` seit jeher berechnet, war aber in keinem `DOC_TARGETS`-Eintrag gebunden. Er ist jetzt für `docs/TEI-MODEL.md` und `docs/TEI-MODEL-AUTH-FILES.md` eingetragen, mit Anker `Personen` und abgesenkter Scan-Schwelle (52 liegt unter der 100er-Grenze).

Durch Mutation belegt, nicht behauptet:

| Zustand | Audit |
|---|---|
| `52 Personen` (Ist) | `No drift detected` |
| auf `51 Personen` zurückgedreht | `Total potential drift hits: 1` |

Keine Kollision mit dem gleichnamigen Anker von `persons` (211): das Drift-Fenster ist ±2 um 52.

## #318 Punkt 7: ein Changelog in einem Schema-Dokument

`DATA-MODEL.md` trug acht aufeinanderfolgende „Why vX?"-Absätze. Die Kette endete bei v4.1.5, ausgeliefert wird v4.2.1, und `TEI-MODEL.md` §11 erklärt sich ausdrücklich zur Source of Truth für Index-Versionen.

Entfernt sind die reinen Changelog-Einträge (v4.0.1, v4.1.1 bis v4.1.5). Geblieben sind die zwei Absätze, die den Entwurf begründen statt einen Bump nachzuerzählen: v4.0.0 (warum Document-Level statt Paragraph-Indexing) und v4.1.0 (warum `lineStarts`/`lineEnds` eine MINOR-Erweiterung waren). Dazu ein Zeiger auf die drei Orte, an denen die Historie tatsächlich gepflegt wird: der Kommentar an der `'version'`-Konstante in `build-corpus-index.py`, `TEI-MODEL.md` §11, und die Git-Historie.

Die Versions-Etiketten `(v4.1.x)` an Größenangabe und Feature-Liste sind weg, sie waren der Grund, warum der Abschnitt eingefroren wirkte.

## Eine Messvorschrift statt einer korrigierten Zahl

Beim Nachmessen der Verszahl kam zunächst 1.358.973 heraus, in der Doku stehen 1.356.748. Das ist kein Drift, sondern eine andere Zählweise:

| Messung | Wert |
|---|---|
| Summe der `lineStarts`-Längen im gebauten Index | 1.356.748 über 600 Texte |
| `<l>`-Elemente im Korpus, roh gezählt | 1.358.973 über 600 Texte |

Die Differenz sind Verse ohne ein einziges lemmatisiertes Wort: sie erzeugen keine Boundary. Beide Zahlen sind richtig, sie messen Verschiedenes. Die Vorschrift steht jetzt daneben, sonst „korrigiert" der nächste Durchgang die richtige Angabe in eine falsche. Gleiches Muster wie bei den Breve-Zahlen in CONTRACTS §A (#318) und den zwei Variantenzahlen (#279).

## Was offen bleibt

- **#315 Punkt 2 (Lead-Editor):** drei Varianten, keine stimmt. `TEI-MODEL.md` §2.1bis nennt vier Texte, `INDEX.md` fünf, im Korpus tragen sechs Dateien `role="lead-editor"` (JT, PUC, TKA, TKR, VTC, WZB, nachgezählt). Ob WZB als Lead-Editor-Text gewollt ist, entscheidet, ob die Tabelle auf sechs geht oder die Datei korrigiert wird. Das ist eine fachliche Frage an @wachauer und @juliahin, kein Nachziehen.
- **#316** (INDEX.md entrümpeln) ist nicht Teil dieses PR: der Löwenanteil ist Streichen, aber die Sprachfrage darin ist eine Entscheidung.
