### PR TITLE
#172: Korpusabhaengige Zahlen aus dem Tabellen-Test entfernt

### DIFF
--- a/testing/tests/results-table.spec.js
+++ b/testing/tests/results-table.spec.js
@@ -89,13 +89,16 @@ test.describe('Issue #114: Tabellenansicht für Korpussuche', () => {
         expect(spalte, 'Treffer-Spalte im Header gefunden').toBeGreaterThan(0);
 
         // toLocaleString('de-DE') setzt Tausenderpunkte, die vor dem Parsen weg
-        // müssen. Der Finite-Test ist kein Schmuck: bei nicht-numerischem Text
-        // gäbe es lauter NaN, und ein NaN-Array ist gegen seine eigene Sortierung
-        // grün (toEqual behandelt NaN als gleich).
-        const treffer = (await page.locator(`#resultsList tbody tr td:nth-child(${spalte})`).allTextContents())
-            .map(t => Number(t.trim().replace(/\./g, '')));
-        expect(treffer.length, 'Zeilen in der Tabelle').toBeGreaterThan(1);
-        expect(treffer.every(Number.isFinite), `Treffer-Spalte numerisch: ${treffer.slice(0, 5)}`).toBe(true);
+        // müssen. Geprüft wird die Rohzelle, nicht die geparste Zahl: eine
+        // Zusicherung, die nur auf Number.isFinite schaut, hielte lauter leere
+        // Zellen für gültig, weil Number('') gleich 0 ist. Ein Array aus lauter
+        // Nullen wäre dann gegen seine eigene Sortierung grün, und der Test
+        // hinge an der falschen Spalte, ohne es zu merken.
+        const zellen = (await page.locator(`#resultsList tbody tr td:nth-child(${spalte})`).allTextContents())
+            .map(t => t.trim());
+        expect(zellen.length, 'Zeilen in der Tabelle').toBeGreaterThan(1);
+        expect(zellen.every(t => /^\d{1,3}(\.\d{3})*$/.test(t)), `Treffer-Spalte numerisch: ${zellen.slice(0, 5)}`).toBe(true);
+        const treffer = zellen.map(t => Number(t.replace(/\./g, '')));
         expect(treffer).toEqual([...treffer].sort((a, b) => b - a));
 
         // Klick Titel-Header und prüfe absteigende Sortierung.

--- a/testing/tests/results-table.spec.js
+++ b/testing/tests/results-table.spec.js
@@ -34,8 +34,18 @@ test.describe('Issue #114: Tabellenansicht für Korpussuche', () => {
         // Toggle auf Tabelle
         await page.click('#viewToggleTable');
         await expect(page.locator('#resultsList table')).toHaveCount(1);
-        // 140 Treffer für "minne" — passe an, falls Korpus wächst
-        await expect(page.locator('#resultsList table tbody tr')).toHaveCount(140);
+        // #172: Render-Parität statt Absolutzahl. Vorher stand hier
+        // `toHaveCount(140)`, also die Zahl der minne-Texte zum Zeitpunkt des
+        // Schreibens. Das Korpus ist nicht eingefroren (laufender Ingest plus
+        // händische Korrekturen), der Test wäre also beim nächsten Ingest mit
+        // minne-Belegen rot geworden, ohne dass am Rendering etwas kaputt ist.
+        // Geprüft wird jetzt, was der Test meint: die Tabelle zeigt jeden
+        // Treffer der Suche, keinen mehr und keinen weniger. Die Gesamtzeile
+        // liegt im tfoot und zählt hier nicht mit.
+        const trefferzahl = await page.evaluate(
+            () => window._mhdbdbApp.currentResults.length);
+        expect(trefferzahl).toBeGreaterThan(0);
+        await expect(page.locator('#resultsList table tbody tr')).toHaveCount(trefferzahl);
     });
 
     test('localStorage persistiert View-Wahl über Reload', async ({ page }) => {
@@ -61,7 +71,9 @@ test.describe('Issue #114: Tabellenansicht für Korpussuche', () => {
         await page.click('#viewToggleTable');
         await page.waitForSelector('#resultsList table');
 
-        // Default: matchCount desc; JT (612 Treffer) sollte oben sein
+        // Default: matchCount desc, JT hat die meisten minne-Belege im Korpus.
+        // Die Zahl stand hier bis #172 daneben und war eine zweite Stelle, die
+        // mit jedem Ingest altert, ohne dass die Aussage sie braucht.
         const firstRowSigle = await page.locator('#resultsList tbody tr').first().locator('.font-mono').textContent();
         expect(firstRowSigle?.trim()).toMatch(/^JT$/);
 

--- a/testing/tests/results-table.spec.js
+++ b/testing/tests/results-table.spec.js
@@ -71,11 +71,32 @@ test.describe('Issue #114: Tabellenansicht für Korpussuche', () => {
         await page.click('#viewToggleTable');
         await page.waitForSelector('#resultsList table');
 
-        // Default: matchCount desc, JT hat die meisten minne-Belege im Korpus.
-        // Die Zahl stand hier bis #172 daneben und war eine zweite Stelle, die
-        // mit jedem Ingest altert, ohne dass die Aussage sie braucht.
-        const firstRowSigle = await page.locator('#resultsList tbody tr').first().locator('.font-mono').textContent();
-        expect(firstRowSigle?.trim()).toMatch(/^JT$/);
+        // Default ist matchCount desc. Bis #172 stand hier die Sigle JT samt
+        // ihren 612 Treffern, also eine korpusabhängige Tatsache als
+        // Stellvertreter für die Sortierung: wächst ein anderer Text beim
+        // nächsten Ingest an minne-Belegen vorbei, wird der Test rot, ohne dass
+        // an der Sortierung etwas kaputt ist. Geprüft wird jetzt die Sortierung
+        // selbst, analog zum Titel-Block darunter.
+        //
+        // Der Spaltenindex kommt aus dem Header, nicht als Konstante: die
+        // Spalten sind seit #160 datengetrieben (RESULT_TABLE_COLUMNS in
+        // app.js), ein Umbau dort würde eine feste 3 still auf die falsche
+        // Spalte zeigen lassen.
+        const spalte = await page.evaluate(() => {
+            const ths = [...document.querySelectorAll('#resultsList table thead th')];
+            return ths.findIndex(th => th.querySelector('[data-sort-col="matchCount"]')) + 1;
+        });
+        expect(spalte, 'Treffer-Spalte im Header gefunden').toBeGreaterThan(0);
+
+        // toLocaleString('de-DE') setzt Tausenderpunkte, die vor dem Parsen weg
+        // müssen. Der Finite-Test ist kein Schmuck: bei nicht-numerischem Text
+        // gäbe es lauter NaN, und ein NaN-Array ist gegen seine eigene Sortierung
+        // grün (toEqual behandelt NaN als gleich).
+        const treffer = (await page.locator(`#resultsList tbody tr td:nth-child(${spalte})`).allTextContents())
+            .map(t => Number(t.trim().replace(/\./g, '')));
+        expect(treffer.length, 'Zeilen in der Tabelle').toBeGreaterThan(1);
+        expect(treffer.every(Number.isFinite), `Treffer-Spalte numerisch: ${treffer.slice(0, 5)}`).toBe(true);
+        expect(treffer).toEqual([...treffer].sort((a, b) => b - a));
 
         // Klick Titel-Header und prüfe absteigende Sortierung.
         // Sortierung im App-Code basiert NUR auf r.title (nicht auf textId);


### PR DESCRIPTION
Schließt #172. Der Ticket-Titel nennt zwei Stellen, faktisch ist nur eine übrig: der 45-%-passRate-Floor lebte in `testing/tests/playground.spec.js:47` und ist mit #326 weggefallen, als das Eigenbau-Framework `testing/test.html` entfernt wurde. Geblieben war die harte Trefferzahl im Tabellen-Test.

## Was sich ändert

Drei Commits, alle in `testing/tests/results-table.spec.js`, kein Produktivcode:

1. **Render-Parität statt `toHaveCount(140)`.** Die 140 war die Zahl der minne-Texte zum Zeitpunkt des Schreibens. Geprüft wird jetzt, was der Test meint: die Tabelle rendert genau die Treffer der Suche, also `tbody tr` gegen `window._mhdbdbApp.currentResults.length`. Die Gesamtzeile liegt im `tfoot` und zählt nicht mit. Dazu `toBeGreaterThan(0)`, damit die Gleichung nicht bei null Treffern tautologisch grün wird.

2. **Sortier-Test prüft die Sortierung, nicht die Sigle JT.** Er behauptete „Default ist matchCount desc" und prüfte dafür, dass in der ersten Zeile JT steht, also dieselbe Fehlerklasse in Textform. Jetzt wird die Treffer-Spalte selbst auf absteigende Ordnung geprüft, symmetrisch zum Titel-Block im selben Test. Der Spaltenindex kommt aus dem Header (`[data-sort-col="matchCount"]`) statt als Konstante, weil die Spalten seit #160 datengetrieben sind.

3. **Guard prüft die Rohzelle statt der geparsten Zahl.** Ein Guard über `Number.isFinite` hätte lauter leere Zellen für gültig gehalten, weil `Number('')` gleich 0 ist, und ein Null-Array ist gegen seine eigene Sortierung grün.

## Gegenproben

Jede der drei Zusicherungen wurde gegen einen eingebauten Fehler gehalten, nicht nur grün gesehen:

| Verstimmung | Ergebnis |
|---|---|
| `currentResults.length + 1` | rot, `toHaveCount` schlägt an |
| Sortierrichtung `a - b` statt `b - a` | rot, `toEqual` schlägt an |
| Spaltenindex fest auf die Titel-Spalte | rot, Guard nennt den Zelleninhalt |

Ohne Verstimmung: voller Spec-Lauf 14 passed, `expected 14, unexpected 0, flaky 0`.

## Review

Lokal drei Runden `fable-reviewer` vor dem ersten Push. Runde 1 ohne Befund, mit dem Hinweis auf die JT-Zusicherung, aus dem Commit 2 wurde. Runde 2 fand den `Number('')`-Fehlschluss (Klasse B, nachgemessen und übernommen), daraus wurde Commit 3. Runde 3 ohne Befund.
