### PR TITLE
#316: Chronik-Tabelle und Feature-Katalog aus den Doku-Einstiegen entfernt

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -126,7 +126,8 @@ Aktuelle Index-Versionen siehe [TEI-MODEL.md §11](TEI-MODEL.md#11-versionierung
 
 - **[JOURNAL.md](JOURNAL.md)** – chronologisch, mit Begründungen und Sackgassen; die Volltexte
   der verdichteten Einträge liegen in [journal-archive.md](journal-archive.md)
-- **[ROADMAP.md](ROADMAP.md) → Recently Completed** – mit Einordnung in die laufenden Prioritäten
+- Die [ROADMAP.md](ROADMAP.md) führt seit 2026-08-02 keine eigene Chronik mehr (#316); sie sagt,
+  was ansteht, und ordnet Laufendes ein.
 
 ### Known Limitations
 - Desktop-only interface (not mobile-responsive)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -37,9 +37,10 @@ The **playground** is for analysis: explorers for the authority files (persons, 
 lemmata, concepts, genres, names) and the TEI analysis tools, from multi-lemma
 proximity search to the rhyme dictionary.
 
-The complete and maintained list, with counts, examples and issue references, is
-[FEATURES.md](FEATURES.md). It was duplicated here until 2026-08-02, and the copy was
-the one that went stale (#316).
+The complete list, with counts, examples and issue references, is
+[FEATURES.md](FEATURES.md). It was duplicated here until 2026-08-02. The copy happened
+to be accurate, but a second catalogue is a second place to keep in step with every new
+tool, and #316 asked to stop paying that twice.
 
 ## Technical Stack
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -26,33 +26,20 @@ The project migrated from runtime XML parsing to pre-built JSON indexes because 
 
 ## Core Features
 
-### Main Site (Public Interface)
-Simple search and reading interface optimized for students and general users:
+Two interfaces over the same corpus.
 
-- **Single Lemma Search** - Search across corpus with Middle High German character normalization
-- **KWIC-Belege** - Pro Treffer ausklappbare Keyword-in-Context-Konkordanz mit Vers-/Zeilenangabe, Sprung zur Fundstelle (#129) und CSV-Export aller Fundstellen eines Texts (#203)
-- **Tabellenansicht** - Umschaltbare Ergebnis-Tabelle (sortierbar) mit Gesamtzeile, Keyness-Spalte (Log-Likelihood), Types + Wörterbuch-Links im Lemma-Panel sowie TSV-/CSV-Export (#114)
-- **Text Selection** - Include/exclude texts via checkbox interface with live filtering
-- **Reading View** - Full-text reader with:
-  - Multi-lemma highlighting (5 colors for concurrent searches)
-  - Rich metadata panel with Wikidata integration
-  - Context navigation (jump between occurrences)
-  - Separate work vs author identifiers (GND/Wikidata)
-- **Variant Resolution** - Automatic mapping of orthographic variants via variants.xml
-- **Wörterbuch** - A–Z-Einstiegsseite (`woerterbuch.html`) zu allen 43.879 Lemma-Seiten mit Indexleiste, Pagination und Deep-Links (#117)
+The **main site** is for search and reading: lemma search with Middle High German
+normalization, KWIC concordances per hit, a sortable results table with keyness and
+export, a reading view with multi-lemma highlighting and a metadata panel, and an
+A–Z register of all lemma pages.
 
-### Playground (Research Interface)
-Advanced exploration tools for medievalists and digital humanities researchers:
+The **playground** is for analysis: explorers for the authority files (persons, works,
+lemmata, concepts, genres, names) and the TEI analysis tools, from multi-lemma
+proximity search to the rhyme dictionary.
 
-- **18 Search Entry Points** - 6 authority file explorers + 12 TEI analysis tools
-- **Multi-Lemma Search** - Find texts containing multiple lemmata with:
-  - Document-level search (all lemmata anywhere in text)
-  - Proximity search (co-occurrence within N words)
-  - Same-verse search (co-occurrence within a single verse line, #106)
-  - 3-stage lemma resolution (exact match → variants → prefix match in both directions, #224)
-  - Color-coded results with clickable navigation to reading view
-- **Authority Exploration** - Browse and search persons, works, lemmata, concepts, genres, names; the Lemmata explorer additionally offers a word-component mode for compound research, grouped by position of the component (#239)
-- **TEI Analysis** - Twelve analysis tools over the pre-loaded MHDBDB corpus: multi-lemma search (document + proximity + same-verse), verse-position lemma search, word frequency, corpus-wide hapax legomena, text statistics, lemma distribution, concept distribution, text comparison, co-occurrence ranking, rhyme dictionary, verse-ending profile, curated character-naming explorer (4 works, Beta)
+The complete and maintained list, with counts, examples and issue references, is
+[FEATURES.md](FEATURES.md). It was duplicated here until 2026-08-02, and the copy was
+the one that went stale (#316).
 
 ## Technical Stack
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -109,7 +109,7 @@ Diese Datei blickt nach vorne. Was abgeschlossen ist, steht chronologisch und mi
 Begründungen im [JOURNAL.md](JOURNAL.md), ältere Einträge in
 [journal-archive.md](journal-archive.md). Bis zum 02.08.2026 stand hier
 zusätzlich eine Tabelle „Recently Completed": sie reichte bis April zurück,
-endete aber am 08.07., während seither 60 PRs gemergt wurden. Eine zweite
+endete aber am 08.07., während seither 80 PRs gemergt wurden. Eine zweite
 Chronik neben dem JOURNAL zu führen hat nicht funktioniert und wurde deshalb
 aufgegeben (#316).
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Strategic priorities for the MHDBDB TEI Repository. Updated 2026-07-31.
+Strategic priorities for the MHDBDB TEI Repository. Updated 2026-08-02.
 
 See [Issue #44](https://github.com/DigitalHumanitiesCraft/mhdbdb-tei-only/issues/44) for the full triage matrix with per-issue status.
 
@@ -103,67 +103,15 @@ Beides derselbe Fehlertyp: die ROADMAP beschreibt den Stand eines Dokuments stat
 | #109 | FWF-Einzelprojekt (Korpus-Tiefenanalyse, NER-Pipeline, phonetische Reimanalyse, Visualisierungen) – Antrag durch KZW, kleines Budget, max. 50% externe Mittel | Scope-Notiz für Antragstext |
 | #111 | Index-Größen-Soft-Cap und modulare Splitting-Strategie | Trigger >50 MB gz (heute ~40); Optionen A modular / B brotli / C binär; keine Entscheidung bis Schwellwert erreicht |
 
-## Recently Completed
+## Fertiges steht im JOURNAL
 
-| # | What |
-|---|------|
-| ~~Merge-Session 08.07.~~ | 13 PRs #174–#186 auf main (Kette A #174→#175→#178→#184, Kette B #177→#183, unabhängig #176/#179/#180/#181/#182/#185, zuletzt #186). Schließt #163 #164 #159 #168 #158 #162 #160 #161 #134 #145 #27 #167 #170. Authority-Index v1.6.0 (posAll[]) live, Cache-Bust + Smoke-Checks Chrome-verifiziert. CI-Lehren (Retarget/Rerun-Payload) im JOURNAL. |
-| ~~#106~~ | Reim-Wörterbuch Minimalvariante (2026-07-02): Zehntes TEI-Analyse-Werkzeug `#rhyme-dictionary` – Reimpartner-Lemmata an benachbarten Versenden (`lineEnds[]`-Scan, Suffix-3-Heuristik auf normalisierten Formen, 2-Letter bei Kurzwörtern), optionaler Text/Autor-Filter, „→ Belege"-Link in Multi-Lemma-Nähe-Suche. Kein neuer Build-Schritt. Punkte 2-7 bleiben in #109 (FWF), Punkt 8 im Multi-Lemma-Backlog. |
-| ~~#114-Followups~~ | Integrationswünsche Tabellenansicht (2026-07-02): Gesamtzeile mit Gesamttrefferzahl (sticky tfoot + „M Treffer gesamt" im Header), Types/Schreibformen + MWB/Lexer-Links im Lemma-Panel (Wörterbuchnetz-API), Keyness-Spalte (signierte Log-Likelihood Text vs. Gesamtkorpus, fett ab 10,83) inkl. Export-Spalte. |
-| ~~#45~~ | Static JSON API (2026-06-12): FAIR-orientierte JSON-API unter `/api/` (2.742 Dateien, ~14 MB), deterministischer Build (`scripts/build-api.py`) + CI-Freshness-Gate, Doku-Seite `api/index.html`; PR #150 gemerged (Closes #45). |
-| ~~#113-Followup~~ | KZW-Synonym-Match in Begriffs-Verteilung + Begriffe-Explorer (2026-05-28, commit `f7c8592c2`): Last-Wins-Bug in `parse_concepts()` gefixt (Primär-Term wurde von Alternative überschrieben, z.B. concept_13023100 zeigte „Früchte" statt „Obst"). Authority-Index v1.2.2 → v1.3.0 mit additiven Feldern `altDE[]`/`altEN[]`/`altNormalized[]` (263/567 Concepts mit deutschem Synonym). Beide UI-Module matchen Synonyme zusätzlich und zeigen „auch: …"-Hint im Autocomplete. Chrome-verifiziert mit „obs"/„frü"/„Wahnsinn-Tobsucht". |
-| ~~#113~~ | Autocomplete im Begriffs-Verteilung-Input (2026-05-15, commit `a2e7b0b36`): klassisches Dropdown unter dem Input mit max. 8 Concept-Suggestions, Pfeil-Navigation (ArrowDown/Up), Enter wählt + sucht, Escape schließt, Klick (mousedown vor blur) wählt + sucht. Reuse `resolveQuery()` als Suggestions-Quelle. ARIA: combobox/listbox/aria-selected/aria-expanded. Live-verifiziert: „ster" → Sterben + Bruderschaft. |
-| ~~#107~~ | Kookkurrenz-Ranking (2026-05-15, commit `70d0bf280`): DWDS-Style „Welche Lemmata stehen am häufigsten bei X?". Window-Scan über `text.words[pos±w]` für jede Position in `text.lemmata[X]`. POS-Filter (Inhaltswörter / NOM / VRB / ADJ / alle) essentiell weil ohne Filter Stopwords dominieren. `êre` (9.930 Vorkommen, 6.361 Partner): 1.002ms inkl. UI-Render dank MessageChannel-Yield-Chunking. POS-Filter-Switch ohne Re-Compute: ~15ms (rawCounts gecacht). Belege-Klick → Multi-Lemma-Suche mit beiden Lemmata vorbefüllt. |
-| ~~#108~~ | Textvergleich (2026-05-15, commit `c53a8ac0d`): Zwei Texte auswählen → drei Lemma-Mengen (Nur A / Beide / Nur B) mit Frequenz pro Text und absoluter Differenz. Reine Set-Ops auf `Object.keys(text.lemmata)`, keine neuen Index-Felder. Lokale `_lemmaMap` (einmal pro `show()` gebaut) reduziert 6s Click-Latenz auf 53ms (112× schneller) – `AuthorityFilesManager.findLemmaById()` ist O(N) linear. Verifiziert PZ vs JT: „triuwe" 447× nur in JT (Lemmatisierungs-Unterschied Wolfram/Albrecht). |
-| ~~#112~~ | Versposition-Klick-Highlight-Bug (2026-05-15, commit `131fed17b`): `verse-position-search.js` + `lemma-distribution.js` bauten Reader-URLs mit `lemmaIds=5567` (cleanId), Highlighter sucht jedoch `#${id}` in `lemmaRef="lexicon.xml#lemma_5567"` – `#5567` matcht nicht. Fix: URL-Param erhält volle Form `lemma_5567`. Live-verifiziert (76 + 140 URLs jeweils mit korrektem Prefix; 4 Highlights für `lemma_5567` in AXW). |
-| ~~#104~~ | Sigle-Titel-Differenzierung (2026-05-15, commit `c0b546a45`): PL1-3, FLG/FLG1, FR1-3 bekommen sprechende Anzeigetitel mit Edition + Datum. FLG-`<biblStruct>` umgestellt auf Neumann/Vollmann-Profe 1990 (Edition) + Harsch 2009 (digitalIntermediary). Index-Bump corpus 4.1.2 / authority 1.2.2. KZW-Wording wortgleich; 130/131 Tests grün, Chrome-UI verifiziert |
-| ~~#81~~ | Sprachstufen-Differenzierung (closed 2026-05-15): SAL/SAT/BAR/TUN waren Wikidata-Fehler (`gmh` bleibt). AC1-3 (Ackermann aus Böhmen) bleiben ebenfalls `gmh` – KZW-Entscheidung 2026-05-08: solange kein ISO-Code für Frühneuhochdeutsch existiert, ist `gmh` die TEI-konformste Lösung. 537 unerforschte Texte als eigener Task ausgelagert (nicht angelegt – nicht in Plan) |
-| ~~#47~~ | TEI Textanalyse Umbrella geschlossen (2026-05-12): R1 (#87-90) und R2-Hauptpunkt Begriffs-Verteilung shipped; Folgepunkte ausgelagert in #107 (Kookkurrenz-Ranking), #108 (Textvergleich), #106 (Vers-Boundary-Features, Punkt 1 als Rolling-Backlog), #109 (FWF-Projekt für NER + tiefere Analysen) |
-| ~~#47 R2~~ | Begriffs-Verteilung (2026-05-12): Neuer Playground-Eintrag analog Lemma-Verteilung (#90), aber concept-basiert. Datenpfad concept → senses → lemmata → texts. Verifiziert mit „Sterben" (682 Lemmata, 659 Texte, 103.657 Vorkommen) und „love" (Intimität mit Candidates) |
-| ~~#47.3~~ | Lemmasuche nach Versposition (2026-05-12): Neuer Playground-Eintrag unter Multi-Lemma-Suche, findet Lemmata am Versanfang/Versende. Corpus-Index v4.1.0 mit `lineStarts[]`/`lineEnds[]` (1,359,789 `<l>` über 603 Versdichtungs-Texte, +6 MB gz). KZW-Wording wortgleich; Chrome-verifiziert (Reimpaare gân/begân, bant/bekant am Versende von AGS) |
-| ~~#105~~ | Authority-Files-Counter (2026-05-12): Stats-Block auf Startseite von 7 → 8 angeglichen; Playground-Loader-Status bleibt bei 7 (technisch korrekt, `contributors.xml` nicht im authority-index) |
-| #73 (shipped, Issue offen) | Lemma-Linking MWB + Lexer (2026-05-12): MWB-Block über Wörterbuchnetz-API (`/dictionaries/MWB/lemmata/{form}`) statt POST-only-Suchformular; Dictionary-Loop für beide Wörterbücher, Section nur sichtbar wenn min. 1 Treffer. Julias initialer Suchlink (`05c8676a4`) war defekt. **Issue bleibt OPEN** (needs-clarification: MWB-API noch unvollständig, KZW-Rückfrage bei Recker-Hamm offen) |
-| ~~#101~~ | Reading-View-Render-Policy (2026-05-12, Julia): `milestone[@unit="verse"]` → `<span class="verse-marker">` (superscript), `div[@type="chapter"]` → `<h3 class="section-head">`, `.hi-initial` Sonderformatierung entfernt; Marginalia/Glossen/Rubrum bleiben unstylisiert |
-| ~~#85~~ | Umbrella div-Wrapper (closed 2026-05-12): Kat. 2 (7 Lieder) bereits in `ef939f530`; Kat. 3 (DJEM `e7b99b990`, DES2 `f51a74468`, DUB `d92e398ec`); 13 MBS-Serie-Texte aus Kat. 1 strukturell als implizit-OK eingestuft |
-| ~~WZB Pentateuch~~ | (2026-05-12, Julia): WZB-Titel + works.xml + projectDesc auf „Wenzelsbibel (Pentateuch: Gen–Dtn, Cod. 2759–2764)" präzisiert; Authority-Index-Rebuild |
-| ~~Blog-Post WZB-Pipeline~~ | (2026-05-12, Julia + C. Pollin): Draft v3 in `publications/BLOG-POST-WZB-PIPELINE.md` (30J. MHDBDB-Kontext, LOD, dreiphasige LLM-Pipeline, böhmische Schreibkonventionen); unpublished |
-| ~~#20~~ | Readability fixes (2026-05-11): Counter „667/667 Texte ausgewählt" auf text-2xl/font-semibold, dedizierte blue-50-Hinweisbox mit Info-Icon zum Deselect-Workflow |
-| ~~#96~~ | Metadatenanzeige (2026-05-11): TEI-XML-Download-Link am Ende des Reader-Metadaten-Panels, Anonym-Wikidata-Link bei `authorId === 'person_anonym'` unterdrückt |
-| ~~#87~~ | Playground TEI Textanalyse UX-Cleanup (2026-05-11): 3 broken Buttons raus, Reorder |
-| ~~#88~~ | Playground Wortfrequenz-Analyse (2026-05-11): Top-N Lemmata mit Frequenz-Bars |
-| ~~#89~~ | Playground Text-Statistiken (2026-05-11): Token-Anzahl, Lemma-Diversität, Hapax-Rate |
-| ~~#90~~ | Playground Lemma-Verteilung (2026-05-11): Bar-Chart Lemma × Text |
-| ~~#100~~ | Pre-flight Working-Tree-Check für Index-Builder (2026-05-11): `git status --porcelain`-Check verhindert dirty Builds |
-| ~~#97-99~~ | Playground Follow-up-Cleanups (2026-05-11): Corpus-Index-Property-Drift gefixt, ~700 Zeilen Dead Code aus tei-ui.js entfernt |
-| ~~#79~~ | /hilfe/ User-facing Help Pages (2026-05-08): 5 Hilfe-Seiten live (Korpussuche, Playground, Daten, Daten beitragen, Index) |
-| ~~#94~~ | Authority-Cache invalidiert nicht bei Versions-Bump (2026-05-08): selbstreferenzieller Vergleich gefixt |
-| ~~#17~~ | Reader View TEI-Strukturelemente (2026-04-16): Token-basierte `<hi rend>` Klassen (43k Compound-Werte gefixt), `<div>/<lg>/<l>/<lb>` Margin-Numbers, Note-Badges für `@type="year\|date"`, 128/128 Tests grün |
-| ~~#52~~ | Authority Files Card (2026-04-16): collapse-by-default, weniger visuelle Dominanz im Playground-Sidebar |
-| ~~#32-followup~~ | vollständig 17/17 (2026-05-07): P1-5 `idno/@type` 3 kontextspezifische Enum-Patterns (`msIdentifier` / `monogr` / `person`), WZB-shelfmark-Fix (Daten vor Schema), Stage-1 PI-Cleanup auf 667 Files, CI Push-Trigger |
-| ~~#68 Teil 1~~ | `hilfe-daten-beitragen.html` (2026-05-07): user-facing Schema-Konversions-Leitfaden für TEI-Beitragende |
-| ~~WZB-Reorg~~ | (2026-05-07): 20 Pipeline-Skripte in `scripts/ingest/wzb/`, 4 Sackgassen in `scripts/_archived/wzb/` |
-| ~~#62~~ | Impressum (2026-04-16): `impressum.html` mit Datenschutz, Footer-Links auf allen Seiten |
-| ~~#48~~ | Playground URL-Routing (2026-04-15): Hash-basierte shareable URLs für alle Playground-Views |
-| ~~#56~~ | Lemmata-Explorer (2026-04-15): Titel-Links zu Lemma-Seiten, URL-Bug-Fix, concept-based Similar Lemmata |
-| ~~#31~~ | Linecode2TEI-Dokumentation (2026-04-15): `docs/LINECODE.md` |
-| ~~#22~~ | TEI Encoding Guidelines (2026-04-16): superseded by TEI-MODEL.md + schema README |
-| ~~#43~~ | Playwright test coverage (2026-04-16): 121/121 passing, 25 skipped intentional |
-| ~~#83~~ | Editor-Attribution & Credits-Modell (2026-04-15) |
-| ~~#84~~ | HZU/HZU2 Datum-Notes – already migrated in #32 Phase A |
-| ~~#32-followup~~ | Schema hardening: 16/17 items done (P1-5 `idno/@type` enum remains) |
-| ~~#32~~ | TEI Model Consolidation (675→666 files, 15M+ transformations, 2 schemas) |
-| ~~#29~~ | Stricker-Texte |
-| ~~#60~~ | Parzival Struktur-Bug |
-| ~~#61~~ | Textauswahl Whitespace-Bug |
-| ~~#53~~ | Korpus durchsuchen UX |
-| ~~#67~~ | Abbreviaturen Header (124 Texte) |
-| ~~#70~~ | pc join spacing |
-| ~~#14~~ | Sonderfall Lizenzen |
-| ~~#50~~ | Fix 43 test failures → 121/121 passing |
-| ~~#42~~ | Persistent lemma pages |
-| ~~#46~~ | Merge Lemma-Suche |
-| ~~#21~~ | Rename Konzepte→Begriffe |
-| ~~#35–40~~ | Provenance metadata (5 batches) |
+Diese Datei blickt nach vorne. Was abgeschlossen ist, steht chronologisch und mit
+Begründungen im [JOURNAL.md](JOURNAL.md), ältere Einträge in
+[journal-archive.md](journal-archive.md). Bis zum 02.08.2026 stand hier
+zusätzlich eine Tabelle „Recently Completed": sie reichte bis April zurück,
+endete aber am 08.07., während seither 60 PRs gemergt wurden. Eine zweite
+Chronik neben dem JOURNAL zu führen hat nicht funktioniert und wurde deshalb
+aufgegeben (#316).
 
 ## Strategic Direction
 

--- a/ingest/wzb/README.md
+++ b/ingest/wzb/README.md
@@ -25,4 +25,4 @@ Alles Entfernte bleibt in der Git-History unter dem alten Pfad `Wenzelsbibel/` v
 ## Kontext
 
 - Verfahren: dreiphasige LLM-Pipeline (Lemma → POS → Sense), beschrieben im Blog-Post-Draft `publications/BLOG-POST-WZB-PIPELINE.md` und in `scripts/ingest/wzb/README.md`
-- Scope-Präzisierung „Pentateuch" (2026-05-12): siehe `docs/ROADMAP.md` → Recently Completed
+- Scope-Präzisierung „Pentateuch" (2026-05-12, `aa114bf89` + `6c4d7955c`): Titel, `works.xml` und `projectDesc` auf „Wenzelsbibel (Pentateuch: Gen–Dtn, Cod. 2759–2764)" gesetzt, danach Authority-Index-Rebuild. Kontext im JOURNAL-Eintrag zum 2026-05-12 (`docs/journal-archive.md`)

--- a/scripts/audit/doc-count-audit.py
+++ b/scripts/audit/doc-count-audit.py
@@ -123,6 +123,8 @@ INTENTIONALLY_SILENT = {
         'nennt die Werkzeuge einzeln in der Routing-Tabelle, nie als Summe',
     ('docs/ARCHITECTURE.md', 'tei_tools'):
         'nennt die Werkzeuge einzeln in der Routing-Tabelle, nie als Summe',
+    ('docs/INDEX.md', 'entry_points'):
+        'verweist seit #316 auf FEATURES.md, statt den Katalog samt Zahlen zu wiederholen',
 }
 
 


### PR DESCRIPTION
Erledigt die beiden Redundanz-Befunde aus #316. **Kein `Closes`**: die Sprachmischung aus demselben Ticket bleibt offen, sie ist eine Entscheidung (welche Doku ist für welches Publikum) und keine Fleißarbeit.

## 1. Die Chronik-Tabelle in der ROADMAP

„Recently Completed" führte 57 Zeilen zurück bis April. Der jüngste Eintrag stammte vom 08.07., seither sind **80 PRs** gemergt worden (`gh pr list --state merged --limit 500 --json mergedAt`, Fenster ab 09.07.; der 08.07. selbst hatte 13, genau die Merge-Session, die als letzte Zeile dastand). INDEX zeigte seit #336 ausgerechnet dorthin, das Freshness-Problem war also verschoben, nicht gelöst.

Vor dem Löschen die Gegenprobe, ob Wissen verloren geht: Stichprobe #113-Followup, Kookkurrenz-Ranking, WZB-Pentateuch, Last-Wins-Bug, Sigle-Titel-Differenzierung. Jeder Eintrag steht in `JOURNAL.md` oder `journal-archive.md`, meist ausführlicher.

An die Stelle tritt ein Absatz, der sagt, wo die Chronik lebt und warum hier keine mehr geführt wird. Das soll verhindern, dass die Tabelle in drei Monaten neu angelegt wird.

## 2. Der Feature-Katalog in INDEX.md

33 Zeilen, die `FEATURES.md` nacherzählen, mit eigenen Zahlen: 18 Entry Points, 12 Analyse-Werkzeuge, 43.879 Lemma-Seiten. Das ist die Fehlerklasse, gegen die `doc-count-audit.py` überhaupt gebaut wurde, nämlich eine zweite Stelle, die bei jedem neuen Werkzeug nachgezogen werden muss. Ersetzt durch drei Absätze ohne eine einzige Zahl, plus Verweis auf FEATURES.md.

Die Zahlen der Kopie waren übrigens korrekt (Audit meldet keine Drift). Der Grund ist also nicht Staleness, sondern die doppelte Pflege: eine erste Fassung des Textes behauptete das Gegenteil und ist im Review gefallen.

`doc-count-audit.py` bekommt dazu den passenden `INTENTIONALLY_SILENT`-Eintrag. Ohne ihn meldet die Selbstprüfung den Anker als blinden Fleck. Gemessen vorher: `[no-hit] docs/INDEX.md / entry_points`. Nachher: „Kein konfiguriertes (Datei, Key)-Paar ohne Anker-Treffer", Exit 0. Das Target bleibt konfiguriert, eine später doch eingesetzte Zahl ist damit sofort gegatet.

## Verweise auf das Gelöschte

| Stelle | Behandlung |
|---|---|
| `docs/INDEX.md` | zeigt für Fertiges nur noch aufs JOURNAL |
| `ingest/wzb/README.md` | verwies auf eine einzelne Tabellenzeile; dort steht der Fakt jetzt selbst, mit `aa114bf89` (Metadaten) und `6c4d7955c` (Index-Rebuild), beide verifiziert |
| `docs/playbooks/MASTERPLAN-AUTONOME-MERGE-SESSION.md:48` | unverändert: meint die gleichnamige Sektion im Body von Issue #44, nicht diese Tabelle |
| `docs/journal-archive.md` | unverändert: historische Erwähnungen, die korrekt bleiben |

Kein Markdown-Link im Repo zeigt auf einen `#recently-completed`-Anker.

## Review

Zwei Runden `fable-reviewer` vor dem ersten Push. Runde 1 fand zwei falsche Behauptungen im neuen Text, beide nachgemessen und übernommen: die PR-Zahl (60 statt 80, mein Messfehler, `--limit 60` deckelt die Ausgabe und ich hatte die Deckelung als Ergebnis gelesen) und die Staleness-Zuschreibung. Ein dritter Punkt zur Sprachmischung wurde mit Messung nicht übernommen: sechs der acht ROADMAP-Sektionen sind bereits deutsch, und der neue INDEX-Bullet steht unter der deutschen Überschrift „Was zuletzt fertig wurde". Runde 2 ohne Befund.

Em-Dash-Gate grün, `doc-count-audit.py` grün. Reine Doku plus eine Audit-Konfiguration, kein Produktivcode, kein Index-Rebuild nötig.
