### PR TITLE
#316: Sprachregel in CLAUDE.md, JOURNAL bleibt deutsch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,14 @@ MHDBDB TEI Repository: ~667 TEI-encoded Middle High German texts with semantic a
 | `features/` | Feature-scoped planning docs (active issues only) |
 | `playbooks/` | Wiederverwendbare Session-Verfahren (autonome Issue-/Merge-/Carearbeit-Sessions) |
 
+### Sprache
+
+**User-facing (Frontend) Hilfe und Doku immer deutsch, Entwickler-Doku immer Englisch.** Die Trennlinie ist das Publikum, nicht der Ordner: `hilfe-*.html`, `impressum.html` und alles, was Nutzerinnen im Browser sehen, bleibt deutsch; die Promptotyping-Docs in `docs/` sind englisch, weil sie in erster Linie von Agenten gelesen werden (#316, umgesetzt 2026-08-03).
+
+**Ausnahme: `JOURNAL.md` und `journal-archive.md` bleiben deutsch** (Entscheidung 03.08.2026). Sie sind ebenfalls für Agenten geschrieben, aber Chronik statt Referenz, und Deutsch kostet dort nichts. Neue JOURNAL-Einträge also weiter auf Deutsch.
+
+Deutsch bleibt außerdem in Commit-Messages, in den Kommentaren der `scripts/`-Dateien und überall dort, wo in einer englischen Datei Dateninhalt zitiert wird: Korpus-Header, mittelhochdeutsche Belege, Werktitel, Namen aus `contributors.xml`.
+
 ## Directory Layout
 
 ```


### PR DESCRIPTION
Der Rest von #316: die Sprachregel selbst war nirgends im Repo notiert, sondern nur im Ticket und im Sitzungsgedächtnis. Für jede Session, die #316 nicht gelesen hat, galt sie damit nicht.

## Was drin steht

CLAUDE.md bekommt einen kurzen Abschnitt „Sprache" direkt unter der Doku-Tabelle:

- User-facing Hilfe und Doku deutsch, Entwickler-Doku englisch. Die Trennlinie ist das Publikum, nicht der Ordner.
- **`JOURNAL.md` und `journal-archive.md` bleiben deutsch.** Das war die letzte offene Teilfrage des Tickets, entschieden am 03.08.: sie sind ebenfalls für Agenten geschrieben, aber Chronik statt Referenz, und Deutsch kostet dort nichts. Neue Einträge also weiter auf Deutsch.
- Die drei Stellen, an denen Deutsch auch innerhalb englischer Dateien richtig ist: Commit-Messages, Kommentare in `scripts/`, zitierter Dateninhalt (Korpus-Header, mittelhochdeutsche Belege, Werktitel, Namen aus `contributors.xml`).

Reine Doku-Änderung, eine Datei, kein Code. Das Em-Dash-Gate läuft grün.

Closes #316
